### PR TITLE
Fix seek 

### DIFF
--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -1,5 +1,4 @@
 public enum InternalEvent: String {
-    case readyToPlay
     case willChangePlayback
     case didChangePlayback
     case willChangeActiveContainer

--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -85,7 +85,7 @@ open class Playback: UIBaseObject, Plugin {
     }
 
     open override func render() {
-        once(InternalEvent.readyToPlay.rawValue) { [unowned self] _ in
+        once(Event.ready.rawValue) { [unowned self] _ in
             if self.startAt != 0.0 {
                 self.seek(self.startAt)
             }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -8,7 +8,7 @@ import AVFoundation
 class AVFoundationPlaybackTests: QuickSpec {
 
     override func spec() {
-        fdescribe("AVFoundationPlayback Tests") {
+        describe("AVFoundationPlayback Tests") {
 
             context("canPlay") {
                 it("Should return true for valid url with mp4 path extension") {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1,6 +1,7 @@
 import Quick
 import Nimble
 import OHHTTPStubs
+import AVFoundation
 
 @testable import Clappr
 
@@ -41,6 +42,46 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
             }
 
+            describe("#isReadyToSeek") {
+                context("when AVPlayer status is readyToPlay") {
+                    it("returns true") {
+                        let playback = AVFoundationPlayback()
+                        let playerStub = AVPlayerStub()
+                        playback.player = playerStub
+
+                        playerStub.setStatus(to: .readyToPlay)
+
+                        expect(playback.isReadyToSeek).to(beTrue())
+                    }
+                }
+
+                context("when AVPlayer status is unknown") {
+
+                    it("returns false") {
+                        let playback = AVFoundationPlayback()
+                        let playerStub = AVPlayerStub()
+                        playback.player = playerStub
+
+                        playerStub.setStatus(to: .unknown)
+
+                        expect(playback.isReadyToSeek).to(beFalse())
+                    }
+                }
+
+                context("when AVPlayer status is failed") {
+
+                    it("returns false") {
+                        let playback = AVFoundationPlayback()
+                        let playerStub = AVPlayerStub()
+                        playback.player = playerStub
+
+                        playerStub.setStatus(to: .failed)
+
+                        expect(playback.isReadyToSeek).to(beFalse())
+                    }
+                }
+            }
+
             describe("#seek") {
 
                 var avFoundationPlayback: AVFoundationPlayback!
@@ -53,6 +94,83 @@ class AVFoundationPlaybackTests: QuickSpec {
                     avFoundationPlayback = AVFoundationPlayback(options: [kSourceUrl: "https://clappr.io/highline.mp4"])
 
                     avFoundationPlayback.play()
+                }
+
+                context("when AVPlayer status is readyToPlay") {
+
+                    it("doesn't store the desired seek time") {
+                        let playback = AVFoundationPlayback()
+                        playback.player = AVPlayerStub()
+
+                        playback.seek(20)
+
+                        expect(playback.seekToTimeWhenReadyToPlay).to(beNil())
+                    }
+
+                    it("calls seek right away") {
+                        let playback = AVFoundationPlayback()
+                        let player = AVPlayerStub()
+                        playback.player = player
+
+                        playback.seek(20)
+
+                        expect(player._item.didCallSeekWithCompletionHandler).to(beTrue())
+                    }
+                }
+
+                context("when AVPlayer status is not readyToPlay") {
+
+                    it("stores the desired seek time") {
+                        let playback = AVFoundationPlayback()
+
+                        playback.seek(20)
+
+                        expect(playback.seekToTimeWhenReadyToPlay).to(equal(20))
+                    }
+
+                    it("doesn't calls seek right away") {
+                        let playback = AVFoundationPlayback()
+                        let player = AVPlayerStub()
+                        playback.player = player
+
+                        player.setStatus(to: .unknown)
+                        playback.seek(20)
+
+                        expect(player._item.didCallSeekWithCompletionHandler).to(beFalse())
+                    }
+                }
+
+                describe("#seekIfNeeded") {
+
+                    context("when seekToTimeWhenReadyToPlay is nil") {
+                        it("doesnt perform a seek") {
+                            let playback = AVFoundationPlayback()
+                            let player = AVPlayerStub()
+                            playback.player = player
+                            player.setStatus(to: .readyToPlay)
+
+                            playback.seekOnReadyIfNeeded()
+
+                            expect(player._item.didCallSeekWithCompletionHandler).to(beFalse())
+                            expect(playback.seekToTimeWhenReadyToPlay).to(beNil())
+                        }
+                    }
+
+                    context("when seekToTimeWhenReadyToPlay is not nil") {
+                        it("does perform a seek") {
+                            let playback = AVFoundationPlayback()
+                            let player = AVPlayerStub()
+                            playback.player = player
+                            player.setStatus(to: .unknown)
+
+                            playback.seek(20)
+                            player.setStatus(to: .readyToPlay)
+                            playback.seekOnReadyIfNeeded()
+
+                            expect(player._item.didCallSeekWithCompletionHandler).to(beTrue())
+                            expect(playback.seekToTimeWhenReadyToPlay).to(beNil())
+                        }
+                    }
                 }
 
                 it("triggers willSeek event") {
@@ -105,5 +223,34 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
             }
         }
+
+        class AVPlayerStub: AVPlayer {
+
+            override var currentItem: AVPlayerItem? {
+                return _item
+            }
+
+            var _item = AVPlayerItemMock(url: URL(string: "https://clappr.io/highline.mp4")!)
+
+            func setStatus(to newStatus: AVPlayerItemStatus) {
+                _item._status = newStatus
+            }
+        }
+
+        class AVPlayerItemMock: AVPlayerItem {
+
+            override var status: AVPlayerItemStatus {
+                return _status
+            }
+
+            var didCallSeekWithCompletionHandler = false
+
+            var _status: AVPlayerItemStatus = AVPlayerItemStatus.unknown
+
+            override func seek(to time: CMTime, completionHandler: @escaping (Bool) -> Void) {
+                didCallSeekWithCompletionHandler = true
+            }
+        }
+
     }
 }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -8,7 +8,7 @@ import AVFoundation
 class AVFoundationPlaybackTests: QuickSpec {
 
     override func spec() {
-        describe("AVFoundationPlayback Tests") {
+        fdescribe("AVFoundationPlayback Tests") {
 
             context("canPlay") {
                 it("Should return true for valid url with mp4 path extension") {
@@ -87,12 +87,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 var avFoundationPlayback: AVFoundationPlayback!
 
                 beforeEach {
-                    stub(condition: isHost("clappr.io")) { _ in
-                        let stubPath = OHPathForFile("video.mp4", type(of: self))
-                        return fixture(filePath: stubPath!, headers: ["Content-Type":"video/mp4"])
-                    }
-                    avFoundationPlayback = AVFoundationPlayback(options: [kSourceUrl: "https://clappr.io/highline.mp4"])
-
+                    avFoundationPlayback = AVFoundationPlayback(options: [kSourceUrl: "http://clappr.io/highline.mp4"])
                     avFoundationPlayback.play()
                 }
 
@@ -100,7 +95,9 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     it("doesn't store the desired seek time") {
                         let playback = AVFoundationPlayback()
-                        playback.player = AVPlayerStub()
+                        let player = AVPlayerStub()
+                        player.setStatus(to: .readyToPlay)
+                        playback.player = player
 
                         playback.seek(20)
 
@@ -110,6 +107,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     it("calls seek right away") {
                         let playback = AVFoundationPlayback()
                         let player = AVPlayerStub()
+                        player.setStatus(to: .readyToPlay)
                         playback.player = player
 
                         playback.seek(20)
@@ -174,7 +172,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 it("triggers willSeek event") {
-                    waitUntil { done in
+                    waitUntil(timeout: 3) { done in
                         let listener = BaseObject()
 
                         listener.listenTo(avFoundationPlayback, eventName: Event.willSeek.rawValue) { info in
@@ -186,7 +184,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 it("triggers seek event") {
-                    waitUntil { done in
+                    waitUntil(timeout: 3) { done in
                         let listener = BaseObject()
 
                         listener.listenTo(avFoundationPlayback, eventName: Event.seek.rawValue) { info in
@@ -198,7 +196,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 it("triggers didSeek when a seek is completed") {
-                    waitUntil { done in
+                    waitUntil(timeout: 3) { done in
                         let listener = BaseObject()
 
                         listener.listenTo(avFoundationPlayback, eventName: Event.didSeek.rawValue) { info in
@@ -210,7 +208,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 it("triggers positionUpdate for the desired position") {
-                    waitUntil { done in
+                    waitUntil(timeout: 3) { done in
                         let listener = BaseObject()
 
                         listener.listenTo(avFoundationPlayback, eventName: Event.positionUpdate.rawValue) { info in


### PR DESCRIPTION
# Goal
To fix seek in iOS 10.3.

# How to test
1. Test the startAt
2. Try to do a seek when the player receives a ready event.
3. Test manually a seek in a video.