### PR TITLE
Fix fullscreen orientation according to the device orientation

### DIFF
--- a/Clappr/Classes/Base/FullscreenController.swift
+++ b/Clappr/Classes/Base/FullscreenController.swift
@@ -1,16 +1,16 @@
 import UIKit
 
 class FullscreenController: UIViewController {
-
+    
     override var shouldAutorotate: Bool {
         return true
     }
-
+    
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UIInterfaceOrientationMask.landscape
     }
-
-    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation { // swiftlint:disable:this variable_name
-        return UIInterfaceOrientation.landscapeRight
+    
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        return UIDevice.current.orientation == UIDeviceOrientation.landscapeLeft ? UIInterfaceOrientation.landscapeLeft : UIInterfaceOrientation.landscapeRight
     }
 }


### PR DESCRIPTION
## Goal

The problem is that when the app calls the function setFullscreen, the default was only landscapeRight.
To fix that we changed the property inside FullscreenController to get the device orientation. 

## How to test

Open the clappr sample and put a breakpoint at the line **100** in `Core.swift`.
Run the app, and change the device orientation, when the breakpoint stops check the value of `fullscreenController.preferredInterfaceOrientationForPresentation.rawvalue`

The value should be 3 for `landscapeLeft` and 4 for `landscapeRight`, you can see more here:

https://developer.apple.com/documentation/uikit/uiinterfaceorientation