### PR TITLE
Fix setFullscreen when the fullsscreen is controled by player

### DIFF
--- a/Clappr/Classes/Base/Core.swift
+++ b/Clappr/Classes/Base/Core.swift
@@ -145,7 +145,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     }
 
     open func setFullscreen(_ fullscreen: Bool) {
-        mediaControl?.fullscreen = fullscreen
+        guard let mediaControl = mediaControl, mediaControl.fullscreen != fullscreen else { return }
+        mediaControl.fullscreen = fullscreen
     }
 
     open func destroy() {

--- a/Clappr/Classes/Base/Core.swift
+++ b/Clappr/Classes/Base/Core.swift
@@ -145,12 +145,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     }
 
     open func setFullscreen(_ fullscreen: Bool) {
-        guard let mediaControl = mediaControl, mediaControl.fullscreen != fullscreen else { return }
-        if optionsUnboxer.fullscreenControledByApp {
-            mediaControl.fullscreen = fullscreen
-        } else {
-            fullscreen ? fullscreenHandler.enterInFullscreen() : fullscreenHandler.exitFullscreen()
-        }
+        fullscreenHandler.set(fullscreen: fullscreen)
     }
 
     open func destroy() {

--- a/Clappr/Classes/Base/Core.swift
+++ b/Clappr/Classes/Base/Core.swift
@@ -146,7 +146,11 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
 
     open func setFullscreen(_ fullscreen: Bool) {
         guard let mediaControl = mediaControl, mediaControl.fullscreen != fullscreen else { return }
-        mediaControl.fullscreen = fullscreen
+        if optionsUnboxer.fullscreenControledByApp {
+            mediaControl.fullscreen = fullscreen
+        } else {
+            fullscreen ? fullscreenHandler.enterInFullscreen() : fullscreenHandler.exitFullscreen()
+        }
     }
 
     open func destroy() {

--- a/Clappr/Classes/Base/FullScreenStateHandler.swift
+++ b/Clappr/Classes/Base/FullScreenStateHandler.swift
@@ -5,6 +5,7 @@ protocol FullscreenStateHandler {
 
     init(core: Core)
 
+    func set(fullscreen: Bool)
     func enterInFullscreen(_: EventUserInfo)
     func enterInFullscreen()
 
@@ -31,6 +32,10 @@ struct FullscreenByApp: FullscreenStateHandler {
 
     var core: Core
 
+    func set(fullscreen: Bool) {
+        core.mediaControl?.fullscreen = fullscreen
+    }
+
     func enterInFullscreen(_: EventUserInfo = [:]) {
         guard !isOnFullscreen else { return }
         core.trigger(InternalEvent.userRequestEnterInFullscreen.rawValue)
@@ -45,6 +50,17 @@ struct FullscreenByApp: FullscreenStateHandler {
 struct FullscreenByPlayer: FullscreenStateHandler {
 
     var core: Core
+
+    func set(fullscreen: Bool) {
+        if shouldChange(fullscreen: fullscreen) {
+            fullscreen ? enterInFullscreen() : exitFullscreen()
+        }
+    }
+
+    func shouldChange(fullscreen: Bool) -> Bool {
+        guard let mediaControl = core.mediaControl else { return false }
+        return mediaControl.fullscreen != fullscreen
+    }
 
     func enterInFullscreen(_: EventUserInfo = [:]) {
         guard !isOnFullscreen else { return }

--- a/Clappr_UITests/FullscreenUITests.swift
+++ b/Clappr_UITests/FullscreenUITests.swift
@@ -15,65 +15,81 @@ class FullscreenUITests: QuickSpec {
 
         describe("Fullscreen") {
 
+            beforeEach {
+                app = XCUIApplication()
+                app.launch()
+                XCUIDevice.shared.orientation = .portrait
+
+                dashboardInteractor = DashboardViewInteractor(app: app)
+                playerInteractor = PlayerViewInteractor(app: app)
+            }
+
+            afterEach {
+                app.terminate()
+            }
+
+            context("setFullscreen") {
+                it("player should set to fullscreen when setFullscreen is called") {
+                    dashboardInteractor.startAsFullscreen = false
+                    dashboardInteractor.fullscreenControledByApp = false
+
+                    dashboardInteractor.startVideo()
+                    playerInteractor.tapOnContainer()
+                    XCUIDevice.shared.orientation = .landscapeLeft
+
+                    expect(playerInteractor.containerFrame == window.frame).to(beTrue())
+                }
+            }
+
             context("start as fullscreen") {
 
                 beforeEach {
-                    app = XCUIApplication()
-                    app.launch()
-
-                    dashboardInteractor = DashboardViewInteractor(app: app)
                     dashboardInteractor.startAsFullscreen = true
-
-                    playerInteractor = PlayerViewInteractor(app: app)
                 }
 
                 it("player should have the same size of window") {
                     dashboardInteractor.fullscreenControledByApp = false
+
                     dashboardInteractor.startVideo()
 
-                    XCTAssert(playerInteractor.containerFrame == window.frame)
+                    expect(playerInteractor.containerFrame == window.frame).to(beTrue())
                 }
 
                 it("player should not have the same size of window ") {
                     dashboardInteractor.fullscreenControledByApp = true
+
                     dashboardInteractor.startVideo()
 
-                    XCTAssert(playerInteractor.containerFrame != window.frame)
+                    expect(playerInteractor.containerFrame != window.frame).to(beTrue())
                 }
             }
 
             context("fullscreen controled by app") {
 
                 beforeEach {
-                    app = XCUIApplication()
-                    app.launch()
-
-                    dashboardInteractor = DashboardViewInteractor(app: app)
-                    dashboardInteractor.fullscreenControledByApp = true
-
                     playerInteractor = PlayerViewInteractor(app: app)
                 }
 
                 it("player should not change the container size when taps on fullscreen button") {
                     dashboardInteractor.startAsFullscreen = false
-                    dashboardInteractor.startVideo()
 
+                    dashboardInteractor.startVideo()
                     let currentFrame = playerInteractor.containerFrame
                     playerInteractor.tapOnContainer()
                     playerInteractor.tapOnFullscreen()
                     
-                    XCTAssert(currentFrame == playerInteractor.containerFrame)
+                    expect(currentFrame == playerInteractor.containerFrame).to(beTrue())
                 }
 
                 it("player should not change the container size when taps on fullscreen button") {
                     dashboardInteractor.startAsFullscreen = true
-                    dashboardInteractor.startVideo()
 
+                    dashboardInteractor.startVideo()
                     let currentFrame = playerInteractor.containerFrame
                     playerInteractor.tapOnContainer()
                     playerInteractor.tapOnFullscreen()
 
-                    XCTAssert(currentFrame == playerInteractor.containerFrame)
+                    expect(currentFrame == playerInteractor.containerFrame).to(beTrue())
                 }
             }
         }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -20,6 +20,33 @@ class ViewController: UIViewController {
         player.attachTo(playerContainer, controller: self)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        NotificationCenter.default.addObserver(self, selector: #selector(rotated), name: .UIDeviceOrientationDidChange, object: nil)
+    }
+
+    func rotated() {
+        if (player?.isFullscreen)! && (UIDevice.current.orientation == .faceUp || UIDevice.current.orientation == .faceDown) {
+            return
+        }
+
+        if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
+            UIApplication.shared.isStatusBarHidden = true
+            player?.setFullscreen(true)
+        } else {
+            UIApplication.shared.isStatusBarHidden = false
+            player?.setFullscreen(false)
+            self.forceOrientation(.portrait)
+        }
+    }
+
+    fileprivate func forceOrientation(_ orientation: UIInterfaceOrientation = .portrait) {
+        UIDevice.current.setValue(
+            orientation.rawValue,
+            forKey: "orientation"
+        )
+    }
+
     func listenToPlayerEvents() {
         player.on(Event.playing) { _ in print("on Play") }
 

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -11,6 +11,10 @@ class ViewController: UIViewController {
         return options[kFullscreenByApp] as? Bool ?? false
     }
 
+    var deviceIsOnLandscape: Bool {
+        return [UIDeviceOrientation.landscapeLeft, UIDeviceOrientation.landscapeRight].contains(UIDevice.current.orientation)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         player = Player(options: options)
@@ -26,21 +30,19 @@ class ViewController: UIViewController {
     }
 
     func rotated() {
-        if (player?.isFullscreen)! && (UIDevice.current.orientation == .faceUp || UIDevice.current.orientation == .faceDown) {
-            return
-        }
-
-        if UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight {
-            UIApplication.shared.isStatusBarHidden = true
-            player?.setFullscreen(true)
-        } else {
-            UIApplication.shared.isStatusBarHidden = false
-            player?.setFullscreen(false)
-            self.forceOrientation(.portrait)
+        guard let playerIsOnFullscreen = player?.isFullscreen else { return }
+        setPlayerTo(fullscreen: deviceIsOnLandscape && !playerIsOnFullscreen)
+        if !deviceIsOnLandscape {
+            forceOrientation(to: .portrait)
         }
     }
 
-    fileprivate func forceOrientation(_ orientation: UIInterfaceOrientation = .portrait) {
+    func setPlayerTo(fullscreen: Bool) {
+        UIApplication.shared.isStatusBarHidden = fullscreen
+        player?.setFullscreen(fullscreen)
+    }
+
+    fileprivate func forceOrientation(to orientation: UIInterfaceOrientation = .portrait) {
         UIDevice.current.setValue(
             orientation.rawValue,
             forKey: "orientation"

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -98,7 +98,18 @@ class CoreTests: QuickSpec {
                         expect(player.core!.parentView?.subviews.contains(core)).to(beFalse())
                         expect(player.core!.mediaControl?.fullscreen).to(beTrue())
                     }
-                    
+
+                    it("Should set to fullscreen video by call `setFullscreen(true)`") {
+                        let core = Core()
+                        core.parentView = UIView()
+
+                        core.render()
+                        core.setFullscreen(true)
+
+                        expect(core.parentView?.subviews.contains(core)).to(beFalse())
+                        expect(core.fullscreenController.view.subviews.contains(core)).to(beTrue())
+                        expect(core.mediaControl?.fullscreen).to(beTrue())
+                    }
                 }
             }
 
@@ -188,7 +199,7 @@ class CoreTests: QuickSpec {
 
                     it("should returns correct value for `kFullscreenByApp`") {
                         optionsUnboxer = OptionsUnboxer(options: [kFullscreenByApp: true])
-                        
+
                         expect(optionsUnboxer.fullscreenControledByApp).to(beTrue())
                     }
                 }

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -110,6 +110,19 @@ class CoreTests: QuickSpec {
                         expect(core.fullscreenController.view.subviews.contains(core)).to(beTrue())
                         expect(core.mediaControl?.fullscreen).to(beTrue())
                     }
+
+                    it("Should not try to set fullscreen video twice by call `setFullscreen(true)` twice") {
+                        let core = Core()
+                        core.parentView = UIView()
+
+                        core.render()
+                        core.setFullscreen(true)
+                        core.setFullscreen(true)
+
+                        expect(core.parentView?.subviews.contains(core)).to(beFalse())
+                        expect(core.fullscreenController.view.subviews.filter { $0 == core }.count).to(equal(1))
+                        expect(core.mediaControl?.fullscreen).to(beTrue())
+                    }
                 }
             }
 

--- a/Tests/CoreTests.swift
+++ b/Tests/CoreTests.swift
@@ -39,7 +39,9 @@ class CoreTests: QuickSpec {
                         let options: Options = [kFullscreen: false]
                         let core = Core(options: options)
                         core.parentView = UIView()
+
                         core.render()
+
                         expect(core.parentView?.subviews.contains(core)).to(beTrue())
                         expect(core.mediaControl?.fullscreen).to(beFalse())
                     }
@@ -47,7 +49,9 @@ class CoreTests: QuickSpec {
                     it("Should start as embed video when `kFullscreen` was not passed") {
                         let core = Core()
                         core.parentView = UIView()
+
                         core.render()
+
                         expect(core.parentView?.subviews.contains(core)).to(beTrue())
                         expect(core.mediaControl?.fullscreen).to(beFalse())
                     }
@@ -60,9 +64,10 @@ class CoreTests: QuickSpec {
                         core.on(InternalEvent.didEnterFullscreen.rawValue) { _ in
                             callbackWasCall = true
                         }
-                        core.render()
-                        expect(callbackWasCall).toEventually(beTrue())
 
+                        core.render()
+
+                        expect(callbackWasCall).toEventually(beTrue())
                         expect(core.parentView?.subviews.contains(core)).to(beFalse())
                         expect(core.fullscreenController.view.subviews.contains(core)).to(beTrue())
                         expect(core.mediaControl?.fullscreen).to(beTrue())
@@ -72,7 +77,9 @@ class CoreTests: QuickSpec {
                         let options: Options = [kFullscreen: true, kFullscreenByApp: true]
                         let core = Core(options: options)
                         core.parentView = UIView()
+
                         core.render()
+
                         expect(core.parentView?.subviews.contains(core)).to(beTrue())
                         expect(core.mediaControl?.fullscreen).to(beFalse())
                     }
@@ -84,9 +91,10 @@ class CoreTests: QuickSpec {
                             callbackWasCalled = true
                         }
                         player.attachTo(UIView(), controller: UIViewController())
-                        player.setFullscreen(true)
-                        expect(callbackWasCalled).toEventually(beTrue())
 
+                        player.setFullscreen(true)
+
+                        expect(callbackWasCalled).toEventually(beTrue())
                         expect(player.core!.parentView?.subviews.contains(core)).to(beFalse())
                         expect(player.core!.mediaControl?.fullscreen).to(beTrue())
                     }
@@ -110,6 +118,7 @@ class CoreTests: QuickSpec {
 
                 it("Should be the top view on core") {
                     core.render()
+
                     expect(core.subviews.last) == core.mediaControl
                 }
             }
@@ -118,12 +127,14 @@ class CoreTests: QuickSpec {
                 context("Addition") {
                     it("Should be able to add plugins") {
                         core.addPlugin(FakeCorePlugin())
+
                         expect(core.plugins.count) == 1
                     }
 
                     it("Should add plugin as subview after rendered") {
                         let plugin = FakeCorePlugin()
                         core.addPlugin(plugin)
+
                         core.render()
 
                         expect(plugin.superview) == core
@@ -134,12 +145,14 @@ class CoreTests: QuickSpec {
                     it("Should return true if a plugin is installed") {
                         core.addPlugin(FakeCorePlugin())
                         let containsPlugin = core.hasPlugin(FakeCorePlugin.self)
+
                         expect(containsPlugin).to(beTrue())
                     }
 
                     it("Should return false if a plugin isn't installed") {
                         core.addPlugin(UICorePlugin())
                         let containsPlugin = core.hasPlugin(FakeCorePlugin.self)
+
                         expect(containsPlugin).to(beFalse())
                     }
                 }
@@ -168,12 +181,14 @@ class CoreTests: QuickSpec {
 
                     it("should returns correct value for `fullscreen`") {
                         optionsUnboxer = OptionsUnboxer(options: [kFullscreen: true])
+
                         expect(optionsUnboxer.fullscreen).to(beTrue())
 
                     }
 
                     it("should returns correct value for `kFullscreenByApp`") {
                         optionsUnboxer = OptionsUnboxer(options: [kFullscreenByApp: true])
+                        
                         expect(optionsUnboxer.fullscreenControledByApp).to(beTrue())
                     }
                 }


### PR DESCRIPTION
## Goal
After the fullscreen controled by app was added, the method ``setFullscreen`` doesnt set player to fullscreen when **kFullscreenByApp is false**.

## How to test
1) Open Sample
2) Disable **Fullscreen controled by app** and **Start player as Fullscreen**
3) Tap on **start video**
4) Change orientation of App to landscapeLeft

**obs: Make sure that the player was set to fullscreen when orientation changes**