### PR TITLE
Create willSeek and didSeek events

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,3 @@
 github "Quick/Quick" == 1.2.0
-github "Quick/Nimble" == 7.0.2
+github "Quick/Nimble" == 7.0.3
+github "AliSoftware/OHHTTPStubs" == 6.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
-github "Quick/Nimble" "v7.0.2"
+github "AliSoftware/OHHTTPStubs" "6.1.0"
+github "Quick/Nimble" "v7.0.3"
 github "Quick/Quick" "v1.2.0"
 github "onevcat/Kingfisher" "3.13.1"

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		321781B21FED97D100EDD678 /* Clappr.h in Headers */ = {isa = PBXBuildFile; fileRef = 96D362881D41339400CCB866 /* Clappr.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3283BF042024D52F00F2B826 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3283BF032024D52F00F2B826 /* OHHTTPStubs.framework */; };
+		3283BF062024D8B100F2B826 /* video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 57351C6720248D78007DEBBE /* video.mp4 */; };
 		32B2F68C1FF6E23700820147 /* MediaOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362931D41339400CCB866 /* MediaOption.swift */; };
 		32B3D23D2007FA7D00D81C0A /* ClapprDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6418DD2007DB9100E81B7C /* ClapprDateFormatter.swift */; };
 		32DA34191FFBCFC400484C90 /* Container.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D3628D1D41339400CCB866 /* Container.swift */; };
@@ -228,6 +230,7 @@
 
 /* Begin PBXFileReference section */
 		321781A81FED90CC00EDD678 /* Clappr.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Clappr.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3283BF032024D52F00F2B826 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/tvOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		32E4020A1FF43262001C2096 /* Clappr_tvOS_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Clappr_tvOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		32E4020E1FF43262001C2096 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		32E402161FF433FA001C2096 /* EventDispatcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDispatcherTests.swift; sourceTree = "<group>"; };
@@ -364,6 +367,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				32E4021E1FF43534001C2096 /* Quick.framework in Frameworks */,
+				3283BF042024D52F00F2B826 /* OHHTTPStubs.framework in Frameworks */,
 				32E4021F1FF43534001C2096 /* Nimble.framework in Frameworks */,
 				32E4020F1FF43263001C2096 /* Clappr.framework in Frameworks */,
 			);
@@ -817,6 +821,7 @@
 			isa = PBXGroup;
 			children = (
 				57351C6920248F08007DEBBE /* OHHTTPStubs.framework */,
+				3283BF032024D52F00F2B826 /* OHHTTPStubs.framework */,
 				32E4021D1FF43534001C2096 /* Nimble.framework */,
 				B46D05A71DB7DBD60004B23F /* Quick.framework */,
 				B46D05A51DB7DBC50004B23F /* Nimble.framework */,
@@ -1155,6 +1160,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3283BF062024D8B100F2B826 /* video.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1226,6 +1232,7 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/tvOS/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/tvOS/Nimble.framework",
+				"$(SRCROOT)/Carthage/Build/tvOS/OHHTTPStubs.framework",
 			);
 			outputPaths = (
 			);

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		32E4021A1FF433FB001C2096 /* BaseObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E402171FF433FA001C2096 /* BaseObjectTests.swift */; };
 		32E4021E1FF43534001C2096 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32E4021C1FF43533001C2096 /* Quick.framework */; };
 		32E4021F1FF43534001C2096 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32E4021D1FF43534001C2096 /* Nimble.framework */; };
+		57351C6820248D78007DEBBE /* video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 57351C6720248D78007DEBBE /* video.mp4 */; };
+		57351C6A20248F08007DEBBE /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57351C6920248F08007DEBBE /* OHHTTPStubs.framework */; };
 		57937C571FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */; };
 		57937C5A1FB0DD2C000A239E /* AVURLAssetWithCookiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */; };
 		57B0A1DF1FF40C3600891037 /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B0A1DE1FF40C3600891037 /* UIObject.swift */; };
@@ -232,6 +234,8 @@
 		32E402171FF433FA001C2096 /* BaseObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObjectTests.swift; sourceTree = "<group>"; };
 		32E4021C1FF43533001C2096 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
 		32E4021D1FF43534001C2096 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
+		57351C6720248D78007DEBBE /* video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = video.mp4; sourceTree = "<group>"; };
+		57351C6920248F08007DEBBE /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesBuilder.swift; sourceTree = "<group>"; };
 		57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesTests.swift; sourceTree = "<group>"; };
 		57B0A1DE1FF40C3600891037 /* UIObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIObject.swift; sourceTree = "<group>"; };
@@ -380,6 +384,7 @@
 			files = (
 				B46D05AB1DB7DE570004B23F /* Nimble.framework in Frameworks */,
 				B46D05AA1DB7DE4B0004B23F /* Quick.framework in Frameworks */,
+				57351C6A20248F08007DEBBE /* OHHTTPStubs.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -434,6 +439,7 @@
 		323DF27A1FF4399600ECA3F3 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				57351C6620248D66007DEBBE /* Stub */,
 				607FACE81AFB9204008FA782 /* Clappr_Tests */,
 				9E692E001F9F898F006510BE /* Clappr_UITests */,
 				32E4020B1FF43262001C2096 /* Clappr_tvOS_Tests */,
@@ -452,6 +458,14 @@
 				32E4020E1FF43262001C2096 /* Info.plist */,
 			);
 			path = Clappr_tvOS_Tests;
+			sourceTree = "<group>";
+		};
+		57351C6620248D66007DEBBE /* Stub */ = {
+			isa = PBXGroup;
+			children = (
+				57351C6720248D78007DEBBE /* video.mp4 */,
+			);
+			path = Stub;
 			sourceTree = "<group>";
 		};
 		607FACC71AFB9204008FA782 = {
@@ -802,6 +816,7 @@
 		D9A0DBC9D3DEA84C86432E68 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				57351C6920248F08007DEBBE /* OHHTTPStubs.framework */,
 				32E4021D1FF43534001C2096 /* Nimble.framework */,
 				B46D05A71DB7DBD60004B23F /* Quick.framework */,
 				B46D05A51DB7DBC50004B23F /* Nimble.framework */,
@@ -1157,6 +1172,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				57351C6820248D78007DEBBE /* video.mp4 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1240,6 +1256,7 @@
 			inputPaths = (
 				"$(SRCROOT)/Carthage/Build/iOS/Quick.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/OHHTTPStubs.framework",
 			);
 			outputPaths = (
 			);

--- a/Example/Clappr/ViewController.swift
+++ b/Example/Clappr/ViewController.swift
@@ -64,6 +64,12 @@ class ViewController: UIViewController {
 
         player.on(Event.stalled) { _ in print("on Stalled") }
 
+        player.on(Event.willSeek) { _ in print("on willSeek") }
+
+        player.on(Event.seek) { _ in print("on seek") }
+
+        player.on(Event.didSeek) { _ in print("on didSeek") }
+
         player.on(Event.requestFullscreen) { _ in
             Logger.logInfo("Entrar em modo fullscreen")
             if self.fullscreenByApp {

--- a/Example/Clappr_tvOS/ViewController.swift
+++ b/Example/Clappr_tvOS/ViewController.swift
@@ -40,6 +40,11 @@ class ViewController: UIViewController {
 
         player.on(Event.stalled) { _ in print("on Stalled") }
 
+        player.on(Event.willSeek) { _ in print("on willSeek") }
+
+        player.on(Event.seek) { _ in print("on seek") }
+
+        player.on(Event.didSeek) { _ in print("on didSeek") }
     }
 
     #if !os(tvOS)

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -24,5 +24,6 @@ public enum Event: String {
     case willUpdatePoster
     case didUpdatePoster
     case seek
+    case willSeek
     case didSeek
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -24,4 +24,5 @@ public enum Event: String {
     case willUpdatePoster
     case didUpdatePoster
     case seek
+    case didSeek
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -79,7 +79,8 @@ open class Player: BaseObject {
              Event.requestFullscreen.rawValue, Event.exitFullscreen.rawValue,
              Event.positionUpdate.rawValue, Event.willPlay.rawValue,
              Event.willPause.rawValue, Event.willStop.rawValue,
-             Event.airPlayStatusUpdate.rawValue, Event.seek.rawValue])
+             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
+             Event.seek.rawValue, Event.didSeek.rawValue])
 
         let loader = Loader(externalPlugins: externalPlugins, options: options)
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -239,9 +239,12 @@ open class AVFoundationPlayback: Playback {
         let time = CMTimeMakeWithSeconds(timeInterval, Int32(NSEC_PER_SEC))
 
         trigger(.seek)
+        trigger(.willSeek)
 
         player?.currentItem?.seek(to: time) { [weak self] success in
-            self?.trigger(.didSeek, userInfo: ["success": success])
+            if success {
+                self?.trigger(.didSeek)
+            }
         }
 
         trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -238,8 +238,12 @@ open class AVFoundationPlayback: Playback {
     open override func seek(_ timeInterval: TimeInterval) {
         let time = CMTimeMakeWithSeconds(timeInterval, Int32(NSEC_PER_SEC))
 
-        player?.currentItem?.seek(to: time)
         trigger(.seek)
+
+        player?.currentItem?.seek(to: time) { [weak self] success in
+            self?.trigger(.didSeek, userInfo: ["success": success])
+        }
+
         trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -365,7 +365,7 @@ open class AVFoundationPlayback: Playback {
         let info = [
             "start_position": CMTimeGetSeconds(timeRange.start),
             "end_position": CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration)),
-            "duration": CMTimeGetSeconds(timeRange.start),
+            "duration": CMTimeGetSeconds(timeRange.duration),
             ]
 
         trigger(.bufferUpdate, userInfo: info)

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -113,7 +113,8 @@ open class Player: UIViewController, BaseObject {
              Event.didStop.rawValue, Event.bufferUpdate.rawValue,
              Event.positionUpdate.rawValue, Event.willPlay.rawValue,
              Event.willPause.rawValue, Event.willStop.rawValue,
-             Event.airPlayStatusUpdate.rawValue, Event.seek.rawValue])
+             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
+             Event.seek.rawValue,Event.didSeek.rawValue])
 
         let loader = Loader(externalPlugins: externalPlugins, options: options)
 

--- a/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
@@ -265,8 +265,12 @@ open class AVFoundationPlayback: Playback, AVPlayerViewControllerDelegate {
     open override func seek(_ timeInterval: TimeInterval) {
         let time = CMTimeMakeWithSeconds(timeInterval, Int32(NSEC_PER_SEC))
 
-        player?.currentItem?.seek(to: time)
         trigger(.seek)
+
+        player?.currentItem?.seek(to: time) { success in
+            trigger(.didSeek, userInfo: ["success": success])
+        }
+
         trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
     }
 

--- a/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
@@ -266,16 +266,25 @@ open class AVFoundationPlayback: Playback, AVPlayerViewControllerDelegate {
         let time = CMTimeMakeWithSeconds(timeInterval, Int32(NSEC_PER_SEC))
 
         trigger(.seek)
+        trigger(.willSeek)
 
-        player?.currentItem?.seek(to: time) { success in
-            trigger(.didSeek, userInfo: ["success": success])
+        player?.currentItem?.seek(to: time) { [weak self] success in
+            if success {
+                self?.trigger(.didSeek)
+            }
         }
 
         trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
     }
 
+    public func playerViewController(_ playerViewController: AVPlayerViewController, timeToSeekAfterUserNavigatedFrom oldTime: CMTime, to targetTime: CMTime) -> CMTime {
+        trigger(.willSeek)
+        return targetTime
+    }
+
     public func playerViewController(_ playerViewController: AVPlayerViewController, willResumePlaybackAfterUserNavigatedFrom oldTime: CMTime, to targetTime: CMTime) {
         trigger(.seek)
+        trigger(.didSeek)
     }
 
     open override func mute(_ enabled: Bool) {

--- a/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_tvOS/Classes/Plugin/Playback/AVFoundationPlayback/AVFoundationPlayback.swift
@@ -408,7 +408,7 @@ open class AVFoundationPlayback: Playback, AVPlayerViewControllerDelegate {
         let info = [
             "start_position": CMTimeGetSeconds(timeRange.start),
             "end_position": CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration)),
-            "duration": CMTimeGetSeconds(timeRange.start),
+            "duration": CMTimeGetSeconds(timeRange.duration),
             ]
 
         trigger(.bufferUpdate, userInfo: info)

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1,5 +1,7 @@
 import Quick
 import Nimble
+import OHHTTPStubs
+
 @testable import Clappr
 
 class AVFoundationPlaybackTests: QuickSpec {
@@ -36,6 +38,59 @@ class AVFoundationPlaybackTests: QuickSpec {
                     let options = [kSourceUrl: "http://clappr.io/highline.zip"]
                     let canPlay = AVFoundationPlayback.canPlay(options as Options)
                     expect(canPlay) == false
+                }
+            }
+
+            describe("#seek") {
+
+                var avFoundationPlayback: AVFoundationPlayback!
+
+                beforeEach {
+                    stub(condition: isHost("clappr.io")) { _ in
+                        let stubPath = OHPathForFile("video.mp4", type(of: self))
+                        return fixture(filePath: stubPath!, headers: ["Content-Type":"video/mp4"])
+                    }
+                    avFoundationPlayback = AVFoundationPlayback(options: [kSourceUrl: "https://clappr.io/highline.mp4"])
+
+                    avFoundationPlayback.play()
+                }
+
+                it("triggers seek event") {
+                    waitUntil { done in
+                        let listener = BaseObject()
+
+                        listener.listenTo(avFoundationPlayback, eventName: Event.seek.rawValue) { info in
+                            done()
+                        }
+
+                        avFoundationPlayback.seek(5)
+                    }
+                }
+
+                it("triggers didSeek when a seek is completed") {
+                    waitUntil { done in
+                        let listener = BaseObject()
+
+                        listener.listenTo(avFoundationPlayback, eventName: Event.didSeek.rawValue) { info in
+                            expect(info!["success"] as? Bool).to(beTrue())
+                            done()
+                        }
+
+                        avFoundationPlayback.seek(5)
+                    }
+                }
+
+                it("triggers positionUpdate for the desired position") {
+                    waitUntil { done in
+                        let listener = BaseObject()
+
+                        listener.listenTo(avFoundationPlayback, eventName: Event.positionUpdate.rawValue) { info in
+                            expect(info!["position"] as? Float64).to(equal(5))
+                            done()
+                        }
+
+                        avFoundationPlayback.seek(5)
+                    }
                 }
             }
         }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -55,6 +55,18 @@ class AVFoundationPlaybackTests: QuickSpec {
                     avFoundationPlayback.play()
                 }
 
+                it("triggers willSeek event") {
+                    waitUntil { done in
+                        let listener = BaseObject()
+
+                        listener.listenTo(avFoundationPlayback, eventName: Event.willSeek.rawValue) { info in
+                            done()
+                        }
+
+                        avFoundationPlayback.seek(5)
+                    }
+                }
+
                 it("triggers seek event") {
                     waitUntil { done in
                         let listener = BaseObject()
@@ -72,7 +84,6 @@ class AVFoundationPlaybackTests: QuickSpec {
                         let listener = BaseObject()
 
                         listener.listenTo(avFoundationPlayback, eventName: Event.didSeek.rawValue) { info in
-                            expect(info!["success"] as? Bool).to(beTrue())
                             done()
                         }
 


### PR DESCRIPTION
## Goal
To create two new events:
- willSeek: triggered when user wants to play another part of the video;
- didSeek: triggered when playback will start another part of the video;

**seek event will be deprecated**

## How to test
In iOS and tvOS: 
1. Open any vod;
2. Move scrubber to any point of the video;
3. Check the output if willSeek and didSeek events were triggered;

## TO DO
After merge, update clappr wiki with the new events.