### PR TITLE
BufferUpdate event should inform buffer duration properly

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -365,7 +365,7 @@ open class AVFoundationPlayback: Playback {
         let info = [
             "start_position": CMTimeGetSeconds(timeRange.start),
             "end_position": CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration)),
-            "duration": CMTimeGetSeconds(timeRange.start),
+            "duration": CMTimeGetSeconds(timeRange.duration),
             ]
 
         trigger(.bufferUpdate, userInfo: info)

--- a/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
@@ -408,7 +408,7 @@ open class AVFoundationPlayback: Playback, AVPlayerViewControllerDelegate {
         let info = [
             "start_position": CMTimeGetSeconds(timeRange.start),
             "end_position": CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration)),
-            "duration": CMTimeGetSeconds(timeRange.start),
+            "duration": CMTimeGetSeconds(timeRange.duration),
             ]
 
         trigger(.bufferUpdate, userInfo: info)


### PR DESCRIPTION
## Goal

BufferUpdate event was not informing buffer duration properly. We should send the information in the userInfo dictionary with `duration` key.