### PR TITLE
Remove previous Playback from view

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
 github "Quick/Nimble" "v6.1.0"
 github "Quick/Quick" "v1.1.0"
-github "onevcat/Kingfisher" "3.6.2"
+github "onevcat/Kingfisher" "3.10.3"

--- a/Clappr/Classes/Base/Container.swift
+++ b/Clappr/Classes/Base/Container.swift
@@ -52,7 +52,7 @@ open class Container: UIBaseObject {
         playbackOptions[kSourceUrl] = source
         playbackOptions[kMimeType] = mimeType
 
-        self.playback?.removeFromSuperview()
+        self.playback?.destroy()
 
         let playbackFactory = PlaybackFactory(loader: loader, options: playbackOptions)
         self.playback = playbackFactory.createPlayback()

--- a/Clappr/Classes/Base/Container.swift
+++ b/Clappr/Classes/Base/Container.swift
@@ -52,8 +52,9 @@ open class Container: UIBaseObject {
         playbackOptions[kSourceUrl] = source
         playbackOptions[kMimeType] = mimeType
 
-        let playbackFactory = PlaybackFactory(loader: loader, options: playbackOptions)
+        self.playback?.removeFromSuperview()
 
+        let playbackFactory = PlaybackFactory(loader: loader, options: playbackOptions)
         self.playback = playbackFactory.createPlayback()
 
         if playback is NoOpPlayback {

--- a/Tests/ContainerTests.swift
+++ b/Tests/ContainerTests.swift
@@ -149,6 +149,14 @@ class ContainerTests: QuickSpec {
                     expect(container.playback?.pluginName) == "AVPlayback"
                     expect(container.playback?.superview) == container
                 }
+
+                it("should keep just one playback as subview at time") {
+                    let container = Container()
+                    container.load("anyVideo")
+                    expect(container.subviews.filter({ $0 is Playback }).count).to(equal(1))
+                    container.load("anyOtherVideo")
+                    expect(container.subviews.filter({ $0 is Playback }).count).to(equal(1))
+                }
             }
 
             describe("Options") {


### PR DESCRIPTION
When the user is trying to load a new resource, the previous playback was not removed from the container's view, causing the player to keep showing the last video's frame, while the new video is being played on background.