### PR TITLE
Fix/rollback ready event

### DIFF
--- a/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -181,6 +181,7 @@ open class AVFoundationPlayback: Playback {
             playerLayer = AVPlayerLayer(player: player)
             self.layer.addSublayer(playerLayer!)
             addObservers()
+            trigger(.ready)
         } else {
             trigger(.error)
             Logger.logError("could not setup player", scope: pluginName)
@@ -332,8 +333,6 @@ open class AVFoundationPlayback: Playback {
     }
 
     fileprivate func readyToPlay() {
-        trigger(.ready)
-
         if let subtitles = self.subtitles {
             trigger(.didUpdateSubtitleSource, userInfo: ["subtitles": subtitles])
         }

--- a/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -173,11 +173,6 @@ open class AVFoundationPlayback: Playback {
         }
     }
 
-    open override func render() {
-        super.render()
-        trigger(.ready)
-    }
-
     fileprivate func setupPlayer() {
         if let asset = self.asset {
             let item: AVPlayerItem = AVPlayerItem(asset: asset)
@@ -337,6 +332,8 @@ open class AVFoundationPlayback: Playback {
     }
 
     fileprivate func readyToPlay() {
+        trigger(.ready)
+
         if let subtitles = self.subtitles {
             trigger(.didUpdateSubtitleSource, userInfo: ["subtitles": subtitles])
         }


### PR DESCRIPTION
# Goal

Rollback changes related to ready event that was causing some issues.

# How to test

1. Run our app in the simulator from Xcode;
2. Check in the console if events coming in this sequence after play video: willplayAd > ready > willplay