### PR TITLE
Fix/fullscreen event

### DIFF
--- a/Clappr/Classes/Base/Core.swift
+++ b/Clappr/Classes/Base/Core.swift
@@ -10,8 +10,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     private (set) lazy var fullscreenController = FullscreenController(nibName: nil, bundle: nil)
 
     lazy var fullscreenHandler: FullscreenStateHandler = {
-        let handler: FullscreenStateHandler = self.optionsUnboxer.fullscreenControledByApp ? FullscreenByApp() : FullscreenByPlayer(core: self)
-        return handler
+        return self.optionsUnboxer.fullscreenControledByApp ? FullscreenByApp(core: self) : FullscreenByPlayer(core: self) as FullscreenStateHandler
     }()
 
     lazy var optionsUnboxer: OptionsUnboxer = OptionsUnboxer(options: self.options)

--- a/Clappr/Classes/Base/Core.swift
+++ b/Clappr/Classes/Base/Core.swift
@@ -145,12 +145,12 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     }
 
     open func setFullscreen(_ fullscreen: Bool) {
-        mediaControl?.fullscreen = fullscreen
         if fullscreen {
             fullscreenHandler.enterInFullscreen()
         } else {
             fullscreenHandler.exitFullscreen()
         }
+        mediaControl?.fullscreen = fullscreen
     }
 
     open func destroy() {

--- a/Clappr/Classes/Base/Core.swift
+++ b/Clappr/Classes/Base/Core.swift
@@ -145,11 +145,6 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     }
 
     open func setFullscreen(_ fullscreen: Bool) {
-        if fullscreen {
-            fullscreenHandler.enterInFullscreen()
-        } else {
-            fullscreenHandler.exitFullscreen()
-        }
         mediaControl?.fullscreen = fullscreen
     }
 

--- a/Clappr/Classes/Base/FullScreenStateHandler.swift
+++ b/Clappr/Classes/Base/FullScreenStateHandler.swift
@@ -1,6 +1,9 @@
 protocol FullscreenStateHandler {
 
-    init()
+    var core: Core? { get }
+    var isOnFullscreen: Bool { get }
+
+    init(core: Core)
 
     func enterInFullscreen(_: EventUserInfo)
     func enterInFullscreen()
@@ -18,53 +21,56 @@ extension FullscreenStateHandler {
     func exitFullscreen() {
         exitFullscreen([:])
     }
-}
 
-class FullscreenByApp: BaseObject, FullscreenStateHandler {
-
-    required override init() {
-        super.init()
-    }
-
-    func enterInFullscreen(_: EventUserInfo = [:]) {
-        trigger(Event.requestFullscreen.rawValue)
-    }
-
-    func exitFullscreen(_: EventUserInfo = [:]) {
-        trigger(Event.exitFullscreen.rawValue)
+    var isOnFullscreen: Bool {
+        return core?.isFullscreen ?? false
     }
 }
 
-class FullscreenByPlayer: BaseObject, FullscreenStateHandler {
+class FullscreenByApp: FullscreenStateHandler {
 
     weak var core: Core?
 
-    required override init() {
-        super.init()
-    }
-
-    convenience init(core: Core) {
-        self.init()
+    required init(core: Core) {
         self.core = core
     }
 
     func enterInFullscreen(_: EventUserInfo = [:]) {
-        guard let core = core else { return }
-        trigger(InternalEvent.willEnterFullscreen.rawValue)
+        guard !isOnFullscreen else { return }
+        core?.trigger(Event.requestFullscreen.rawValue)
+    }
+
+    func exitFullscreen(_: EventUserInfo = [:]) {
+        guard isOnFullscreen else { return }
+        core?.trigger(Event.exitFullscreen.rawValue)
+    }
+}
+
+class FullscreenByPlayer: FullscreenStateHandler {
+
+    weak var core: Core?
+
+    required init(core: Core) {
+        self.core = core
+    }
+
+    func enterInFullscreen(_: EventUserInfo = [:]) {
+        guard let core = core, !isOnFullscreen else { return }
+        core.trigger(InternalEvent.willEnterFullscreen.rawValue)
         core.mediaControl?.fullscreen = true
         core.fullscreenController.view.backgroundColor = UIColor.black
         core.fullscreenController.modalPresentationStyle = .overFullScreen
         core.parentController?.present(core.fullscreenController, animated: false, completion: nil)
         core.fullscreenController.view.addSubviewMatchingConstraints(core)
-        trigger(InternalEvent.didEnterFullscreen.rawValue)
+        core.trigger(InternalEvent.didEnterFullscreen.rawValue)
     }
 
     func exitFullscreen(_: EventUserInfo = [:]) {
-        guard let core = core else { return }
-        trigger(InternalEvent.willExitFullscreen.rawValue)
+        guard let core = core, isOnFullscreen else { return }
+        core.trigger(InternalEvent.willExitFullscreen.rawValue)
         core.mediaControl?.fullscreen = false
         core.parentView?.addSubviewMatchingConstraints(core)
         core.fullscreenController.dismiss(animated: false, completion: nil)
-        trigger(InternalEvent.didExitFullscreen.rawValue)
+        core.trigger(InternalEvent.didExitFullscreen.rawValue)
     }
 }

--- a/Clappr/Classes/Base/FullScreenStateHandler.swift
+++ b/Clappr/Classes/Base/FullScreenStateHandler.swift
@@ -1,6 +1,6 @@
 protocol FullscreenStateHandler {
 
-    var core: Core? { get }
+    var core: Core { get }
     var isOnFullscreen: Bool { get }
 
     init(core: Core)
@@ -23,39 +23,31 @@ extension FullscreenStateHandler {
     }
 
     var isOnFullscreen: Bool {
-        return core?.isFullscreen ?? false
+        return core.mediaControl?.fullscreen ?? false
     }
 }
 
-class FullscreenByApp: FullscreenStateHandler {
+struct FullscreenByApp: FullscreenStateHandler {
 
-    weak var core: Core?
-
-    required init(core: Core) {
-        self.core = core
-    }
+    var core: Core
 
     func enterInFullscreen(_: EventUserInfo = [:]) {
         guard !isOnFullscreen else { return }
-        core?.trigger(Event.requestFullscreen.rawValue)
+        core.trigger(InternalEvent.userRequestEnterInFullscreen.rawValue)
     }
 
     func exitFullscreen(_: EventUserInfo = [:]) {
         guard isOnFullscreen else { return }
-        core?.trigger(Event.exitFullscreen.rawValue)
+        core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
     }
 }
 
-class FullscreenByPlayer: FullscreenStateHandler {
+struct FullscreenByPlayer: FullscreenStateHandler {
 
-    weak var core: Core?
-
-    required init(core: Core) {
-        self.core = core
-    }
+    var core: Core
 
     func enterInFullscreen(_: EventUserInfo = [:]) {
-        guard let core = core, !isOnFullscreen else { return }
+        guard !isOnFullscreen else { return }
         core.trigger(InternalEvent.willEnterFullscreen.rawValue)
         core.mediaControl?.fullscreen = true
         core.fullscreenController.view.backgroundColor = UIColor.black
@@ -66,7 +58,7 @@ class FullscreenByPlayer: FullscreenStateHandler {
     }
 
     func exitFullscreen(_: EventUserInfo = [:]) {
-        guard let core = core, isOnFullscreen else { return }
+        guard isOnFullscreen else { return }
         core.trigger(InternalEvent.willExitFullscreen.rawValue)
         core.mediaControl?.fullscreen = false
         core.parentView?.addSubviewMatchingConstraints(core)

--- a/Clappr/Classes/Base/Player.swift
+++ b/Clappr/Classes/Base/Player.swift
@@ -76,6 +76,7 @@ open class Player: BaseObject {
              Event.playing.rawValue, Event.didComplete.rawValue,
              Event.didPause.rawValue, Event.stalled.rawValue,
              Event.didStop.rawValue, Event.bufferUpdate.rawValue,
+             Event.requestFullscreen.rawValue, Event.exitFullscreen.rawValue,
              Event.positionUpdate.rawValue, Event.willPlay.rawValue,
              Event.willPause.rawValue, Event.willStop.rawValue,
              Event.airPlayStatusUpdate.rawValue, Event.seek.rawValue])
@@ -94,10 +95,10 @@ open class Player: BaseObject {
         self.core?.on(InternalEvent.didChangeActivePlayback.rawValue) { [weak self] _ in self?.bindPlaybackEvents() }
         self.core?.on(InternalEvent.didEnterFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.forward(.requestFullscreen, userInfo: info) }
         self.core?.on(InternalEvent.didExitFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.forward(.exitFullscreen, userInfo: info) }
+        self.core?.on(InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.forward(.requestFullscreen, userInfo: info) }
+        self.core?.on(InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.forward(.exitFullscreen, userInfo: info) }
 
         bindPlaybackEvents()
-
-        self.core?.render()
     }
 
     open func attachTo(_ view: UIView, controller: UIViewController) {

--- a/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Clappr/Classes/Enum/InternalEvent.swift
@@ -14,4 +14,6 @@ public enum InternalEvent: String {
     case didNotLoadSource
     case willDestroy
     case didDestroy
+    case userRequestEnterInFullscreen
+    case userRequestExitFullscreen
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -14,19 +14,6 @@ class ViewController: UIViewController {
         listenToPlayerEvents()
 
         player.attachTo(playerContainer, controller: self)
-        NotificationCenter.default.addObserver(self, selector: #selector(ViewController.rotated), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-    func rotated() {
-        if UIDevice.current.orientation.isLandscape {
-            player.setFullscreen(true)
-        } else {
-            player.setFullscreen(true)
-        }
     }
 
     func listenToPlayerEvents() {
@@ -41,10 +28,6 @@ class ViewController: UIViewController {
         player.on(Event.ready) { _ in print("on Ready") }
 
         player.on(Event.error) { userInfo in print("on Error: \(String(describing: userInfo))") }
-
-        player.on(Event.requestFullscreen) { _ in print("on Enter Fullscreen") }
-
-        player.on(Event.exitFullscreen) { _ in print("on Exit Fullscreen") }
 
         player.on(Event.stalled) { _ in print("on Stalled") }
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -32,10 +32,12 @@ class ViewController: UIViewController {
         player.on(Event.stalled) { _ in print("on Stalled") }
 
         player.on(Event.requestFullscreen) { _ in
+            self.showAlert(with: "Fullscreen", message: "Entrar em modo fullscreen")
             self.player.setFullscreen(true)
         }
 
         player.on(Event.exitFullscreen) { _ in
+            self.showAlert(with: "Fullscreen", message: "Sair do modo fullscreen")
             self.player.setFullscreen(false)
         }
     }
@@ -50,5 +52,11 @@ class ViewController: UIViewController {
 
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation { // swiftlint:disable:this variable_name
         return UIInterfaceOrientation.portrait
+    }
+
+    func showAlert(with title: String, message: String) {
+        let alertViewController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertViewController.addAction(UIAlertAction(title: "ok", style: UIAlertActionStyle.default, handler: nil))
+        self.navigationController?.present(alertViewController, animated: true, completion: nil)
     }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -7,6 +7,10 @@ class ViewController: UIViewController {
     var player: Player!
     var options: Options = [:]
 
+    var fullscreenByApp: Bool {
+        return options[kFullscreenByApp] as? Bool ?? false
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         player = Player(options: options)
@@ -32,13 +36,17 @@ class ViewController: UIViewController {
         player.on(Event.stalled) { _ in print("on Stalled") }
 
         player.on(Event.requestFullscreen) { _ in
-            self.showAlert(with: "Fullscreen", message: "Entrar em modo fullscreen")
-            self.player.setFullscreen(true)
+            Logger.logInfo("Entrar em modo fullscreen")
+            if self.fullscreenByApp {
+                self.player.setFullscreen(true)
+            }
         }
 
         player.on(Event.exitFullscreen) { _ in
-            self.showAlert(with: "Fullscreen", message: "Sair do modo fullscreen")
-            self.player.setFullscreen(false)
+            Logger.logInfo("Sair do modo fullscreen")
+            if self.fullscreenByApp {
+                self.player.setFullscreen(false)
+            }
         }
     }
 

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -44,17 +44,13 @@ class CoreTests: QuickSpec {
                         let options: Options = [kFullscreen: true]
                         let core = Core(options: options)
                         core.parentView = UIView()
-
-                        self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: core) { notification in
-                            return true
+                        var callbackWasCall = false
+                        core.on(InternalEvent.didEnterFullscreen.rawValue) { _ in
+                            callbackWasCall = true
                         }
-
-                        self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: core) { notification in
-                            return true
-                        }
-
                         core.render()
-                        self.waitForExpectations(timeout: 2, handler: nil)
+                        expect(callbackWasCall).toEventually(beTrue())
+
                         expect(core.parentView?.subviews.contains(core)).to(beFalse())
                         expect(core.fullscreenController.view.subviews.contains(core)).to(beTrue())
                         expect(core.mediaControl?.fullscreen).to(beTrue())
@@ -70,23 +66,17 @@ class CoreTests: QuickSpec {
                     }
 
                     it("Should start as fullscreen video when `kFullscreen: true` and `kFullscreenByApp: false` was passed") {
-                        let options: Options = [kFullscreen: true]
-                        let core = Core(options: options)
-                        core.parentView = UIView()
-
-                        self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: core.fullscreenHandler) { notification in
-                            return true
+                        let player = Player(options: [kFullscreen: true] as Options)
+                        var callbackWasCalled = false
+                        player.on(.requestFullscreen) { _ in
+                            callbackWasCalled = true
                         }
+                        player.attachTo(UIView(), controller: UIViewController())
+                        player.setFullscreen(true)
+                        expect(callbackWasCalled).toEventually(beTrue())
 
-                        self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: core.fullscreenHandler) { notification in
-                            return true
-                        }
-
-                        core.render()
-                        self.waitForExpectations(timeout: 2, handler: nil)
-                        expect(core.parentView?.subviews.contains(core)).to(beFalse())
-                        expect(core.fullscreenController.view.subviews.contains(core)).to(beTrue())
-                        expect(core.mediaControl?.fullscreen).to(beTrue())
+                        expect(player.core!.parentView?.subviews.contains(core)).to(beFalse())
+                        expect(player.core!.mediaControl?.fullscreen).to(beTrue())
                     }
                     
                 }

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -45,11 +45,11 @@ class CoreTests: QuickSpec {
                         let core = Core(options: options)
                         core.parentView = UIView()
 
-                        self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: core.fullscreenHandler) { notification in
+                        self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: core) { notification in
                             return true
                         }
 
-                        self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: core.fullscreenHandler) { notification in
+                        self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: core) { notification in
                             return true
                         }
 

--- a/Tests/FullscreenStateHandlerTests.swift
+++ b/Tests/FullscreenStateHandlerTests.swift
@@ -32,7 +32,7 @@ class FullscreenStateHandlerTests: QuickSpec {
                         player.on(.requestFullscreen) { _ in
                             callbackWasCalled = true
                         }
-                        player.setFullscreen(true)
+                        player.core?.fullscreenHandler.enterInFullscreen()
                         expect(callbackWasCalled).toEventually(beTrue())
                     }
                 }
@@ -53,7 +53,7 @@ class FullscreenStateHandlerTests: QuickSpec {
                         player.on(.exitFullscreen) { _ in
                             callbackWasCalled = true
                         }
-                        player.setFullscreen(false)
+                        player.core?.fullscreenHandler.exitFullscreen()
                         expect(callbackWasCalled).toEventually(beTrue())
                     }
                 }
@@ -82,12 +82,12 @@ class FullscreenStateHandlerTests: QuickSpec {
                         player.on(.requestFullscreen) { _ in
                             callbackWasCalled = true
                         }
-                        player.setFullscreen(true)
+                        player.core!.fullscreenHandler.enterInFullscreen()
                         expect(callbackWasCalled).toEventually(beTrue())
                     }
 
                     it("should set layout to fullscreen") {
-                        player.setFullscreen(true)
+                        player.core!.fullscreenHandler.enterInFullscreen()
                         let controller = player.core!.fullscreenController
                         expect(controller.view.backgroundColor).to(equal(UIColor.black))
                         expect(controller.modalPresentationStyle).to(equal(UIModalPresentationStyle.overFullScreen))
@@ -148,7 +148,7 @@ class FullscreenStateHandlerTests: QuickSpec {
                         player.on(.exitFullscreen) { _ in
                             callbackWasCalled = true
                         }
-                        player.setFullscreen(false)
+                        player.core?.fullscreenHandler.exitFullscreen()
                         expect(callbackWasCalled).toEventually(beTrue())
                     }
 

--- a/Tests/FullscreenStateHandlerTests.swift
+++ b/Tests/FullscreenStateHandlerTests.swift
@@ -10,34 +10,32 @@ class FullscreenStateHandlerTests: QuickSpec {
             context("when fullscreen is done by app") {
 
                 var core: Core!
-                var fullscreenHandler: FullscreenStateHandler!
 
                 beforeEach {
                     core = Core(options: [kFullscreenByApp: true] as Options)
-                    fullscreenHandler = core.fullscreenHandler
                 }
 
                 context("and player enter in fullscreen mode") {
 
                     beforeEach {
-                        fullscreenHandler.exitFullscreen()
+                        core.setFullscreen(false)
                     }
 
                     it("should set property `fullscreen` of mediaControll to `true`") {
-                        fullscreenHandler.enterInFullscreen()
                         core.setFullscreen(true)
                         expect(core.mediaControl?.fullscreen).to(beTrue())
                     }
 
                     it("should post notification `requestFullscreen`") {
-                        self.expectation(forNotification: Event.requestFullscreen.rawValue, object: fullscreenHandler) { notification in
+                       self.expectation(forNotification: Event.requestFullscreen.rawValue, object: core) { notification in
                             return true
                         }
-                        fullscreenHandler.enterInFullscreen()
+
+                        core.setFullscreen(true)
                         self.waitForExpectations(timeout: 2, handler: nil)
                     }
 
-                    it("should listen event from player") {
+                    it("should listen to requestFullscreen event from player") {
                         let player = Player(options: core.options)
                         var callbackWasCalled = false
 
@@ -55,20 +53,20 @@ class FullscreenStateHandlerTests: QuickSpec {
                 context("and player close fullscreen mode") {
 
                     beforeEach {
-                        fullscreenHandler.enterInFullscreen()
+                        core.setFullscreen(true)
                     }
 
                     it("should set property `fullscreen` of mediaControll to `false`") {
-                        fullscreenHandler.exitFullscreen()
                         core.setFullscreen(false)
                         expect(core.mediaControl?.fullscreen).to(beFalse())
                     }
 
                     it("should post notification `exitFullscreen`") {
-                        self.expectation(forNotification: Event.exitFullscreen.rawValue, object: fullscreenHandler) { notification in
+                        self.expectation(forNotification: Event.exitFullscreen.rawValue, object: core) { notification in
                             return true
                         }
-                        fullscreenHandler.exitFullscreen()
+
+                        core.setFullscreen(false)
                         self.waitForExpectations(timeout: 2, handler: nil)
                     }
 
@@ -110,7 +108,7 @@ class FullscreenStateHandlerTests: QuickSpec {
                     }
 
                     it("should post notification `willEnterFullscreen`") {
-                        self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: fullscreenHandler) { notification in
+                        self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: core) { notification in
                             return true
                         }
                         fullscreenHandler.enterInFullscreen()
@@ -118,9 +116,10 @@ class FullscreenStateHandlerTests: QuickSpec {
                     }
 
                     it("should post notification `didEnterFullscreen`") {
-                        self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: fullscreenHandler) { notification in
+                        self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: core) { notification in
                             return true
                         }
+
                         fullscreenHandler.enterInFullscreen()
                         self.waitForExpectations(timeout: 2, handler: nil)
                     }
@@ -155,20 +154,20 @@ class FullscreenStateHandlerTests: QuickSpec {
                         }
 
                         it("shouldn't post notification `willEnterFullscreen`") {
-                            let expect = self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: fullscreenHandler) { notification in
+                            let expectation = self.expectation(forNotification: InternalEvent.willEnterFullscreen.rawValue, object: core) { notification in
                                 return true
                             }
 
-                            expect.isInverted = true
+                            expectation.isInverted = true
                             core.setFullscreen(true)
                             self.waitForExpectations(timeout: 2, handler: nil)
                         }
 
                         it("shouldn't post notification `didEnterFullscreen`") {
-                            let expect = self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: fullscreenHandler) { notification in
+                            let expectation = self.expectation(forNotification: InternalEvent.didEnterFullscreen.rawValue, object: core) { notification in
                                 return true
                             }
-                            expect.isInverted = true
+                            expectation.isInverted = true
                             core.setFullscreen(true)
                             self.waitForExpectations(timeout: 2, handler: nil)
                         }
@@ -188,17 +187,19 @@ class FullscreenStateHandlerTests: QuickSpec {
                     }
 
                     it("should post notification `willExitFullscreen`") {
-                        self.expectation(forNotification: InternalEvent.willExitFullscreen.rawValue, object: fullscreenHandler) { notification in
+                        self.expectation(forNotification: InternalEvent.willExitFullscreen.rawValue, object: core) { notification in
                             return true
                         }
+
                         fullscreenHandler.exitFullscreen()
                         self.waitForExpectations(timeout: 2, handler: nil)
                     }
 
                     it("should post notification `didExitFullscreen`") {
-                        self.expectation(forNotification: InternalEvent.didExitFullscreen.rawValue, object: fullscreenHandler) { notification in
+                        self.expectation(forNotification: InternalEvent.didExitFullscreen.rawValue, object: core) { notification in
                             return true
                         }
+
                         fullscreenHandler.exitFullscreen()
                         self.waitForExpectations(timeout: 2, handler: nil)
                     }
@@ -231,17 +232,21 @@ class FullscreenStateHandlerTests: QuickSpec {
                         }
 
                         it("shouldn't post notification `willExitFullscreen`") {
-                            self.expectation(forNotification: InternalEvent.willExitFullscreen.rawValue, object: fullscreenHandler) { notification in
-                                return false
+                            let expectation = self.expectation(forNotification: InternalEvent.willExitFullscreen.rawValue, object: core) { notification in
+                                return true
                             }
+
+                            expectation.isInverted = true
                             core.setFullscreen(false)
                             self.waitForExpectations(timeout: 2, handler: nil)
                         }
 
                         it("shouldn't post notification `didExitFullscreen`") {
-                            self.expectation(forNotification: InternalEvent.didExitFullscreen.rawValue, object: fullscreenHandler) { notification in
-                                return false
+                            let expectation = self.expectation(forNotification: InternalEvent.didExitFullscreen.rawValue, object: core) { notification in
+                                return true
                             }
+
+                            expectation.isInverted = true
                             core.setFullscreen(false)
                             self.waitForExpectations(timeout: 2, handler: nil)
                         }


### PR DESCRIPTION
### Summary
When user requests fullscreen, the player change the layout to fullscreen by itself.
This feature was implemented on this PR: [Fullscreen handle by application](https://github.com/clappr/clappr-ios/pull/138)
But some bugs was found.

### Goal
 - Apply tests for events
 - Add alert for sample app
 - Block setfullscreen was called twice
 - Increase tests coverage

### How to test
 #### Test: Application controls fullscreen
 1. Run App and switch the option **fullscreen controled by app** to **on**.
 2. Open the video
 3. Change the orientation to landscape
 4. **The player should change the icon to fullscreen**
 5. Change the orientation to portrait
 6. **The player should change the icon to default(embed)**

#### Test: Player controls fullscreen
 1. Run App and switch the option **fullscreen controled by app** to **off**.
 2. Open the video
 3. Tap to set the video to fullscreen
 4. **The player should change the layout and icon to fullscreen**
 5. Tap to close fullscreen of video
 6. **The player should change the layout and icon to embed**
