### PR TITLE
Add Fullscreen ViewController on Sample App

### DIFF
--- a/Example/Clappr/Base.lproj/Main.storyboard
+++ b/Example/Clappr/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="X5F-KS-Cdq">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="X5F-KS-Cdq">
+    <device id="retina3_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,7 +15,7 @@
             <objects>
                 <navigationController id="X5F-KS-Cdq" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="lV7-k1-Jii">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -34,17 +35,17 @@
                         <viewControllerLayoutGuide type="bottom" id="2pD-ht-Ixh"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="KNV-CV-WeC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fullscreen controlled by app" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D5g-dh-ZqY">
-                                <rect key="frame" x="16" y="104" width="286" height="16"/>
+                                <rect key="frame" x="16" y="104" width="231" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tY3-dQ-IX8">
-                                <rect key="frame" x="40" y="503" width="295" height="44"/>
+                                <rect key="frame" x="40" y="316" width="240" height="44"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                 <accessibility key="accessibilityConfiguration" identifier="StartVideo"/>
                                 <constraints>
@@ -58,17 +59,17 @@
                                 </connections>
                             </button>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jcb-bi-KKQ">
-                                <rect key="frame" x="310" y="97" width="51" height="31"/>
+                                <rect key="frame" x="255" y="97" width="51" height="31"/>
                                 <accessibility key="accessibilityConfiguration" identifier="FullscreenControledByApp"/>
                             </switch>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Start player as fullscreen" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LOy-Tl-w1v">
-                                <rect key="frame" x="16" y="160" width="286" height="16"/>
+                                <rect key="frame" x="16" y="160" width="231" height="16"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yI1-Wk-Mdf">
-                                <rect key="frame" x="310" y="153" width="51" height="31"/>
+                                <rect key="frame" x="255" y="153" width="51" height="31"/>
                                 <accessibility key="accessibilityConfiguration" identifier="StartAsFullscreen"/>
                             </switch>
                         </subviews>
@@ -109,14 +110,15 @@
                         <viewControllerLayoutGuide type="bottom" id="2fi-mo-0CV"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="kh9-bI-dsS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5zE-hA-IRs" userLabel="Player Container">
-                                <rect key="frame" x="-4" y="84" width="383" height="333"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="288"/>
                                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="30R-xP-Ym2"/>
+                                    <constraint firstAttribute="height" constant="288" id="Gsm-7W-Dup"/>
                                 </constraints>
                                 <variation key="default">
                                     <mask key="constraints">
@@ -127,10 +129,9 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="5zE-hA-IRs" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="20" id="2V5-15-1vR"/>
-                            <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="5zE-hA-IRs" secondAttribute="bottom" constant="250" id="ULG-ic-dbv"/>
-                            <constraint firstItem="5zE-hA-IRs" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" constant="-20" id="gHG-UN-LaX"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="5zE-hA-IRs" secondAttribute="trailing" constant="-20" id="t57-9V-Zkj"/>
+                            <constraint firstItem="5zE-hA-IRs" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="19J-W3-snx"/>
+                            <constraint firstAttribute="trailing" secondItem="5zE-hA-IRs" secondAttribute="trailing" id="1IQ-ll-rwC"/>
+                            <constraint firstItem="5zE-hA-IRs" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" id="2V5-15-1vR"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Tests/Clappr_UITests/FullscreenUITests.swift
+++ b/Tests/Clappr_UITests/FullscreenUITests.swift
@@ -13,7 +13,7 @@ class FullscreenUITests: QuickSpec {
             return app.windows.element(boundBy: 0)
         }
 
-        describe("Fullscreen") {
+        describe(".Fullscreen") {
 
             beforeEach {
                 app = XCUIApplication()
@@ -28,68 +28,63 @@ class FullscreenUITests: QuickSpec {
                 app.terminate()
             }
 
-            context("setFullscreen") {
-                it("player should set to fullscreen when setFullscreen is called") {
-                    dashboardInteractor.startAsFullscreen = false
-                    dashboardInteractor.fullscreenControledByApp = false
-
-                    dashboardInteractor.startVideo()
-                    playerInteractor.tapOnContainer()
-                    XCUIDevice.shared.orientation = .landscapeLeft
-
-                    expect(playerInteractor.containerFrame == window.frame).to(beTrue())
-                }
-            }
-
-            context("start as fullscreen") {
+            context("when the option of start as fullscreen is passed") {
 
                 beforeEach {
                     dashboardInteractor.startAsFullscreen = true
                 }
 
-                it("player should have the same size of window") {
-                    dashboardInteractor.fullscreenControledByApp = false
+                context("when fullscreen is controled by the player") {
+                    it("sets the player as fullscreen") {
+                        dashboardInteractor.fullscreenControledByApp = false
 
-                    dashboardInteractor.startVideo()
+                        dashboardInteractor.startVideo()
 
-                    expect(playerInteractor.containerFrame == window.frame).to(beTrue())
+                        expect(playerInteractor.containerFrame == window.frame).to(beTrue())
+                    }
                 }
 
-                it("player should not have the same size of window ") {
-                    dashboardInteractor.fullscreenControledByApp = true
+                context("when fullscreen is controled by the app") {
+                    it("doesn't sets fullscreen mode on player") {
+                        dashboardInteractor.fullscreenControledByApp = true
 
-                    dashboardInteractor.startVideo()
+                        dashboardInteractor.startVideo()
 
-                    expect(playerInteractor.containerFrame != window.frame).to(beTrue())
+                        expect(playerInteractor.containerFrame != window.frame).to(beTrue())
+                    }
                 }
             }
 
-            context("fullscreen controled by app") {
+            context("when the option of fullscreen controled by app is passed") {
 
                 beforeEach {
                     playerInteractor = PlayerViewInteractor(app: app)
                 }
 
-                it("player should not change the container size when taps on fullscreen button") {
-                    dashboardInteractor.startAsFullscreen = false
+                context("and user taps on fullscreen button") {
 
-                    dashboardInteractor.startVideo()
-                    let currentFrame = playerInteractor.containerFrame
-                    playerInteractor.tapOnContainer()
-                    playerInteractor.tapOnFullscreen()
-                    
-                    expect(currentFrame == playerInteractor.containerFrame).to(beTrue())
+                    it("sets the player as fullscreen") {
+                        dashboardInteractor.fullscreenControledByApp = true
+
+                        dashboardInteractor.startVideo()
+                        playerInteractor.tapOnContainer()
+                        playerInteractor.tapOnFullscreen()
+
+                        expect(playerInteractor.containerFrame == window.frame).to(beTrue())
+                    }
                 }
 
-                it("player should not change the container size when taps on fullscreen button") {
-                    dashboardInteractor.startAsFullscreen = true
+                context("and user taps on fullscreen button after a previous tap") {
+                    it("sets the player as embed mode") {
+                        dashboardInteractor.fullscreenControledByApp = true
 
-                    dashboardInteractor.startVideo()
-                    let currentFrame = playerInteractor.containerFrame
-                    playerInteractor.tapOnContainer()
-                    playerInteractor.tapOnFullscreen()
+                        dashboardInteractor.startVideo()
+                        playerInteractor.tapOnContainer()
+                        playerInteractor.tapOnFullscreen()
+                        playerInteractor.tapOnFullscreen()
 
-                    expect(currentFrame == playerInteractor.containerFrame).to(beTrue())
+                        expect(playerInteractor.containerFrame != window.frame).to(beTrue())
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Goal
Remove rotation logic of portrait/landscape of Clappr Example in order to simplify the sample app.
Add a ViewController in the sample app to be used when kFullscreenByApp option is enabled.

## How to test
1. Open the sample app.
2. Enable fullscreen controlled by the app.
3. Check if the player enters in the fullscreen mode when the fullscreen button is tapped.
4. Taps again and check if it goes to embed mode.