### PR TITLE
fix: hold AirPlay Button instance in MediaControl

### DIFF
--- a/Sources/Clappr_iOS/Classes/Base/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Base/MediaControl.swift
@@ -28,7 +28,7 @@ open class MediaControl: UIBaseObject {
     @IBOutlet open var playbackControlButton: UIButton?
     @IBOutlet open var fullscreenButton: UIButton?
 
-    @IBOutlet open weak var airPlayVolumeView: MPVolumeView?
+    @IBOutlet open var airPlayVolumeView: MPVolumeView?
 
     internal(set) open weak var container: Container?
     internal(set) open var controlsHidden = false


### PR DESCRIPTION
# Goal 

Hold AirPlay Button instance in MediaControl

![clappr](https://user-images.githubusercontent.com/610797/37171433-a56adcd8-22ec-11e8-9ed1-21f0dac4591f.png)

# More Info

Marking the AirPlay Button Outlet as `weak` was making the MediaControl to loose the button's reference when used in iOS 11.3 beta 4 (Xcode 9.3 beta 4)

# How to test

- Build Clappr_Example and test the AirPlay feature 
- Is desirable that you run this test in both:
(1) Xcode 9.3 Beta 4 - iOS 11.3 beta 4
(2) Xcode 9.2 - iOS 11.2
