### PR TITLE
Adjust fastlane for ios tvos release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,12 @@ fastlane/Preview.html
 fastlane/screenshots
 
 # scan temporary files
-fastlane/test_output
+fastlane/test_output_ios
+fastlane/test_output_tvos
 
 # xcov reports
-fastlane/xcov_report
+fastlane/xcov_report_ios
+fastlane/xcov_report_tvos
 
 # lint output
 fastlane/lint_output

--- a/Clappr.xcodeproj/xcshareddata/xcschemes/Clappr_tvOS.xcscheme
+++ b/Clappr.xcodeproj/xcshareddata/xcschemes/Clappr_tvOS.xcscheme
@@ -27,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,11 +27,11 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    scan(scheme: "Clappr_Example", output_directory: "fastlane/test_output_ios")
-    xcov(scheme: "Clappr_Example", output_directory: "fastlane/xcov_report_ios")
-
     scan(scheme: "Clappr_tvOS", output_directory: "fastlane/test_output_tvos")
     xcov(scheme: "Clappr_tvOS", output_directory: "fastlane/xcov_report_tvos")
+    
+    scan(scheme: "Clappr_Example", output_directory: "fastlane/test_output_ios")
+    xcov(scheme: "Clappr_Example", output_directory: "fastlane/xcov_report_ios")
   end
 
   desc "Bump version in Podspec and Info.plist"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,15 +20,18 @@ platform :ios do
     # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
     # cocoapods
     carthage(
-      platform: 'iOS',
+      platform: 'iOS,tvOS',
       cache_builds: true
     )
   end
 
   desc "Runs all the tests"
   lane :test do
-    scan(scheme: "Clappr-Example")
-    xcov(scheme: "Clappr-Example")
+    scan(scheme: "Clappr_Example", output_directory: "fastlane/test_output_ios")
+    xcov(scheme: "Clappr_Example", output_directory: "fastlane/xcov_report_ios")
+
+    scan(scheme: "Clappr_tvOS", output_directory: "fastlane/test_output_tvos")
+    xcov(scheme: "Clappr_tvOS", output_directory: "fastlane/xcov_report_tvos")
   end
 
   desc "Bump version in Podspec and Info.plist"
@@ -39,7 +42,7 @@ platform :ios do
     version_bump_podspec(path: "Clappr.podspec", version_number: version)
 
     update_info_plist(
-      plist_path: "Clappr/Info.plist",
+      plist_path: "Sources/Info.plist",
       block: lambda { |plist|
         plist["CFBundleShortVersionString"] = version
       }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,7 +54,7 @@ platform :ios do
   desc "Release a new version of Clappr"
   lane :release do |options|
     UI.user_error!("You need to provide the new version number like: make release version=X.X.X") if options[:version].to_s.strip.empty?
-    
+
     ensure_environment_vars
 
     pull_dev_and_master
@@ -157,6 +157,7 @@ end
 
 def merge(branch:, into:)
   checkout("#{into}")
+  Actions.sh("git pull origin #{into}")
   Actions.sh("git merge #{branch}")
   UI.success("Successfully merged \"#{branch}\" into \"#{into}\" 💾.")
 end
@@ -175,7 +176,9 @@ def ensure_environment_vars
 end
 
 def pull_dev_and_master
+  Actions.sh("git push origin dev:dev")
   Actions.sh("git fetch origin dev:dev --update-head-ok")
+  Actions.sh("git push origin master:master")
   Actions.sh("git fetch origin master:master --update-head-ok")
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,8 +36,6 @@ platform :ios do
 
   desc "Bump version in Podspec and Info.plist"
   lane :version_bump do |options|
-    UI.user_error!("You need to provide the new version number.") unless options[:version]
-
     version = options[:version]
     version_bump_podspec(path: "Clappr.podspec", version_number: version)
 
@@ -55,8 +53,10 @@ platform :ios do
 
   desc "Release a new version of Clappr"
   lane :release do |options|
-    ensure_environment_vars
+    UI.user_error!("You need to provide the new version number like: make release version=X.X.X") if options[:version].to_s.strip.empty?
     
+    ensure_environment_vars
+
     pull_dev_and_master
 
     ensure_git_status_clean


### PR DESCRIPTION
# Goal
Adjust fastlane script to works for iOS and tvOS.

## How to test
### Unit and UI tests
1. `make setup` and `make test`: makes sure that all the tests pass

### Release
**This is just an explanation of how the release will work. You should not try this unless you're really publishing a new Clappr version.**
    
If you want to test the script without publishing, you need to do the following

1. Fork and clone this repo your machine;
2. Comment the `pod_push` command in the script;
3. Run `make setup` and `make test`;
4. Run `pod lib lint` to check it the podspec is valid to publish;
5. Change the path to your forked repo in the script:
```
set_github_release(
      repository_name: "your_github_username_here/clappr-ios",
      api_token: ENV["GITHUB_TOKEN"],
      name: "",
      tag_name: options[:version],
      description: "TODO: write release notes here"
    )
```
6. In `dev` branch, run `make release version=5.0.0`;

Check if a new release is created in your forked repo.