### PR TITLE
Retrieve all stored cookies

### DIFF
--- a/Sources/Clappr_iOS/Classes/Extension/AVURLAssetWithCookiesBuilder.swift
+++ b/Sources/Clappr_iOS/Classes/Extension/AVURLAssetWithCookiesBuilder.swift
@@ -34,9 +34,7 @@ struct AVURLAssetWithCookiesBuilder: AVURLAssetWithCookies {
     }
 
     private func getCookies() -> [HTTPCookie]? {
-        if let host = self.url.host, let cookieUrl = URL(string: "http://\(host)") {
-            return HTTPCookieStorage.shared.cookies(for: cookieUrl)
-        }
-        return nil
+        let url = self.url.absoluteString
+        return HTTPCookieStorage.shared.cookies?.filter { url.range(of:$0.domain) != nil }
     }
 }

--- a/Sources/Clappr_iOS/Classes/Extension/AVURLAssetWithCookiesBuilder.swift
+++ b/Sources/Clappr_iOS/Classes/Extension/AVURLAssetWithCookiesBuilder.swift
@@ -34,7 +34,6 @@ struct AVURLAssetWithCookiesBuilder: AVURLAssetWithCookies {
     }
 
     private func getCookies() -> [HTTPCookie]? {
-        let url = self.url.absoluteString
-        return HTTPCookieStorage.shared.cookies?.filter { url.range(of:$0.domain) != nil }
+        return HTTPCookieStorage.shared.cookies?.filter { self.url.host == $0.domain }
     }
 }

--- a/Tests/Clappr_Tests/AVURLAssetWithCookiesTests.swift
+++ b/Tests/Clappr_Tests/AVURLAssetWithCookiesTests.swift
@@ -30,6 +30,19 @@ class AVURLAssetWithCookiesTests: QuickSpec {
                 expect(avUrlAssetWithCookies.options[AVURLAssetHTTPCookiesKey]).toNot(beNil())
             }
 
+            it("retrieve cookies with different paths") {
+                let anotherCookie = HTTPCookie(properties: [HTTPCookiePropertyKey.domain: "clappr.io",
+                                                            HTTPCookiePropertyKey.path: "/another/path",
+                                                            HTTPCookiePropertyKey.name: "testing",
+                                                            HTTPCookiePropertyKey.value: "still works"])!
+                HTTPCookieStorage.shared.setCookie(anotherCookie)
+
+                let avUrlAssetWithCookies = AVURLAssetWithCookiesBuilder(url: URL(string: "http://clappr.io/highline.mp4")!)
+
+                expect(avUrlAssetWithCookies.cookies?.count).to(equal(2))
+                expect(avUrlAssetWithCookies.options[AVURLAssetHTTPCookiesKey]).toNot(beNil())
+            }
+
             it("doesn't sets cookies that aren't associated with the media url") {
                 let anotherCookie = HTTPCookie(properties: [HTTPCookiePropertyKey.domain: "anotherdomain.io",
                                                  HTTPCookiePropertyKey.path: "/",


### PR DESCRIPTION
#### Problem
When we get cookies with different paths, we are not able to retrieve them all from HTTPCookieStorage

#### Goal
Change the way we fetch it