### PR TITLE
BaseObject: Add eventKey for handling on/off events

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Clappr (0.1.3):
+  - Clappr (0.2.2):
     - HanekeSwift (~> 0.10)
   - FBSnapshotTestCase (2.0.7):
     - FBSnapshotTestCase/SwiftSupport (= 2.0.7)
@@ -7,12 +7,12 @@ PODS:
   - FBSnapshotTestCase/SwiftSupport (2.0.7):
     - FBSnapshotTestCase/Core
   - HanekeSwift (0.10.1)
-  - Nimble (3.0.0)
+  - Nimble (3.1.0)
   - Nimble-Snapshots (3.0.0):
     - FBSnapshotTestCase (~> 2.0.7)
     - Nimble
     - Quick
-  - Quick (0.8.0)
+  - Quick (0.9.1)
 
 DEPENDENCIES:
   - Clappr (from `../`)
@@ -26,11 +26,11 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Clappr: c5f53d9a4e37b7dcc09fc6cb58710f371d00b0fd
+  Clappr: 043d1133167eb6a893b703f692c64b6a5415a4a0
   FBSnapshotTestCase: 7e85180d0d141a0cf472352edda7e80d7eaeb547
   HanekeSwift: 08e47d3d0f2899ec58e5d257beba0de619aca9e8
-  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
+  Nimble: 79d40f4d69d47314229bbabacaa02b8838c779b9
   Nimble-Snapshots: ab41dd737dcd33a0b0cb005a30465fef70b7207a
-  Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
+  Quick: a5221fc21788b6aeda934805e68b061839bc3165
 
 COCOAPODS: 0.39.0

--- a/Example/Tests/BaseObjectTests.swift
+++ b/Example/Tests/BaseObjectTests.swift
@@ -89,6 +89,14 @@ class BaseObjectTests: QuickSpec {
                     
                     expect(callbackWasCalled) == false
                 }
+                
+                it("Callback should not be called if removed") {
+                    let listenId = baseObject.once(eventName, callback: callback)
+                    baseObject.off(listenId)
+                    baseObject.trigger(eventName)
+                    
+                    expect(callbackWasCalled) == false
+                }
             }
             
             describe("listenTo") {

--- a/Example/Tests/BaseObjectTests.swift
+++ b/Example/Tests/BaseObjectTests.swift
@@ -104,8 +104,8 @@ class BaseObjectTests: QuickSpec {
             
             describe("off") {
                 it("Callback should not be called if removed") {
-                    let key = baseObject.on(eventName, callback: callback)
-                    baseObject.off(key)
+                    let listenId = baseObject.on(eventName, callback: callback)
+                    baseObject.off(listenId)
                     baseObject.trigger(eventName)
                     
                     expect(callbackWasCalled) == false
@@ -117,10 +117,10 @@ class BaseObjectTests: QuickSpec {
                         anotherCallbackWasCalled = true
                     }
                     
-                    let key = baseObject.on(eventName, callback: callback)
+                    let listenId = baseObject.on(eventName, callback: callback)
                     baseObject.on(eventName, callback: anotherCallback)
                     
-                    baseObject.off(key)
+                    baseObject.off(listenId)
                     baseObject.trigger(eventName)
                     
                     expect(callbackWasCalled) == false
@@ -163,8 +163,8 @@ class BaseObjectTests: QuickSpec {
                 it("Should cancel handler for an event on a given context object") {
                     let contextObject = BaseObject()
                     
-                    let key = baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
-                    baseObject.stopListening(key)
+                    let listenId = baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
+                    baseObject.stopListening(listenId)
                     
                     contextObject.trigger(eventName)
                     

--- a/Example/Tests/BaseObjectTests.swift
+++ b/Example/Tests/BaseObjectTests.swift
@@ -104,8 +104,8 @@ class BaseObjectTests: QuickSpec {
             
             describe("off") {
                 it("Callback should not be called if removed") {
-                    baseObject.on(eventName, callback: callback)
-                    baseObject.off(eventName, callback: callback)
+                    let key = baseObject.on(eventName, callback: callback)
+                    baseObject.off(key)
                     baseObject.trigger(eventName)
                     
                     expect(callbackWasCalled) == false
@@ -117,10 +117,10 @@ class BaseObjectTests: QuickSpec {
                         anotherCallbackWasCalled = true
                     }
                     
-                    baseObject.on(eventName, callback: callback)
+                    let key = baseObject.on(eventName, callback: callback)
                     baseObject.on(eventName, callback: anotherCallback)
                     
-                    baseObject.off(eventName, callback: callback)
+                    baseObject.off(key)
                     baseObject.trigger(eventName)
                     
                     expect(callbackWasCalled) == false
@@ -163,10 +163,10 @@ class BaseObjectTests: QuickSpec {
                 it("Should cancel handler for an event on a given context object") {
                     let contextObject = BaseObject()
                     
-                    baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
-                    baseObject.stopListening(contextObject, eventName: eventName, callback: callback)
+                    let key = baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
+                    baseObject.stopListening(key)
                     
-                    baseObject.trigger(eventName)
+                    contextObject.trigger(eventName)
                     
                     expect(callbackWasCalled) == false
                 }

--- a/Pod/Classes/Base/BaseObject.swift
+++ b/Pod/Classes/Base/BaseObject.swift
@@ -44,8 +44,10 @@ public class BaseObject: NSObject, EventProtocol {
         }
     }
     
-    public func once(eventName: String, callback: EventCallback) {
-        onceEventsHashes.append(on(eventName, callback: callback))
+    public func once(eventName: String, callback: EventCallback) -> String {
+        let listenId = on(eventName, callback: callback)
+        onceEventsHashes.append(listenId)
+        return listenId
     }
     
     public func off(listenId: String) {

--- a/Pod/Classes/Base/UIBaseObject.swift
+++ b/Pod/Classes/Base/UIBaseObject.swift
@@ -11,8 +11,8 @@ public class UIBaseObject: UIView, EventProtocol {
         baseObject.once(eventName, callback: callback)
     }
     
-    public func off(eventKey: String) {
-        baseObject.off(eventKey)
+    public func off(listenId: String) {
+        baseObject.off(listenId)
     }
     
     public func trigger(eventName:String) {
@@ -31,8 +31,8 @@ public class UIBaseObject: UIView, EventProtocol {
         baseObject.stopListening()
     }
     
-    public func stopListening(eventKey: String) {
-        baseObject.stopListening(eventKey)
+    public func stopListening(listenId: String) {
+        baseObject.stopListening(listenId)
     }
     
     public func getEventContextObject() -> BaseObject {

--- a/Pod/Classes/Base/UIBaseObject.swift
+++ b/Pod/Classes/Base/UIBaseObject.swift
@@ -7,8 +7,8 @@ public class UIBaseObject: UIView, EventProtocol {
         return baseObject.on(eventName, callback: callback)
     }
     
-    public func once(eventName:String, callback: EventCallback) {
-        baseObject.once(eventName, callback: callback)
+    public func once(eventName:String, callback: EventCallback) -> String {
+        return baseObject.once(eventName, callback: callback)
     }
     
     public func off(listenId: String) {

--- a/Pod/Classes/Base/UIBaseObject.swift
+++ b/Pod/Classes/Base/UIBaseObject.swift
@@ -3,16 +3,16 @@ import Foundation
 public class UIBaseObject: UIView, EventProtocol {
     private let baseObject = BaseObject()
     
-    public func on(eventName:String, callback: EventCallback) {
-        baseObject.on(eventName, callback: callback)
+    public func on(eventName:String, callback: EventCallback) -> String {
+        return baseObject.on(eventName, callback: callback)
     }
     
     public func once(eventName:String, callback: EventCallback) {
         baseObject.once(eventName, callback: callback)
     }
     
-    public func off(eventName:String, callback: EventCallback) {
-        baseObject.off(eventName, callback: callback)
+    public func off(eventKey: String) {
+        baseObject.off(eventKey)
     }
     
     public func trigger(eventName:String) {
@@ -23,16 +23,16 @@ public class UIBaseObject: UIView, EventProtocol {
         baseObject.trigger(eventName, userInfo: userInfo)
     }
     
-    public func listenTo<T: EventProtocol>(contextObject: T, eventName: String, callback: EventCallback) {
-        baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
+    public func listenTo<T: EventProtocol>(contextObject: T, eventName: String, callback: EventCallback) -> String {
+        return baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
     }
     
     public func stopListening() {
         baseObject.stopListening()
     }
     
-    public func stopListening<T : EventProtocol>(contextObject: T, eventName: String, callback: EventCallback) {
-        baseObject.stopListening(contextObject, eventName: eventName, callback: callback)
+    public func stopListening(eventKey: String) {
+        baseObject.stopListening(eventKey)
     }
     
     public func getEventContextObject() -> BaseObject {

--- a/Pod/Classes/Protocol/EventProtocol.swift
+++ b/Pod/Classes/Protocol/EventProtocol.swift
@@ -1,14 +1,14 @@
 public protocol EventProtocol {
     func on(eventName:String, callback: EventCallback) -> String
     func once(eventName:String, callback: EventCallback)
-    func off(eventKey: String)
+    func off(listenId: String)
     
     func trigger(eventName:String)
     func trigger(eventName:String, userInfo: [NSObject : AnyObject]?)
     
     func listenTo<T: EventProtocol>(contextObject: T, eventName: String, callback: EventCallback) -> String
     func stopListening()
-    func stopListening(eventKey: String)
+    func stopListening(listenId: String)
     
     func getEventContextObject() -> BaseObject
 }

--- a/Pod/Classes/Protocol/EventProtocol.swift
+++ b/Pod/Classes/Protocol/EventProtocol.swift
@@ -1,6 +1,6 @@
 public protocol EventProtocol {
     func on(eventName:String, callback: EventCallback) -> String
-    func once(eventName:String, callback: EventCallback)
+    func once(eventName:String, callback: EventCallback) -> String
     func off(listenId: String)
     
     func trigger(eventName:String)

--- a/Pod/Classes/Protocol/EventProtocol.swift
+++ b/Pod/Classes/Protocol/EventProtocol.swift
@@ -1,14 +1,14 @@
 public protocol EventProtocol {
-    func on(eventName:String, callback: EventCallback)
+    func on(eventName:String, callback: EventCallback) -> String
     func once(eventName:String, callback: EventCallback)
-    func off(eventName:String, callback: EventCallback)
+    func off(eventKey: String)
     
     func trigger(eventName:String)
     func trigger(eventName:String, userInfo: [NSObject : AnyObject]?)
     
-    func listenTo<T: EventProtocol>(contextObject: T, eventName: String, callback: EventCallback)
+    func listenTo<T: EventProtocol>(contextObject: T, eventName: String, callback: EventCallback) -> String
     func stopListening()
-    func stopListening<T: EventProtocol>(contextObject: T, eventName: String, callback: EventCallback)
+    func stopListening(eventKey: String)
     
     func getEventContextObject() -> BaseObject
 }


### PR DESCRIPTION
Why? 
- Avoid using callback memory address for identifying event.