### PR TITLE
Add support to use the framework in Objective-C projects

### DIFF
--- a/Example/Clappr/ViewController.swift
+++ b/Example/Clappr/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        player = Player(options: options)
+        player = Player(options: options, externalPlugins: [])
 
         listenToPlayerEvents()
 

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -22,7 +22,7 @@ open class Container: UIBaseObject {
         didSet {
             if self.playback != oldValue {
                 self.playback?.removeFromSuperview()
-                self.playback?.once(Event.playing.rawValue) { [weak self] _ in self?.options[kStartAt] = 0.0 }
+                self.playback?.once(Event.playing.eventName()) { [weak self] _ in self?.options[kStartAt] = 0.0 }
                 trigger(InternalEvent.didChangePlayback.rawValue)
             }
         }

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -9,7 +9,7 @@ open class Container: UIBaseObject {
     @objc open var mediaControlEnabled = false {
         didSet {
             let eventToTrigger: Event = mediaControlEnabled ? .enableMediaControl : .disableMediaControl
-            trigger(eventToTrigger)
+            triggerEvent(eventToTrigger)
         }
     }
 

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -83,8 +83,6 @@
             return "willSeek"
         case .didSeek:
             return "didSeek"
-        default:
-            return ""
         }
     }
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -1,4 +1,4 @@
-public enum Event: String {
+@objc public enum Event: NSInteger {
     case bufferUpdate
     case positionUpdate
     case ready
@@ -26,4 +26,65 @@ public enum Event: String {
     case seek
     case willSeek
     case didSeek
+    
+    func eventName() -> String {
+        switch self {
+        case .bufferUpdate:
+            return "bufferUpdate"
+        case .positionUpdate:
+            return "positionUpdate"
+        case .ready:
+            return "ready"
+        case .stalled:
+            return "stalled"
+        case .willUpdateAudioSource:
+            return "willUpdateAudioSource"
+        case .didUpdateAudioSource:
+            return "didUpdateAudioSource"
+        case .willUpdateSubtitleSource:
+            return "willUpdateSubtitleSource"
+        case .didUpdateSubtitleSource:
+            return "didUpdateSubtitleSource"
+        case .disableMediaControl:
+            return "disableMediaControl"
+        case .enableMediaControl:
+            return "enableMediaControl"
+        case .didComplete:
+            return "didComplete"
+        case .willPlay:
+            return "willPlay"
+        case .playing:
+            return "playing"
+        case .willPause:
+            return "willPause"
+        case .didPause:
+            return "didPause"
+        case .willStop:
+            return "willStop"
+        case .didStop:
+            return "didStop"
+        case .error:
+            return "error"
+        case .airPlayStatusUpdate:
+            return "airPlayStatusUpdate"
+        case .requestFullscreen:
+            return "requestFullscreen"
+        case .exitFullscreen:
+            return "exitFullscreen"
+        case .requestPosterUpdate:
+            return "requestPosterUpdate"
+        case .willUpdatePoster:
+            return "willUpdatePoster"
+        case .didUpdatePoster:
+            return "didUpdatePoster"
+        case .seek:
+            return "seek"
+        case .willSeek:
+            return "willSeek"
+        case .didSeek:
+            return "didSeek"
+        default:
+            return ""
+        }
+    }
 }

--- a/Sources/Clappr/Classes/Enum/PluginType.swift
+++ b/Sources/Clappr/Classes/Enum/PluginType.swift
@@ -1,3 +1,3 @@
-public enum PluginType {
+@objc public enum PluginType: NSInteger {
     case core, container, playback
 }

--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -65,10 +65,10 @@ open class SpinnerPlugin: UIContainerPlugin {
 
     private func bindPlaybackEvents() {
         guard let playback = container?.playback else { return }
-        listenTo(playback, eventName: Event.playing.rawValue) { [weak self] (info: EventUserInfo) in self?.stopAnimating(info) }
-        listenTo(playback, eventName: Event.stalled.rawValue) { [weak self] (info: EventUserInfo) in self?.startAnimating(info) }
-        listenTo(playback, eventName: Event.error.rawValue) { [weak self] (info: EventUserInfo) in self?.stopAnimating(info) }
-        listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] (info: EventUserInfo) in self?.stopAnimating(info) }
+        listenTo(playback, eventName: Event.playing.eventName()) { [weak self] (info: EventUserInfo) in self?.stopAnimating(info) }
+        listenTo(playback, eventName: Event.stalled.eventName()) { [weak self] (info: EventUserInfo) in self?.startAnimating(info) }
+        listenTo(playback, eventName: Event.error.eventName()) { [weak self] (info: EventUserInfo) in self?.stopAnimating(info) }
+        listenTo(playback, eventName: Event.didComplete.eventName()) { [weak self] (info: EventUserInfo) in self?.stopAnimating(info) }
 
     }
 

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -1,4 +1,4 @@
-public protocol Plugin {
+@objc public protocol Plugin {
     static var type: PluginType { get }
     static var name: String { get }
     var pluginName: String { get }

--- a/Sources/Clappr_iOS/Classes/Base/BaseObject.swift
+++ b/Sources/Clappr_iOS/Classes/Base/BaseObject.swift
@@ -15,7 +15,7 @@ open class BaseObject: NSObject, EventProtocol {
         return on(eventName, callback: callback, contextObject: self)
     }
 
-    @discardableResult
+    @objc @discardableResult
     fileprivate func on(_ eventName: String, callback: @escaping EventCallback, contextObject: BaseObject) -> String {
         let listenId = createListenId(eventName, contextObject: contextObject)
         let eventHandler = EventHandler(callback: wrapEventCallback(listenId, callback: callback))

--- a/Sources/Clappr_iOS/Classes/Base/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Base/MediaControl.swift
@@ -183,18 +183,18 @@ open class MediaControl: UIBaseObject {
         }
 
         if let container = self.container {
-            listenTo(container, eventName: Event.disableMediaControl.rawValue) { [weak self] _ in self?.disable() }
-            listenTo(container, eventName: Event.enableMediaControl.rawValue) { [weak self] _ in self?.enable() }
+            listenTo(container, eventName: Event.disableMediaControl.eventName()) { [weak self] _ in self?.disable() }
+            listenTo(container, eventName: Event.enableMediaControl.eventName()) { [weak self] _ in self?.enable() }
         }
 
         if let playback = container?.playback {
-            listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.triggerPlay() }
-            listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in self?.triggerPause() }
-            listenTo(playback, eventName: Event.stalled.rawValue) { [weak self] _ in self?.playbackStalled() }
-            listenTo(playback, eventName: Event.ready.rawValue) { [weak self] _ in self?.playbackReady() }
-            listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in self?.playbackControlState = .stopped }
-            listenTo(playback, eventName: Event.positionUpdate.rawValue) { [weak self] (info: EventUserInfo) in self?.timeUpdated(info) }
-            listenTo(playback, eventName: Event.bufferUpdate.rawValue) { [weak self] (info: EventUserInfo) in self?.progressUpdated(info) }
+            listenTo(playback, eventName: Event.playing.eventName()) { [weak self] _ in self?.triggerPlay() }
+            listenTo(playback, eventName: Event.didPause.eventName()) { [weak self] _ in self?.triggerPause() }
+            listenTo(playback, eventName: Event.stalled.eventName()) { [weak self] _ in self?.playbackStalled() }
+            listenTo(playback, eventName: Event.ready.eventName()) { [weak self] _ in self?.playbackReady() }
+            listenTo(playback, eventName: Event.didComplete.eventName()) { [weak self] _ in self?.playbackControlState = .stopped }
+            listenTo(playback, eventName: Event.positionUpdate.eventName()) { [weak self] (info: EventUserInfo) in self?.timeUpdated(info) }
+            listenTo(playback, eventName: Event.bufferUpdate.eventName()) { [weak self] (info: EventUserInfo) in self?.progressUpdated(info) }
         }
     }
 
@@ -281,25 +281,25 @@ open class MediaControl: UIBaseObject {
 
     @objc open func hide() {
         hideControlsTimer?.invalidate()
-        trigger(Event.disableMediaControl.rawValue)
+        trigger(Event.disableMediaControl.eventName())
         setSubviewsVisibility(hidden: true)
     }
 
     @objc open func show() {
-        trigger(Event.enableMediaControl.rawValue)
+        trigger(Event.enableMediaControl.eventName())
         setSubviewsVisibility(hidden: false)
         scheduleTimerToHideControls()
     }
 
     @objc open func showAnimated() {
-        trigger(Event.enableMediaControl.rawValue)
+        trigger(Event.enableMediaControl.eventName())
         setSubviewsVisibility(hidden: false, animated: true)
         scheduleTimerToHideControls()
     }
 
     @objc open func hideAnimated() {
         hideControlsTimer?.invalidate()
-        trigger(Event.disableMediaControl.rawValue)
+        trigger(Event.disableMediaControl.eventName())
         setSubviewsVisibility(hidden: true, animated: true)
     }
 
@@ -346,19 +346,19 @@ open class MediaControl: UIBaseObject {
     fileprivate func pause() {
         playbackControlState = .paused
         container?.playback?.pause()
-        trigger(Event.didPause.rawValue)
+        trigger(Event.didPause.eventName())
     }
 
     fileprivate func play() {
         playbackControlState = .playing
         container?.playback?.play()
-        trigger(Event.playing.rawValue)
+        trigger(Event.playing.eventName())
     }
 
     fileprivate func stop() {
         playbackControlState = .stopped
         container?.playback?.stop()
-        trigger(Event.didStop.rawValue)
+        trigger(Event.didStop.eventName())
     }
 
     @objc open func scheduleTimerToHideControls() {
@@ -372,7 +372,7 @@ open class MediaControl: UIBaseObject {
         if isPlaybackPlaying() {
             hideAnimated()
         } else if let playback = container?.playback {
-            listenToOnce(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.hideAnimated() }
+            listenToOnce(playback, eventName: Event.playing.eventName()) { [weak self] _ in self?.hideAnimated() }
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Base/MediaControl.swift
@@ -205,12 +205,12 @@ open class MediaControl: UIBaseObject {
     @objc open func triggerPlay() {
         playbackControlState = .playing
         playbackControlButton?.isHidden = false
-        trigger(Event.playing)
+        triggerEvent(Event.playing)
     }
 
     @objc open func triggerPause() {
         playbackControlState = .paused
-        trigger(Event.didPause)
+        triggerEvent(Event.didPause)
     }
 
     @objc open func disable() {

--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -85,7 +85,7 @@ open class Playback: UIBaseObject, Plugin {
     }
 
     open override func render() {
-        once(Event.ready.rawValue) { [unowned self] _ in
+        once(Event.ready.eventName()) { [unowned self] _ in
             if self.startAt != 0.0 {
                 self.seek(self.startAt)
             }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -66,7 +66,7 @@ open class Player: BaseObject {
         }
     }
 
-    public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
+    @objc public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
         super.init()
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")
@@ -87,10 +87,10 @@ open class Player: BaseObject {
         setCore(Core(loader: loader, options: options))
     }
     
-    public init(url: String) {
+    @objc public init(url: String) {
         super.init()
+        let options = [kSourceUrl : url]
         
-        let options = [kSourceUrl : "http://clappr.io/highline.mp4"]
         Logger.logInfo("loading with \(options)", scope: "Clappr")
         
         self.playbackEventsToListen.append(contentsOf:

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -66,7 +66,7 @@ open class Player: BaseObject {
         }
     }
 
-    public init(options: Options, externalPlugins: [Plugin.Type]) {
+    public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
         super.init()
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -66,9 +66,17 @@ open class Player: BaseObject {
         }
     }
 
-    public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
+    public init(var options: Options!, var externalPlugins: [Plugin.Type]!) {
         super.init()
-
+        
+        if options == nil {
+            options = [:]
+        }
+        
+        if externalPlugins == nil {
+            externalPlugins = []
+        }
+        
         Logger.logInfo("loading with \(options)", scope: "Clappr")
 
         self.playbackEventsToListen.append(contentsOf:

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -86,6 +86,28 @@ open class Player: BaseObject {
 
         setCore(Core(loader: loader, options: options))
     }
+    
+    public init(url: String) {
+        super.init()
+        
+        let options = [kSourceUrl : "http://clappr.io/highline.mp4"]
+        Logger.logInfo("loading with \(options)", scope: "Clappr")
+        
+        self.playbackEventsToListen.append(contentsOf:
+            [Event.ready.rawValue, Event.error.rawValue,
+             Event.playing.rawValue, Event.didComplete.rawValue,
+             Event.didPause.rawValue, Event.stalled.rawValue,
+             Event.didStop.rawValue, Event.bufferUpdate.rawValue,
+             Event.requestFullscreen.rawValue, Event.exitFullscreen.rawValue,
+             Event.positionUpdate.rawValue, Event.willPlay.rawValue,
+             Event.willPause.rawValue, Event.willStop.rawValue,
+             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
+             Event.seek.rawValue, Event.didSeek.rawValue])
+        
+        let loader = Loader(externalPlugins: [], options: options)
+        
+        setCore(Core(loader: loader, options: options))
+    }
 
     fileprivate func setCore(_ core: Core) {
         self.core?.stopListening()

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -72,15 +72,15 @@ open class Player: BaseObject {
         Logger.logInfo("loading with \(options)", scope: "Clappr")
 
         self.playbackEventsToListen.append(contentsOf:
-            [Event.ready.rawValue, Event.error.rawValue,
-             Event.playing.rawValue, Event.didComplete.rawValue,
-             Event.didPause.rawValue, Event.stalled.rawValue,
-             Event.didStop.rawValue, Event.bufferUpdate.rawValue,
-             Event.requestFullscreen.rawValue, Event.exitFullscreen.rawValue,
-             Event.positionUpdate.rawValue, Event.willPlay.rawValue,
-             Event.willPause.rawValue, Event.willStop.rawValue,
-             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
-             Event.seek.rawValue, Event.didSeek.rawValue])
+            [Event.ready.eventName(), Event.error.eventName(),
+             Event.playing.eventName(), Event.didComplete.eventName(),
+             Event.didPause.eventName(), Event.stalled.eventName(),
+             Event.didStop.eventName(), Event.bufferUpdate.eventName(),
+             Event.requestFullscreen.eventName(), Event.exitFullscreen.eventName(),
+             Event.positionUpdate.eventName(), Event.willPlay.eventName(),
+             Event.willPause.eventName(), Event.willStop.eventName(),
+             Event.airPlayStatusUpdate.eventName(), Event.willSeek.eventName(),
+             Event.seek.eventName(), Event.didSeek.eventName()])
 
         let loader = Loader(externalPlugins: externalPlugins, options: options)
 
@@ -93,16 +93,15 @@ open class Player: BaseObject {
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")
         
-        self.playbackEventsToListen.append(contentsOf:
-            [Event.ready.rawValue, Event.error.rawValue,
-             Event.playing.rawValue, Event.didComplete.rawValue,
-             Event.didPause.rawValue, Event.stalled.rawValue,
-             Event.didStop.rawValue, Event.bufferUpdate.rawValue,
-             Event.requestFullscreen.rawValue, Event.exitFullscreen.rawValue,
-             Event.positionUpdate.rawValue, Event.willPlay.rawValue,
-             Event.willPause.rawValue, Event.willStop.rawValue,
-             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
-             Event.seek.rawValue, Event.didSeek.rawValue])
+        self.playbackEventsToListen.append(contentsOf: [Event.ready.eventName(), Event.error.eventName(),
+             Event.playing.eventName(), Event.didComplete.eventName(),
+             Event.didPause.eventName(), Event.stalled.eventName(),
+             Event.didStop.eventName(), Event.bufferUpdate.eventName(),
+             Event.requestFullscreen.eventName(), Event.exitFullscreen.eventName(),
+             Event.positionUpdate.eventName(), Event.willPlay.eventName(),
+             Event.willPause.eventName(), Event.willStop.eventName(),
+             Event.airPlayStatusUpdate.eventName(), Event.willSeek.eventName(),
+             Event.seek.eventName(), Event.didSeek.eventName()])
         
         let loader = Loader(externalPlugins: [], options: options)
         
@@ -155,7 +154,7 @@ open class Player: BaseObject {
 
     @discardableResult
     open func on(_ event: Event, callback: @escaping EventCallback) -> String {
-        return on(event.rawValue, callback: callback)
+        return on(event.eventName(), callback: callback)
     }
 
     fileprivate func bindPlaybackEvents() {
@@ -181,7 +180,7 @@ open class Player: BaseObject {
     }
 
     fileprivate func forward(_ event: Event, userInfo: EventUserInfo) {
-        trigger(event.rawValue, userInfo: userInfo)
+        trigger(event.eventName(), userInfo: userInfo)
     }
 
     @objc open func destroy() {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -89,7 +89,7 @@ open class Player: BaseObject {
     
     @objc public init(url: String) {
         super.init()
-        let options = [kSourceUrl : url]
+        let options: Options = [kSourceUrl : url]
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")
         

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -66,16 +66,8 @@ open class Player: BaseObject {
         }
     }
 
-    public init(var options: Options!, var externalPlugins: [Plugin.Type]!) {
+    public init(options: Options, externalPlugins: [Plugin.Type]) {
         super.init()
-        
-        if options == nil {
-            options = [:]
-        }
-        
-        if externalPlugins == nil {
-            externalPlugins = []
-        }
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -86,33 +86,6 @@ open class Player: BaseObject {
 
         setCore(Core(loader: loader, options: options))
     }
-    
-    @objc public init(url: String, posterUrl: String, fullScreen: Bool, fullScreenByApp: Bool, mediaControl: Bool) {
-        super.init()
-        let options: Options = [
-            kSourceUrl: url,
-            kPosterUrl: posterUrl,
-            kFullscreen: fullScreen,
-            kFullscreenByApp: fullScreenByApp,
-            kMediaControl: mediaControl
-        ]
-        
-        Logger.logInfo("loading with \(options)", scope: "Clappr")
-        
-        self.playbackEventsToListen.append(contentsOf: [Event.ready.eventName(), Event.error.eventName(),
-             Event.playing.eventName(), Event.didComplete.eventName(),
-             Event.didPause.eventName(), Event.stalled.eventName(),
-             Event.didStop.eventName(), Event.bufferUpdate.eventName(),
-             Event.requestFullscreen.eventName(), Event.exitFullscreen.eventName(),
-             Event.positionUpdate.eventName(), Event.willPlay.eventName(),
-             Event.willPause.eventName(), Event.willStop.eventName(),
-             Event.airPlayStatusUpdate.eventName(), Event.willSeek.eventName(),
-             Event.seek.eventName(), Event.didSeek.eventName()])
-        
-        let loader = Loader(externalPlugins: [], options: options)
-        
-        setCore(Core(loader: loader, options: options))
-    }
 
     fileprivate func setCore(_ core: Core) {
         self.core?.stopListening()

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -87,9 +87,15 @@ open class Player: BaseObject {
         setCore(Core(loader: loader, options: options))
     }
     
-    @objc public init(url: String) {
+    @objc public init(url: String, posterUrl: String, fullScreen: Bool, fullScreenByApp: Bool, mediaControl: Bool) {
         super.init()
-        let options: Options = [kSourceUrl : url]
+        let options: Options = [
+            kSourceUrl: url,
+            kPosterUrl: posterUrl,
+            kFullscreen: fullScreen,
+            kFullscreenByApp: fullScreenByApp,
+            kMediaControl: mediaControl
+        ]
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")
         

--- a/Sources/Clappr_iOS/Classes/Base/UIBaseObject.swift
+++ b/Sources/Clappr_iOS/Classes/Base/UIBaseObject.swift
@@ -64,11 +64,11 @@ open class UIBaseObject: UIView, EventProtocol {
 }
 
 public extension UIBaseObject {
-    public func trigger(_ event: Event) {
+    public func triggerEvent(_ event: Event) {
         trigger(event.eventName())
     }
 
-    public func trigger(_ event: Event, userInfo: EventUserInfo) {
+    public func triggerEvent(_ event: Event, userInfo: EventUserInfo) {
         trigger(event.eventName(), userInfo: userInfo)
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/UIBaseObject.swift
+++ b/Sources/Clappr_iOS/Classes/Base/UIBaseObject.swift
@@ -65,10 +65,10 @@ open class UIBaseObject: UIView, EventProtocol {
 
 public extension UIBaseObject {
     public func trigger(_ event: Event) {
-        trigger(event.rawValue)
+        trigger(event.eventName())
     }
 
     public func trigger(_ event: Event, userInfo: EventUserInfo) {
-        trigger(event.rawValue, userInfo: userInfo)
+        trigger(event.eventName(), userInfo: userInfo)
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -121,9 +121,9 @@ open class PosterPlugin: UIContainerPlugin {
             Logger.logWarn("Unable to update poster, no url was found", scope: pluginName)
             return
         }
-        trigger(Event.willUpdatePoster)
+        triggerEvent(Event.willUpdatePoster)
         setPosterImage(with: posterUrl)
-        trigger(Event.didUpdatePoster)
+        triggerEvent(Event.didUpdatePoster)
 
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -75,16 +75,16 @@ open class PosterPlugin: UIContainerPlugin {
 
     private func bindPlaybackEvents() {
         if let playback = container?.playback {
-            listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.playbackStarted() }
-            listenTo(playback, eventName: Event.stalled.rawValue) { [weak self] _ in self?.playbackStalled() }
-            listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in self?.playbackEnded() }
+            listenTo(playback, eventName: Event.playing.eventName()) { [weak self] _ in self?.playbackStarted() }
+            listenTo(playback, eventName: Event.stalled.eventName()) { [weak self] _ in self?.playbackStalled() }
+            listenTo(playback, eventName: Event.didComplete.eventName()) { [weak self] _ in self?.playbackEnded() }
         }
     }
 
     private func bindContainerEvents() {
         guard let container = container else { return }
         listenTo(container, eventName: InternalEvent.didChangePlayback.rawValue) { [weak self] _ in self?.didChangePlayback() }
-        listenTo(container, eventName: Event.requestPosterUpdate.rawValue) { [weak self] info in self?.updatePoster(info) }
+        listenTo(container, eventName: Event.requestPosterUpdate.eventName()) { [weak self] info in self?.updatePoster(info) }
     }
 
     @objc var isNoOpPlayback: Bool {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -184,7 +184,7 @@ open class AVFoundationPlayback: Playback {
             setupPlayer()
         }
 
-        trigger(.willPlay)
+        triggerEvent(.willPlay)
         player?.play()
 
         if let currentItem = player?.currentItem {
@@ -203,9 +203,9 @@ open class AVFoundationPlayback: Playback {
             layer.addSublayer(playerLayer!)
             setupMaxResolution(for: bounds.size)
             addObservers()
-            trigger(.ready)
+            triggerEvent(.ready)
         } else {
-            trigger(.error)
+            triggerEvent(.error)
             Logger.logError("could not setup player", scope: pluginName)
         }
     }
@@ -232,22 +232,22 @@ open class AVFoundationPlayback: Playback {
     }
 
     @objc func playbackDidEnd() {
-        trigger(.didComplete)
+        triggerEvent(.didComplete)
         updateState(.idle)
     }
 
     open override func pause() {
-        trigger(.willPause)
+        triggerEvent(.willPause)
         player?.pause()
         updateState(.paused)
     }
 
     open override func stop() {
-        trigger(.willStop)
+        triggerEvent(.willStop)
         player?.pause()
         updateState(.idle)
         releaseResources()
-        trigger(.didStop)
+        triggerEvent(.didStop)
     }
 
     @objc func releaseResources() {
@@ -269,16 +269,16 @@ open class AVFoundationPlayback: Playback {
 
         let time = CMTimeMakeWithSeconds(timeInterval, Int32(NSEC_PER_SEC))
 
-        trigger(.seek)
-        trigger(.willSeek)
+        triggerEvent(.seek)
+        triggerEvent(.willSeek)
 
         player?.currentItem?.seek(to: time) { [weak self] success in
             if success {
-                self?.trigger(.didSeek)
+                self?.triggerEvent(.didSeek)
             }
         }
 
-        trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
+        triggerEvent(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
     }
 
     open override func observeValue(forKeyPath keyPath: String?, of _: Any?,
@@ -310,11 +310,11 @@ open class AVFoundationPlayback: Playback {
 
         switch newState {
         case .buffering:
-            trigger(.stalled)
+            triggerEvent(.stalled)
         case .paused:
-            trigger(.didPause)
+            triggerEvent(.didPause)
         case .playing:
-            trigger(.playing)
+            triggerEvent(.playing)
         default:
             break
         }
@@ -331,7 +331,7 @@ open class AVFoundationPlayback: Playback {
             restoreBackgroundSession()
         }
 
-        self.trigger(.airPlayStatusUpdate, userInfo: ["externalPlaybackActive": player!.isExternalPlaybackActive])
+        self.triggerEvent(.airPlayStatusUpdate, userInfo: ["externalPlaybackActive": player!.isExternalPlaybackActive])
     }
 
     private func enableBackgroundSession() {
@@ -365,7 +365,7 @@ open class AVFoundationPlayback: Playback {
             readyToPlay()
         } else if playerStatus == .failed {
             let error = player.currentItem!.error!
-            self.trigger(.error, userInfo: ["error": error])
+            self.triggerEvent(.error, userInfo: ["error": error])
             Logger.logError("playback failed with error: \(error.localizedDescription) ", scope: pluginName)
         }
     }
@@ -381,11 +381,11 @@ open class AVFoundationPlayback: Playback {
         seekOnReadyIfNeeded()
 
         if let subtitles = self.subtitles {
-            trigger(.didUpdateSubtitleSource, userInfo: ["subtitles": subtitles])
+            triggerEvent(.didUpdateSubtitleSource, userInfo: ["subtitles": subtitles])
         }
 
         if let audioSources = self.audioSources {
-            trigger(.didUpdateAudioSource, userInfo: ["audios": audioSources])
+            triggerEvent(.didUpdateAudioSource, userInfo: ["audios": audioSources])
         }
 
         addTimeElapsedCallback()
@@ -400,7 +400,7 @@ open class AVFoundationPlayback: Playback {
     fileprivate func timeUpdated(_ time: CMTime) {
         if isPlaying {
             updateState(.playing)
-            trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
+            triggerEvent(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
         }
     }
 
@@ -415,7 +415,7 @@ open class AVFoundationPlayback: Playback {
             "duration": CMTimeGetSeconds(timeRange.duration),
             ]
 
-        trigger(.bufferUpdate, userInfo: info)
+        triggerEvent(.bufferUpdate, userInfo: info)
     }
 
     fileprivate func handleBufferingEvent(_ keyPath: String?) {

--- a/Sources/Clappr_tvOS/Classes/Base/BaseObject.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/BaseObject.swift
@@ -61,11 +61,11 @@ extension BaseObject {
         return eventDispatcher
     }
 
-    public func trigger(_ event: Event) {
+    public func triggerEvent(_ event: Event) {
         trigger(event.eventName())
     }
 
-    public func trigger(_ event: Event, userInfo: EventUserInfo) {
+    public func triggerEvent(_ event: Event, userInfo: EventUserInfo) {
         trigger(event.eventName(), userInfo: userInfo)
     }
 
@@ -77,3 +77,5 @@ extension BaseObject {
         return "\(type(of: self))"
     }
 }
+
+

--- a/Sources/Clappr_tvOS/Classes/Base/BaseObject.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/BaseObject.swift
@@ -62,11 +62,11 @@ extension BaseObject {
     }
 
     public func trigger(_ event: Event) {
-        trigger(event.rawValue)
+        trigger(event.eventName())
     }
 
     public func trigger(_ event: Event, userInfo: EventUserInfo) {
-        trigger(event.rawValue, userInfo: userInfo)
+        trigger(event.eventName(), userInfo: userInfo)
     }
 
     func logIdentifier() -> String {

--- a/Sources/Clappr_tvOS/Classes/Base/Core.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Core.swift
@@ -87,8 +87,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
             return
         }
 
-        listenTo(mediaControl, eventName: Event.requestFullscreen.rawValue) { [weak self] (userInfo: EventUserInfo) in self?.enterFullscreen(userInfo) }
-        listenTo(mediaControl, eventName: Event.exitFullscreen.rawValue) { [weak self] (userInfo: EventUserInfo) in self?.exitFullscreen(userInfo) }
+        listenTo(mediaControl, eventName: Event.requestFullscreen.eventName()) { [weak self] (userInfo: EventUserInfo) in self?.enterFullscreen(userInfo) }
+        listenTo(mediaControl, eventName: Event.exitFullscreen.eventName()) { [weak self] (userInfo: EventUserInfo) in self?.exitFullscreen(userInfo) }
     }
 
     fileprivate func enterFullscreen(_: EventUserInfo) {

--- a/Sources/Clappr_tvOS/Classes/Base/MediaControl.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/MediaControl.swift
@@ -167,18 +167,18 @@ open class MediaControl: UIBaseObject {
 
     open func bindEventListeners() {
         if let container = self.container {
-            listenTo(container, eventName: Event.disableMediaControl.rawValue) { [weak self] _ in self?.disable() }
-            listenTo(container, eventName: Event.enableMediaControl.rawValue) { [weak self] _ in self?.enable() }
+            listenTo(container, eventName: Event.disableMediaControl.eventName()) { [weak self] _ in self?.disable() }
+            listenTo(container, eventName: Event.enableMediaControl.eventName()) { [weak self] _ in self?.enable() }
         }
 
         if let playback = container?.playback {
-            listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.triggerPlay() }
-            listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in self?.triggerPause() }
-            listenTo(playback, eventName: Event.stalled.rawValue) { [weak self] _ in self?.playbackStalled() }
-            listenTo(playback, eventName: Event.ready.rawValue) { [weak self] _ in self?.playbackReady() }
-            listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in self?.playbackControlState = .stopped }
-            listenTo(playback, eventName: Event.positionUpdate.rawValue) { [weak self] (info: EventUserInfo) in self?.timeUpdated(info) }
-            listenTo(playback, eventName: Event.bufferUpdate.rawValue) { [weak self] (info: EventUserInfo) in self?.progressUpdated(info) }
+            listenTo(playback, eventName: Event.playing.eventName()) { [weak self] _ in self?.triggerPlay() }
+            listenTo(playback, eventName: Event.didPause.eventName()) { [weak self] _ in self?.triggerPause() }
+            listenTo(playback, eventName: Event.stalled.eventName()) { [weak self] _ in self?.playbackStalled() }
+            listenTo(playback, eventName: Event.ready.eventName()) { [weak self] _ in self?.playbackReady() }
+            listenTo(playback, eventName: Event.didComplete.eventName()) { [weak self] _ in self?.playbackControlState = .stopped }
+            listenTo(playback, eventName: Event.positionUpdate.eventName()) { [weak self] (info: EventUserInfo) in self?.timeUpdated(info) }
+            listenTo(playback, eventName: Event.bufferUpdate.eventName()) { [weak self] (info: EventUserInfo) in self?.progressUpdated(info) }
         }
     }
 
@@ -189,12 +189,12 @@ open class MediaControl: UIBaseObject {
     open func triggerPlay() {
         playbackControlState = .playing
         playbackControlButton?.isHidden = false
-        trigger(Event.playing)
+        triggerEvent(Event.playing)
     }
 
     open func triggerPause() {
         playbackControlState = .paused
-        trigger(Event.didPause)
+        triggerEvent(Event.didPause)
     }
 
     open func disable() {
@@ -265,25 +265,25 @@ open class MediaControl: UIBaseObject {
 
     open func hide() {
         hideControlsTimer?.invalidate()
-        trigger(Event.disableMediaControl.rawValue)
+        trigger(Event.disableMediaControl.eventName())
         setSubviewsVisibility(hidden: true)
     }
 
     open func show() {
-        trigger(Event.enableMediaControl.rawValue)
+        trigger(Event.enableMediaControl.eventName())
         setSubviewsVisibility(hidden: false)
         scheduleTimerToHideControls()
     }
 
     open func showAnimated() {
-        trigger(Event.enableMediaControl.rawValue)
+        trigger(Event.enableMediaControl.eventName())
         setSubviewsVisibility(hidden: false, animated: true)
         scheduleTimerToHideControls()
     }
 
     open func hideAnimated() {
         hideControlsTimer?.invalidate()
-        trigger(Event.disableMediaControl.rawValue)
+        trigger(Event.disableMediaControl.eventName())
         setSubviewsVisibility(hidden: true, animated: true)
     }
 
@@ -320,7 +320,7 @@ open class MediaControl: UIBaseObject {
     @IBAction open func toggleFullscreen(_: UIButton) {
         fullscreen = !fullscreen
         let event = fullscreen ? Event.requestFullscreen : Event.exitFullscreen
-        trigger(event.rawValue)
+        trigger(event.eventName())
         scheduleTimerToHideControls()
         updateScrubberPosition()
     }
@@ -328,19 +328,19 @@ open class MediaControl: UIBaseObject {
     fileprivate func pause() {
         playbackControlState = .paused
         container?.playback?.pause()
-        trigger(Event.didPause.rawValue)
+        trigger(Event.didPause.eventName())
     }
 
     fileprivate func play() {
         playbackControlState = .playing
         container?.playback?.play()
-        trigger(Event.playing.rawValue)
+        trigger(Event.playing.eventName())
     }
 
     fileprivate func stop() {
         playbackControlState = .stopped
         container?.playback?.stop()
-        trigger(Event.didStop.rawValue)
+        trigger(Event.didStop.eventName())
     }
 
     open func scheduleTimerToHideControls() {
@@ -354,7 +354,7 @@ open class MediaControl: UIBaseObject {
         if isPlaybackPlaying() {
             hideAnimated()
         } else if let playback = container?.playback {
-            listenToOnce(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.hideAnimated() }
+            listenToOnce(playback, eventName: Event.playing.eventName()) { [weak self] _ in self?.hideAnimated() }
         }
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Playback.swift
@@ -89,7 +89,7 @@ open class Playback: UIBaseObject, Plugin {
     }
 
     open override func render() {
-        once(Event.ready.rawValue) { [unowned self] _ in
+        once(Event.ready.eventName()) { [unowned self] _ in
             if self.startAt != 0.0 {
                 self.seek(self.startAt)
             }

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -101,7 +101,7 @@ open class Player: UIViewController, BaseObject {
         }
     }
 
-    public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
+    @objc public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
         super.init(nibName: nil, bundle: nil)
 
         Logger.logInfo("loading with \(options)", scope: "Clappr")
@@ -118,6 +118,27 @@ open class Player: UIViewController, BaseObject {
 
         let loader = Loader(externalPlugins: externalPlugins, options: options)
 
+        setCore(Core(loader: loader, options: options))
+    }
+    
+    @objc public init(url: String) {
+        super.init(nibName: nil, bundle: nil)
+        let options = [kSourceUrl: url]
+        
+        Logger.logInfo("loading with \(options)", scope: "Clappr")
+        
+        self.playbackEventsToListen.append(contentsOf:
+            [Event.ready.rawValue, Event.error.rawValue,
+             Event.playing.rawValue, Event.didComplete.rawValue,
+             Event.didPause.rawValue, Event.stalled.rawValue,
+             Event.didStop.rawValue, Event.bufferUpdate.rawValue,
+             Event.positionUpdate.rawValue, Event.willPlay.rawValue,
+             Event.willPause.rawValue, Event.willStop.rawValue,
+             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
+             Event.seek.rawValue,Event.didSeek.rawValue])
+        
+        let loader = Loader(externalPlugins: [], options: options)
+        
         setCore(Core(loader: loader, options: options))
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -120,32 +120,6 @@ open class Player: UIViewController, BaseObject {
 
         setCore(Core(loader: loader, options: options))
     }
-    
-    @objc public init(url: String, posterUrl: String, fullScreen: Bool, fullScreenByApp: Bool, mediaControl: Bool) {
-        super.init(nibName: nil, bundle: nil)
-        let options: Options = [
-            kSourceUrl: url,
-            kPosterUrl: posterUrl,
-            kFullscreen: fullScreen,
-            kMediaControl: mediaControl
-        ]
-        
-        Logger.logInfo("loading with \(options)", scope: "Clappr")
-        
-        self.playbackEventsToListen.append(contentsOf:
-            [Event.ready.eventName(), Event.error.eventName(),
-             Event.playing.eventName(), Event.didComplete.eventName(),
-             Event.didPause.eventName(), Event.stalled.eventName(),
-             Event.didStop.eventName(), Event.bufferUpdate.eventName(),
-             Event.positionUpdate.eventName(), Event.willPlay.eventName(),
-             Event.willPause.eventName(), Event.willStop.eventName(),
-             Event.airPlayStatusUpdate.eventName(), Event.willSeek.eventName(),
-             Event.seek.eventName(),Event.didSeek.eventName()])
-        
-        let loader = Loader(externalPlugins: [], options: options)
-        
-        setCore(Core(loader: loader, options: options))
-    }
 
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -122,12 +122,11 @@ open class Player: UIViewController, BaseObject {
     }
     
     @objc public init(url: String, posterUrl: String, fullScreen: Bool, fullScreenByApp: Bool, mediaControl: Bool) {
-        super.init()
+        super.init(nibName: nil, bundle: nil)
         let options: Options = [
             kSourceUrl: url,
             kPosterUrl: posterUrl,
             kFullscreen: fullScreen,
-            kFullscreenByApp: fullScreenByApp,
             kMediaControl: mediaControl
         ]
         

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -190,7 +190,7 @@ open class Player: UIViewController, BaseObject {
         core?.setFullscreen(fullscreen)
     }
 
-    @discardableResult
+    @objc @discardableResult
     open func on(_ event: Event, callback: @escaping EventCallback) -> String {
         return on(event.rawValue, callback: callback)
     }

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -121,9 +121,15 @@ open class Player: UIViewController, BaseObject {
         setCore(Core(loader: loader, options: options))
     }
     
-    @objc public init(url: String) {
-        super.init(nibName: nil, bundle: nil)
-        let options: Options = [kSourceUrl : url]
+    @objc public init(url: String, posterUrl: String, fullScreen: Bool, fullScreenByApp: Bool, mediaControl: Bool) {
+        super.init()
+        let options: Options = [
+            kSourceUrl: url,
+            kPosterUrl: posterUrl,
+            kFullscreen: fullScreen,
+            kFullscreenByApp: fullScreenByApp,
+            kMediaControl: mediaControl
+        ]
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")
         

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -123,7 +123,7 @@ open class Player: UIViewController, BaseObject {
     
     @objc public init(url: String) {
         super.init(nibName: nil, bundle: nil)
-        let options = [kSourceUrl: url]
+        let options: Options = [kSourceUrl : url]
         
         Logger.logInfo("loading with \(options)", scope: "Clappr")
         

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -107,14 +107,14 @@ open class Player: UIViewController, BaseObject {
         Logger.logInfo("loading with \(options)", scope: "Clappr")
 
         self.playbackEventsToListen.append(contentsOf:
-            [Event.ready.rawValue, Event.error.rawValue,
-             Event.playing.rawValue, Event.didComplete.rawValue,
-             Event.didPause.rawValue, Event.stalled.rawValue,
-             Event.didStop.rawValue, Event.bufferUpdate.rawValue,
-             Event.positionUpdate.rawValue, Event.willPlay.rawValue,
-             Event.willPause.rawValue, Event.willStop.rawValue,
-             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
-             Event.seek.rawValue,Event.didSeek.rawValue])
+            [Event.ready.eventName(), Event.error.eventName(),
+             Event.playing.eventName(), Event.didComplete.eventName(),
+             Event.didPause.eventName(), Event.stalled.eventName(),
+             Event.didStop.eventName(), Event.bufferUpdate.eventName(),
+             Event.positionUpdate.eventName(), Event.willPlay.eventName(),
+             Event.willPause.eventName(), Event.willStop.eventName(),
+             Event.airPlayStatusUpdate.eventName(), Event.willSeek.eventName(),
+             Event.seek.eventName(),Event.didSeek.eventName()])
 
         let loader = Loader(externalPlugins: externalPlugins, options: options)
 
@@ -128,14 +128,14 @@ open class Player: UIViewController, BaseObject {
         Logger.logInfo("loading with \(options)", scope: "Clappr")
         
         self.playbackEventsToListen.append(contentsOf:
-            [Event.ready.rawValue, Event.error.rawValue,
-             Event.playing.rawValue, Event.didComplete.rawValue,
-             Event.didPause.rawValue, Event.stalled.rawValue,
-             Event.didStop.rawValue, Event.bufferUpdate.rawValue,
-             Event.positionUpdate.rawValue, Event.willPlay.rawValue,
-             Event.willPause.rawValue, Event.willStop.rawValue,
-             Event.airPlayStatusUpdate.rawValue, Event.willSeek.rawValue,
-             Event.seek.rawValue,Event.didSeek.rawValue])
+            [Event.ready.eventName(), Event.error.eventName(),
+             Event.playing.eventName(), Event.didComplete.eventName(),
+             Event.didPause.eventName(), Event.stalled.eventName(),
+             Event.didStop.eventName(), Event.bufferUpdate.eventName(),
+             Event.positionUpdate.eventName(), Event.willPlay.eventName(),
+             Event.willPause.eventName(), Event.willStop.eventName(),
+             Event.airPlayStatusUpdate.eventName(), Event.willSeek.eventName(),
+             Event.seek.eventName(),Event.didSeek.eventName()])
         
         let loader = Loader(externalPlugins: [], options: options)
         
@@ -192,7 +192,7 @@ open class Player: UIViewController, BaseObject {
 
     @objc @discardableResult
     open func on(_ event: Event, callback: @escaping EventCallback) -> String {
-        return on(event.rawValue, callback: callback)
+        return on(event.eventName(), callback: callback)
     }
 
     fileprivate func bindPlaybackEvents() {
@@ -207,7 +207,7 @@ open class Player: UIViewController, BaseObject {
                 playbackEventsListenIds.append(listenId)
             }
 
-            let listenId = listenToOnce(playback, eventName: Event.playing.rawValue, callback: { [weak self] _ in self?.bindPlayer(playback: playback) })
+            let listenId = listenToOnce(playback, eventName: Event.playing.eventName(), callback: { [weak self] _ in self?.bindPlayer(playback: playback) })
             playbackEventsListenIds.append(listenId)
         }
     }
@@ -228,7 +228,7 @@ open class Player: UIViewController, BaseObject {
     }
 
     fileprivate func forward(_ event: Event, userInfo: EventUserInfo) {
-        trigger(event.rawValue, userInfo: userInfo)
+        trigger(event.eventName(), userInfo: userInfo)
     }
 
     open func destroy() {

--- a/Sources/Clappr_tvOS/Classes/Base/UIBaseObject.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/UIBaseObject.swift
@@ -65,11 +65,11 @@ open class UIBaseObject: UIView, EventProtocol {
 }
 
 public extension UIBaseObject {
-    public func trigger(_ event: Event) {
-        trigger(event.rawValue)
+    public func triggerEvent(_ event: Event) {
+        trigger(event.eventName())
     }
 
-    public func trigger(_ event: Event, userInfo: EventUserInfo) {
-        trigger(event.rawValue, userInfo: userInfo)
+    public func triggerEvent(_ event: Event, userInfo: EventUserInfo) {
+        trigger(event.eventName(), userInfo: userInfo)
     }
 }

--- a/Sources/Clappr_tvOS/Classes/Plugin/Playback/NoOpPlayback.swift
+++ b/Sources/Clappr_tvOS/Classes/Plugin/Playback/NoOpPlayback.swift
@@ -28,7 +28,7 @@ open class NoOpPlayback: Playback {
 
     open override func render() {
 //        addSubviewMatchingConstraints(errorLabel)
-        trigger(.ready)
+        triggerEvent(.ready)
     }
 
     fileprivate func setupLabel() {


### PR DESCRIPTION
# Goal
Make it possible to use the framework in Objective-C iOS/tvOS projects.

# How to test

- Create an iOS OR tvOS project and select Objective-C as the programming language. Create a view controller to display the player and setup the following:

```objective-c
#import "ViewController.h"
// Import the framework using the generated Umbrella header
#import <Clappr/Clappr-Swift.h>

// Declare a property for the player
@interface ViewController ()
@property Player *player;
@end

@implementation ViewController

// Add the player using the default initializer and attach it to a view
- (void)viewDidLoad {
    [super viewDidLoad];

    NSDictionary *options = @{@"sourceUrl": @"http://clappr.io/highline.mp4",
                              @"posterUrl": @"http://clappr.io/poster.png",
                              @"fullScreen": NO,
                              @"fullscreenDisabled": NO,
                              @"fullscreenByApp": NO,
                              @"startAt": @(0.0);
    
    self.player = [[Player alloc] initWithOptions:options externalPlugins:@[]];
    [self.player attachTo:self.view controller:self];

    // listen to player events
    [self listenToEvents];
}

- (void)listenToEvents {
    // Add events as needed
    [self.player on:@"playing" callback:^(NSDictionary * userInfo) {
        // execute code needed based on the triggered event
    }];
}

@end
```
- Run the app
- Run all tests