### PR TITLE
Enable test coverage for Clappr schema

### DIFF
--- a/Clappr.xcodeproj/xcshareddata/xcschemes/Clappr.xcscheme
+++ b/Clappr.xcodeproj/xcshareddata/xcschemes/Clappr.xcscheme
@@ -27,7 +27,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
## Goal

Enable test coverage in xcode.

## How to test

Run tests in xcode and check coverage report.