### PR TITLE
Fix player slider swipe when inside a ScrollView

### DIFF
--- a/Clappr/Classes/Base/MediaControl.swift
+++ b/Clappr/Classes/Base/MediaControl.swift
@@ -377,13 +377,28 @@ open class MediaControl: UIBaseObject {
             case .began:
                 isSeeking = true
                 hideControlsTimer?.invalidate()
+                toggleScrollEnable(in: view, to: false)
             case .ended:
                 container?.playback?.seek(secondsRelativeToPoint(touchPoint))
                 isSeeking = false
                 scheduleTimerToHideControls()
+                toggleScrollEnable(in: view, to: true)
             default: break
             }
         }
+    }
+    
+    //This function was necessary because our apps were using the player inside
+    //a scrollview, so a conflict was happening between the swipe event in the
+    //slider and the scrollview.
+    private func toggleScrollEnable(in view: UIView?,to isEnabled: Bool) {
+        guard let view = view else {
+            return
+        }
+        if let scrollView = view as? UIScrollView {
+            scrollView.isScrollEnabled = isEnabled
+        }
+        toggleScrollEnable(in: view.superview, to: isEnabled)
     }
 
     open func secondsRelativeToPoint(_ touchPoint: CGPoint) -> Double {


### PR DESCRIPTION
**Goal**
A problem was happening when the player was inside a scrollview, the conflict was happening between the swipe and scroll events.
We intend to change the MediaControl slide bar for a native component.

**How to test**

To simulate the problem, open the sample and put the player inside a ScrollView.