### PR TITLE
NoOpPlayback should'nt trigger a ready event on render

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		9E3AE5341FB330C000DFBBEB /* OptionsUnboxerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3AE5331FB330C000DFBBEB /* OptionsUnboxerTests.swift */; };
 		9E3F43F91F3102D800417919 /* AppStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3F43F81F3102D800417919 /* AppStateManager.swift */; };
 		9E3F43FC1F31116100417919 /* AppStateManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3F43FA1F3102E900417919 /* AppStateManagerTests.swift */; };
+		9E5226791FBA207C008C4A15 /* NoOpPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5226781FBA207C008C4A15 /* NoOpPlaybackTests.swift */; };
 		9E692E0A1F9F89B3006510BE /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B46D05A51DB7DBC50004B23F /* Nimble.framework */; };
 		9E692E0B1F9F89B3006510BE /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B46D05A71DB7DBD60004B23F /* Quick.framework */; };
 		9E692E0C1F9F89BF006510BE /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = B46D05A71DB7DBD60004B23F /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -216,6 +217,7 @@
 		9E3AE5331FB330C000DFBBEB /* OptionsUnboxerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsUnboxerTests.swift; sourceTree = "<group>"; };
 		9E3F43F81F3102D800417919 /* AppStateManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStateManager.swift; sourceTree = "<group>"; };
 		9E3F43FA1F3102E900417919 /* AppStateManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStateManagerTests.swift; sourceTree = "<group>"; };
+		9E5226781FBA207C008C4A15 /* NoOpPlaybackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoOpPlaybackTests.swift; sourceTree = "<group>"; };
 		9E692DFF1F9F898F006510BE /* Clappr_UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Clappr_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E692E0E1F9F8A53006510BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9E692E0F1F9F8A53006510BE /* PlayerViewElements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewElements.swift; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 				9EC853301F7BF06A00716778 /* FullscreenStateHandlerTests.swift */,
 				57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */,
 				9E3AE5331FB330C000DFBBEB /* OptionsUnboxerTests.swift */,
+				9E5226781FBA207C008C4A15 /* NoOpPlaybackTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -841,6 +844,7 @@
 				EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */,
 				96912C3E1C21A1AF003A4AFD /* PosterPluginTests.swift in Sources */,
 				96B4656B1BF6028A0025975A /* UIPluginTests.swift in Sources */,
+				9E5226791FBA207C008C4A15 /* NoOpPlaybackTests.swift in Sources */,
 				9603A06C1C05E6D100B55D8F /* PlayerTests.swift in Sources */,
 				96664E6D1BF209CF00095E6E /* ContainerTests.swift in Sources */,
 				EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */,

--- a/Clappr/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Clappr/Classes/Plugin/Container/PosterPlugin.swift
@@ -76,7 +76,6 @@ open class PosterPlugin: UIContainerPlugin {
     private func bindPlaybackEvents() {
         if let playback = container?.playback {
             listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.playbackStarted() }
-            listenTo(playback, eventName: Event.ready.rawValue) { [weak self] _ in self?.playbackReady() }
             listenTo(playback, eventName: Event.stalled.rawValue) { [weak self] _ in self?.playbackStalled() }
             listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in self?.playbackEnded() }
         }
@@ -88,7 +87,13 @@ open class PosterPlugin: UIContainerPlugin {
         listenTo(container, eventName: Event.requestPosterUpdate.rawValue) { [weak self] info in self?.updatePoster(info) }
     }
 
+    var isNoOpPlayback: Bool {
+        guard let playback = container?.playback else { return false }
+        return type(of: playback) == NoOpPlayback.self
+    }
+
     private func didChangePlayback() {
+        isHidden = isNoOpPlayback
         stopListening()
         bindPlaybackEvents()
         bindContainerEvents()
@@ -107,12 +112,6 @@ open class PosterPlugin: UIContainerPlugin {
         container?.mediaControlEnabled = false
         playButton.isHidden = false
         isHidden = false
-    }
-
-    fileprivate func playbackReady() {
-        if container?.playback?.pluginName == "NoOp" {
-            isHidden = true
-        }
     }
 
     fileprivate func updatePoster(_ info: EventUserInfo) {

--- a/Clappr/Classes/Plugin/Playback/NoOpPlayback.swift
+++ b/Clappr/Classes/Plugin/Playback/NoOpPlayback.swift
@@ -28,7 +28,6 @@ open class NoOpPlayback: Playback {
 
     open override func render() {
         addSubviewMatchingConstraints(errorLabel)
-        trigger(.ready)
     }
 
     fileprivate func setupLabel() {

--- a/Tests/NoOpPlaybackTests.swift
+++ b/Tests/NoOpPlaybackTests.swift
@@ -1,0 +1,27 @@
+import Quick
+import Nimble
+import AVFoundation
+
+@testable import Clappr
+
+class NoOpPlaybackTests: QuickSpec {
+    override func spec() {
+        super.spec()
+
+        describe(".NoOpPlayback") {
+            describe("#render") {
+                it("not trigger ready event") {
+                    let playback = NoOpPlayback()
+                    var didCallEvent = false
+                    playback.on(Event.ready.rawValue) { _ in
+                        didCallEvent = true
+                    }
+
+                    playback.render()
+
+                    expect(didCallEvent) == false
+                }
+            }
+        }
+    }
+}

--- a/Tests/NoOpPlaybackTests.swift
+++ b/Tests/NoOpPlaybackTests.swift
@@ -10,7 +10,7 @@ class NoOpPlaybackTests: QuickSpec {
 
         describe(".NoOpPlayback") {
             describe("#render") {
-                it("not trigger ready event") {
+                it("doesn't trigger ready event") {
                     let playback = NoOpPlayback()
                     var didCallEvent = false
                     playback.on(Event.ready.rawValue) { _ in

--- a/Tests/PosterPluginTests.swift
+++ b/Tests/PosterPluginTests.swift
@@ -44,18 +44,50 @@ class PosterPluginTests: QuickSpec {
 
                     expect(posterPlugin.superview) == container
                 }
+            }
 
-                it("Should be hidden if playback is a NoOp") {
-                    container = Container(options: [kSourceUrl: "none", kPosterUrl: "http://clappr.io/poster.png"])
-                    container.render()
+            context("when change a playback") {
 
-                    let posterPlugin = self.getPosterPlugin(container)
+                var posterPlugin: PosterPlugin!
 
-                    expect(posterPlugin.isHidden).to(beTrue())
+                beforeEach {
+                    container = Container()
+                }
+
+                context("and playback is NoOP") {
+
+                    beforeEach {
+                        container.playback = NoOpPlayback()
+                        posterPlugin = self.getPosterPlugin(container)
+                    }
+
+                    it("plugin is set to invisible") {
+                        expect(posterPlugin.isHidden).toEventually(beTrue())
+                    }
+
+                    it("isNoOpPlayback is true") {
+                        expect(posterPlugin.isNoOpPlayback) == true
+                    }
+                }
+
+                context("and playback isnt NoOp") {
+
+                    beforeEach {
+                        container.playback = AVFoundationPlayback()
+                        posterPlugin = self.getPosterPlugin(container)
+                    }
+
+                    it("plugin is set to visible") {
+                        expect(posterPlugin.isHidden).toEventually(beFalse())
+                    }
+
+                    it("isNoOpPlayback is true") {
+                        expect(posterPlugin.isNoOpPlayback) == false
+                    }
                 }
             }
 
-            context("State") {
+            describe("Container Events") {
                 var posterPlugin: PosterPlugin!
 
                 beforeEach {

--- a/Tests/PosterPluginTests.swift
+++ b/Tests/PosterPluginTests.swift
@@ -14,7 +14,7 @@ class PosterPluginTests: QuickSpec {
             ]
 
             context("when container has no options") {
-                it("plugin is set to invisible") {
+                it("hides itself") {
                     container = Container()
                     container.render()
 
@@ -25,7 +25,7 @@ class PosterPluginTests: QuickSpec {
             }
 
             context("when container doesnt have posterUrl option") {
-                it("plugin is set to invisible") {
+                it("hides itself") {
                     container = Container(options: ["anotherOption": true])
                     container.render()
 
@@ -36,7 +36,7 @@ class PosterPluginTests: QuickSpec {
             }
 
             context("when container has posterUrl option") {
-                it("plugin is render") {
+                it("it renders itself") {
                     container = Container(options: options)
                     container.render()
 
@@ -61,7 +61,7 @@ class PosterPluginTests: QuickSpec {
                         posterPlugin = self.getPosterPlugin(container)
                     }
 
-                    it("plugin is set to invisible") {
+                    it("hides itself") {
                         expect(posterPlugin.isHidden).toEventually(beTrue())
                     }
 
@@ -77,7 +77,7 @@ class PosterPluginTests: QuickSpec {
                         posterPlugin = self.getPosterPlugin(container)
                     }
 
-                    it("plugin is set to visible") {
+                    it("reveal itself") {
                         expect(posterPlugin.isHidden).toEventually(beFalse())
                     }
 
@@ -97,7 +97,7 @@ class PosterPluginTests: QuickSpec {
                 }
 
                 context("when container trigger a play event") {
-                    it("plugin is set to invisible") {
+                    it("hides itself") {
                         expect(posterPlugin.isHidden).to(beFalse())
                         container.playback?.trigger(Event.playing.rawValue)
                         expect(posterPlugin.isHidden).to(beTrue())
@@ -105,7 +105,7 @@ class PosterPluginTests: QuickSpec {
                 }
 
                 context("when container trigger a end event") {
-                    it("plugin is set to visible") {
+                    it("reveal itself") {
                         container.playback?.trigger(Event.playing.rawValue)
                         container.playback?.trigger(Event.didComplete.rawValue)
 

--- a/Tests/PosterPluginTests.swift
+++ b/Tests/PosterPluginTests.swift
@@ -5,15 +5,16 @@ import Nimble
 class PosterPluginTests: QuickSpec {
 
     override func spec() {
-        describe("Poster Plugin") {
+
+        describe(".PosterPlugin") {
             var container: Container!
             let options = [
                 kSourceUrl: "http://globo.com/video.mp4",
                 kPosterUrl: "http://clappr.io/poster.png",
             ]
 
-            context("Initialization") {
-                it("Should not be visible if container has no options") {
+            context("when container has no options") {
+                it("plugin is set to invisible") {
                     container = Container()
                     container.render()
 
@@ -21,8 +22,10 @@ class PosterPluginTests: QuickSpec {
 
                     expect(posterPlugin.isHidden).to(beTrue())
                 }
+            }
 
-                it("Should not be visible if container doesn't have posterUrl Option") {
+            context("when container doesnt have posterUrl option") {
+                it("plugin is set to invisible") {
                     container = Container(options: ["anotherOption": true])
                     container.render()
 
@@ -30,8 +33,10 @@ class PosterPluginTests: QuickSpec {
 
                     expect(posterPlugin.isHidden).to(beTrue())
                 }
+            }
 
-                it("Should be rendered if container have posterUrl Option") {
+            context("when container has posterUrl option") {
+                it("plugin is render") {
                     container = Container(options: options)
                     container.render()
 
@@ -59,17 +64,21 @@ class PosterPluginTests: QuickSpec {
                     posterPlugin = self.getPosterPlugin(container)
                 }
 
-                it("Should be hidden after container Play event ") {
-                    expect(posterPlugin.isHidden).to(beFalse())
-                    container.playback?.trigger(Event.playing.rawValue)
-                    expect(posterPlugin.isHidden).to(beTrue())
+                context("when container trigger a play event") {
+                    it("plugin is set to invisible") {
+                        expect(posterPlugin.isHidden).to(beFalse())
+                        container.playback?.trigger(Event.playing.rawValue)
+                        expect(posterPlugin.isHidden).to(beTrue())
+                    }
                 }
 
-                it("Should be not hidden after container Ended event") {
-                    container.playback?.trigger(Event.playing.rawValue)
-                    container.playback?.trigger(Event.didComplete.rawValue)
+                context("when container trigger a end event") {
+                    it("plugin is set to visible") {
+                        container.playback?.trigger(Event.playing.rawValue)
+                        container.playback?.trigger(Event.didComplete.rawValue)
 
-                    expect(posterPlugin.isHidden).to(beFalse())
+                        expect(posterPlugin.isHidden).to(beFalse())
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Goal
 - Remove trigger ready event on render of NoOpPlayback. 
 - Handle visibility of PosterPlugin by listening the didChangePlayback event.

## Summary
When the source of the video isn't a valid source(mp4, hls, etc...), the activePlayback is setted to NoOpPlayback.
When a ready event is trigger by the activePlayback, the PosterPlugin handles their own visibility.

## How to test
 1) Set ``kSourceUrl`` value to **"invalid"** on ``DashboardViewController.swift``
 2) Add a breakpoint on ``Event.ready`` at ``ViewController.swift``
 3) Ready event should'nt be triggered
 
