### PR TITLE
Exposes asset property in AVFoundationPlayback

### DIFF
--- a/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -21,7 +21,7 @@ open class AVFoundationPlayback: Playback {
     fileprivate var playerStatus: AVPlayerItemStatus = .unknown
     fileprivate var currentState = PlaybackState.idle
     fileprivate var timeObserver: Any?
-    fileprivate var asset: AVURLAsset?
+    open var asset: AVURLAsset?
 
     private var backgroundSessionBackup: String?
 


### PR DESCRIPTION
# Goal

- To expose `asset` property in `AVFoundationPlayback`

# How to test

- Just make sure that this change didn't affect Clappr functionality