### PR TITLE
Fix/add xcode9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - PROJECT="Clappr.xcodeproj"
     - SCHEME="Clappr-Example"
-    - DESTINATION="platform=iOS Simulator,name=iPhone 6s Plus,OS=10.0"
+    - DESTINATION="platform=iOS Simulator,name=iPhone 6s Plus,OS=11.0"
 
 before_install:
   - brew update
@@ -19,7 +19,7 @@ before_install:
   - gem install cocoapods -v '1.1.1'
   - pod repo update
   - gem install simctl --no-rdoc --no-ri --no-document --quiet
-  - ruby -rsimctl -e 'SimCtl.warmup("iPhone 6s Plus", "iOS 10.0", 300)'
+  - ruby -rsimctl -e 'SimCtl.warmup("iPhone 6s Plus", "iOS 11.0", 300)'
 
 script:
   - swiftlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ before_install:
   - gem install cocoapods -v '1.1.1'
   - pod repo update
   - gem install simctl --no-rdoc --no-ri --no-document --quiet
-  - ruby -rsimctl -e 'SimCtl.warmup("iPhone 7", "iOS 11.1", 300)'
+  - xcrun simctl boot $(xcrun simctl create "iPhone 7" com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-11-1)
+  - open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/
+  - sleep 300
 
 script:
   - swiftlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - gem install cocoapods -v '1.1.1'
   - pod repo update
   - gem install simctl --no-rdoc --no-ri --no-document --quiet
+  - xcrun simctl shutdown all && xcrun simctl erase all
   - xcrun simctl boot $(xcrun simctl create "iPhone 7" com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-11-1)
   - open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/
   - sleep 300
@@ -26,4 +27,4 @@ before_install:
 script:
   - swiftlint
   - pod lib lint
-  - xcodebuild test -project "${PROJECT}" -scheme "${SCHEME}" -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -destination "${DESTINATION}" | xcpretty -s && exit ${PIPESTATUS[0]}
+  - xcodebuild test -project "Clappr.xcodeproj" -scheme "Clappr-Example" -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -destination "platform=iOS Simulator,name=iPhone 7,OS=11.0" | xcpretty -s && exit ${PIPESTATUS[0]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # * https://github.com/supermarin/xcpretty#usage
 language: objective-c
 
-osx_image: xcode8.3
+osx_image: xcode9.1
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - PROJECT="Clappr.xcodeproj"
     - SCHEME="Clappr-Example"
-    - DESTINATION="platform=iOS Simulator,name=iPhone 6s Plus,OS=11.0"
+    - DESTINATION="platform=iOS Simulator,name=iPhone 6s Plus,OS=11.1"
 
 before_install:
   - brew update
@@ -19,7 +19,7 @@ before_install:
   - gem install cocoapods -v '1.1.1'
   - pod repo update
   - gem install simctl --no-rdoc --no-ri --no-document --quiet
-  - ruby -rsimctl -e 'SimCtl.warmup("iPhone 6s Plus", "iOS 11.0", 300)'
+  - ruby -rsimctl -e 'SimCtl.warmup("iPhone 6s Plus", "iOS 11.1", 300)'
 
 script:
   - swiftlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ env:
   global:
     - PROJECT="Clappr.xcodeproj"
     - SCHEME="Clappr-Example"
-    - DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=11.1"
+    - SIMULATOR_ID=`xcrun simctl create "iPhone 7" com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-11-1`
+    - DESTINATION="platform=iOS Simulator,id=${SIMULATOR_ID}"
 
 before_install:
   - brew update
@@ -18,13 +19,11 @@ before_install:
   - carthage bootstrap --platform iOS
   - gem install cocoapods -v '1.1.1'
   - pod repo update
-  - gem install simctl --no-rdoc --no-ri --no-document --quiet
-  - xcrun simctl shutdown all && xcrun simctl erase all
-  - xcrun simctl boot $(xcrun simctl create "iPhone 7" com.apple.CoreSimulator.SimDeviceType.iPhone-7 com.apple.CoreSimulator.SimRuntime.iOS-11-1)
+  - xcrun simctl boot ${SIMULATOR_ID}
   - open /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app/
-  - sleep 300
+  - sleep 150
 
 script:
   - swiftlint
   - pod lib lint
-  - xcodebuild test -project "Clappr.xcodeproj" -scheme "Clappr-Example" -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -destination "platform=iOS Simulator,name=iPhone 7,OS=11.0" | xcpretty -s && exit ${PIPESTATUS[0]}
+  - xcodebuild test -project "${PROJECT}" -scheme "${SCHEME}" -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -destination "${DESTINATION}" | xcpretty -s && exit ${PIPESTATUS[0]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   global:
     - PROJECT="Clappr.xcodeproj"
     - SCHEME="Clappr-Example"
-    - DESTINATION="platform=iOS Simulator,name=iPhone 6s Plus,OS=11.1"
+    - DESTINATION="platform=iOS Simulator,name=iPhone 7,OS=11.1"
 
 before_install:
   - brew update
@@ -19,7 +19,7 @@ before_install:
   - gem install cocoapods -v '1.1.1'
   - pod repo update
   - gem install simctl --no-rdoc --no-ri --no-document --quiet
-  - ruby -rsimctl -e 'SimCtl.warmup("iPhone 6s Plus", "iOS 11.1", 300)'
+  - ruby -rsimctl -e 'SimCtl.warmup("iPhone 7", "iOS 11.1", 300)'
 
 script:
   - swiftlint

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "onevcat/Kingfisher" ~> 3.0
+github "onevcat/Kingfisher" == 3.13.1

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 1.1.0
-github "Quick/Nimble" ~> 6.1.0
+github "Quick/Quick" == 1.2.0
+github "Quick/Nimble" == 7.0.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v6.1.0"
-github "Quick/Quick" "v1.1.0"
-github "onevcat/Kingfisher" "3.10.3"
+github "Quick/Nimble" "v7.0.2"
+github "Quick/Quick" "v1.2.0"
+github "onevcat/Kingfisher" "3.13.1"

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -853,7 +853,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -893,7 +893,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -912,6 +912,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -931,6 +932,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -952,6 +954,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -970,6 +973,7 @@
 				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -996,7 +1000,7 @@
 				);
 				INFOPLIST_FILE = Clappr/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.clappr.Clappr;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1024,7 +1028,7 @@
 				);
 				INFOPLIST_FILE = Clappr/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.clappr.Clappr;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -58,7 +58,7 @@ class ViewController: UIViewController {
         return UIInterfaceOrientationMask.portrait
     }
 
-    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation { // swiftlint:disable:this variable_name
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         return UIInterfaceOrientation.portrait
     }
 

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -4,6 +4,18 @@ import Nimble
 
 class CoreTests: QuickSpec {
     override func spec() {
+        class StubPlayback: Playback {
+            override var pluginName: String {
+                return "stupPlayback"
+            }
+        }
+
+        class FakeCorePlugin: UICorePlugin {
+            override var pluginName: String {
+                return "FakeCorePLugin"
+            }
+        }
+
         let options = [kSourceUrl: "http//test.com"]
         var core: Core!
         let loader = Loader(externalPlugins: [StubPlayback.self])
@@ -166,18 +178,6 @@ class CoreTests: QuickSpec {
                     }
                 }
             }
-        }
-    }
-
-    class StubPlayback: Playback {
-        override var pluginName: String {
-            return "stupPlayback"
-        }
-    }
-
-    class FakeCorePlugin: UICorePlugin {
-        override var pluginName: String {
-            return "FakeCorePLugin"
         }
     }
 }


### PR DESCRIPTION
# GOAL
Adjust Clappr project to Xcode9 and iOS11

# How to test
1. Run Clappr project on xcode9 inside a simulator or device running iOS11 
2. Run unit tests and certificate if all passes.