### PR TITLE
Change the order of how Container and Core views are rendered

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -108,8 +108,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     open override func render() {
         addToContainer()
 
-        plugins.forEach(installPlugin)
         containers.forEach(renderContainer)
+        plugins.forEach(installPlugin)
 
         if let mediaControl = self.mediaControl {
             addSubviewMatchingConstraints(mediaControl)

--- a/Sources/Clappr_tvOS/Classes/Base/Core.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Core.swift
@@ -116,8 +116,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     open override func render() {
         addToContainer()
 
-        plugins.forEach(installPlugin)
         containers.forEach(renderContainer)
+        plugins.forEach(installPlugin)
 
         if let mediaControl = self.mediaControl {
             addSubviewMatchingConstraints(mediaControl)

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -390,6 +390,18 @@ class CoreTests: QuickSpec {
                     expect(core.hasPlugin(UICorePlugin.self)) == false
                 }
             }
+
+            context("core position") {
+                it("is positioned in front of Container view") {
+                    let loader = Loader(externalPlugins: [FakeCorePlugin.self])
+                    let core = Core(loader: loader, options: options as Options)
+
+                    core.render()
+
+                    expect(core.subviews.first).to(beAKindOf(Container.self))
+                    expect(core.subviews[1]).to(beAKindOf(FakeCorePlugin.self))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Goal

We have identified that the Container and Core views were not in the right order, as specified in [our documentation](https://github.com/clappr/clappr-docs/wiki/Architecture).

As you can see, the first layer should be Core and the Container is right behind it. In the current implementation, is the opposite.

# How to test

1. Make sure that all tests are passing;
2. Run Clappr and check if everything behaves correctly