### PR TITLE
Prevent pause event after video is ended

### DIFF
--- a/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -389,7 +389,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     fileprivate func handlePlayerRateChanged() {
-        if(player?.rate == 0) {
+        if player?.rate == 0 && currentState != .idle {
             updateState(.paused)
         }
     }


### PR DESCRIPTION
## Goal

The problem is that when video is ended, a pause event is being triggered. To fix that, we prevent change the internal state of the playback after the video is ended.

## How to test

Run the clappr sample and observe if an "on Paused" is printed on the log after the video is ended.