### PR TITLE
Send a ready event before the video starts to play

### DIFF
--- a/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -181,6 +181,7 @@ open class AVFoundationPlayback: Playback {
             playerLayer = AVPlayerLayer(player: player)
             self.layer.addSublayer(playerLayer!)
             addObservers()
+            trigger(.ready)
         } else {
             trigger(.error)
             Logger.logError("could not setup player", scope: pluginName)
@@ -332,8 +333,6 @@ open class AVFoundationPlayback: Playback {
     }
 
     fileprivate func readyToPlay() {
-        trigger(.ready)
-
         if let subtitles = self.subtitles {
             trigger(.didUpdateSubtitleSource, userInfo: ["subtitles": subtitles])
         }

--- a/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -173,6 +173,11 @@ open class AVFoundationPlayback: Playback {
         }
     }
 
+    open override func render() {
+        super.render()
+        trigger(.ready)
+    }
+
     fileprivate func setupPlayer() {
         if let asset = self.asset {
             let item: AVPlayerItem = AVPlayerItem(asset: asset)
@@ -181,7 +186,6 @@ open class AVFoundationPlayback: Playback {
             playerLayer = AVPlayerLayer(player: player)
             self.layer.addSublayer(playerLayer!)
             addObservers()
-            trigger(.ready)
         } else {
             trigger(.error)
             Logger.logError("could not setup player", scope: pluginName)


### PR DESCRIPTION
### Summary
Was reported that the player was sending a ready event twice. We notice that NoOpPlayback was triggering a ready event in render method, so we decided to no trigger anymore. 

### Goal
Was reported that the ready event is triggered after the willPlayAd. Following the desired architecture of player, the ready event must be triggered after the idle state.

### How to test
1. Run all unit/ui tests
2. On logs, Check out if the ready event was triggered before willPlayAd

