### PR TITLE
Fix start At for iOS < 11

### DIFF
--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -1,4 +1,5 @@
 public enum InternalEvent: String {
+    case readyToPlay
     case willChangePlayback
     case didChangePlayback
     case willChangeActiveContainer

--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -85,7 +85,7 @@ open class Playback: UIBaseObject, Plugin {
     }
 
     open override func render() {
-        once(Event.ready.rawValue) { [unowned self] _ in
+        once(InternalEvent.readyToPlay.rawValue) { [unowned self] _ in
             if self.startAt != 0.0 {
                 self.seek(self.startAt)
             }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -340,6 +340,8 @@ open class AVFoundationPlayback: Playback {
     }
 
     fileprivate func readyToPlay() {
+        trigger(InternalEvent.readyToPlay.rawValue)
+
         if let subtitles = self.subtitles {
             trigger(.didUpdateSubtitleSource, userInfo: ["subtitles": subtitles])
         }


### PR DESCRIPTION
## Goal
Fix startAt when the player is ready. 

## How to test
1. Run all unit tests.
2. Try to use startAt in iOS 10.3 and iOS 11.