### PR TITLE
Destroy player

### DIFF
--- a/Sources/Clappr/Classes/View/DragDetectorView.swift
+++ b/Sources/Clappr/Classes/View/DragDetectorView.swift
@@ -10,7 +10,7 @@ open class DragDetectorView: UIView {
 
     @objc fileprivate(set) open var currentTouch: UITouch?
 
-    @objc open var target: AnyObject?
+    @objc open weak var target: AnyObject?
 
     @objc open var selector: Selector!
 

--- a/Sources/Clappr_iOS/Classes/Base/Core.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Core.swift
@@ -174,5 +174,6 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         mediaControl?.removeFromSuperview()
         mediaControl = nil
         fullscreenController = nil
+        removeFromSuperview()
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Core.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Core.swift
@@ -7,7 +7,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     @objc open var parentController: UIViewController?
     @objc open var parentView: UIView?
 
-    @objc private (set) lazy var fullscreenController = FullscreenController(nibName: nil, bundle: nil)
+    @objc private (set) var fullscreenController: FullscreenController? = FullscreenController(nibName: nil, bundle: nil)
 
     lazy var fullscreenHandler: FullscreenStateHandler = {
         return self.optionsUnboxer.fullscreenControledByApp ? FullscreenByApp(core: self) : FullscreenByPlayer(core: self) as FullscreenStateHandler
@@ -173,5 +173,6 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         Logger.logDebug("destroyed", scope: "Core")
         mediaControl?.removeFromSuperview()
         mediaControl = nil
+        fullscreenController = nil
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Core.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Core.swift
@@ -5,7 +5,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     @objc fileprivate(set) open var plugins: [UICorePlugin] = []
 
     @objc open weak var parentController: UIViewController?
-    @objc open weak var parentView: UIView?
+    @objc open var parentView: UIView?
 
     @objc private (set) var fullscreenController: FullscreenController? = FullscreenController(nibName: nil, bundle: nil)
 

--- a/Sources/Clappr_iOS/Classes/Base/Core.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Core.swift
@@ -4,8 +4,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     @objc fileprivate(set) open var mediaControl: MediaControl?
     @objc fileprivate(set) open var plugins: [UICorePlugin] = []
 
-    @objc open var parentController: UIViewController?
-    @objc open var parentView: UIView?
+    @objc open weak var parentController: UIViewController?
+    @objc open weak var parentView: UIView?
 
     @objc private (set) var fullscreenController: FullscreenController? = FullscreenController(nibName: nil, bundle: nil)
 

--- a/Sources/Clappr_iOS/Classes/Base/Core.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Core.swift
@@ -171,5 +171,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         trigger(InternalEvent.didDestroy.rawValue)
 
         Logger.logDebug("destroyed", scope: "Core")
+        mediaControl?.removeFromSuperview()
+        mediaControl = nil
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
+++ b/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
@@ -46,13 +46,14 @@ struct FullscreenByPlayer: FullscreenStateHandler {
     }
 
     func enterInFullscreen() {
+        guard let fullscreenController = core.fullscreenController else { return }
         guard !core.isFullscreen else { return }
         core.trigger(InternalEvent.willEnterFullscreen.rawValue)
         core.isFullscreen = true
-        core.fullscreenController.view.backgroundColor = UIColor.black
-        core.fullscreenController.modalPresentationStyle = .overFullScreen
-        core.parentController?.present(core.fullscreenController, animated: false, completion: nil)
-        core.fullscreenController.view.addSubviewMatchingConstraints(core)
+        fullscreenController.view.backgroundColor = UIColor.black
+        fullscreenController.modalPresentationStyle = .overFullScreen
+        core.parentController?.present(fullscreenController, animated: false, completion: nil)
+        fullscreenController.view.addSubviewMatchingConstraints(core)
         core.trigger(InternalEvent.didEnterFullscreen.rawValue)
         core.trigger(InternalEvent.userRequestEnterInFullscreen.rawValue)
     }
@@ -62,7 +63,7 @@ struct FullscreenByPlayer: FullscreenStateHandler {
         core.trigger(InternalEvent.willExitFullscreen.rawValue)
         core.isFullscreen = false
         core.parentView?.addSubviewMatchingConstraints(core)
-        core.fullscreenController.dismiss(animated: false, completion: nil)
+        core.fullscreenController?.dismiss(animated: false, completion: nil)
         core.trigger(InternalEvent.didExitFullscreen.rawValue)
         core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
     }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -140,7 +140,7 @@ class CoreTests: QuickSpec {
 
                         expect(callbackWasCall).toEventually(beTrue())
                         expect(core.parentView?.subviews.contains(core)).to(beFalse())
-                        expect(core.fullscreenController.view.subviews.contains(core)).to(beTrue())
+                        expect(core.fullscreenController?.view.subviews.contains(core)).to(beTrue())
                         expect(core.isFullscreen).to(beTrue())
                     }
 
@@ -190,7 +190,7 @@ class CoreTests: QuickSpec {
                         it("sets core as subview of fullscreenController") {
                             core.setFullscreen(true)
 
-                            expect(core.fullscreenController.view.subviews.contains(core)).to(beTrue())
+                            expect(core.fullscreenController?.view.subviews.contains(core)).to(beTrue())
                         }
 
                         it("set isFullscreen to true") {
@@ -202,13 +202,13 @@ class CoreTests: QuickSpec {
                         it("sets the backgroundColor of fullscreenController to black") {
                             core.setFullscreen(true)
 
-                            expect(core.fullscreenController.view.backgroundColor).to(equal(.black))
+                            expect(core.fullscreenController?.view.backgroundColor).to(equal(.black))
                         }
 
                         it("sets the modalPresentationStyle of fullscreenController to .overFullscreen") {
                             core.setFullscreen(true)
 
-                            expect(core.fullscreenController.modalPresentationStyle)
+                            expect(core.fullscreenController?.modalPresentationStyle)
                                 .to(equal(UIModalPresentationStyle.overFullScreen))
                         }
 
@@ -238,7 +238,7 @@ class CoreTests: QuickSpec {
                             core.setFullscreen(true)
                             core.setFullscreen(true)
 
-                            expect(core.fullscreenController.view.subviews.filter { $0 == core }.count).to(equal(1))
+                            expect(core.fullscreenController?.view.subviews.filter { $0 == core }.count).to(equal(1))
                         }
                     }
 
@@ -285,7 +285,7 @@ class CoreTests: QuickSpec {
                         it("removes core as subview of fullscreenController") {
                             core.setFullscreen(false)
 
-                            expect(core.fullscreenController.view.subviews).toNot(contain(core))
+                            expect(core.fullscreenController?.view.subviews).toNot(contain(core))
                         }
 
                         it("only set core as subview of parentView once") {

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -522,6 +522,18 @@ class CoreTests: QuickSpec {
 
                     expect(countOfContainers) == countOfDestroyedContainers
                 }
+                
+                it("clears mediaControl reference") {
+                    core.destroy()
+                    
+                    expect(core.mediaControl).toEventually(beNil())
+                }
+                
+                it("clears fullscreen reference") {
+                    core.destroy()
+                    
+                    expect(core.fullscreenController).toEventually(beNil())
+                }
             }
 
             context("when changes a activePlayback") {


### PR DESCRIPTION
## Goal
When we tried to call the method `destroy()` from a player instance we had memory issues with  `Core`, `FullscreenStateHandler` and `DragDetectorView` that were not deallocated.

Before:
![image](https://user-images.githubusercontent.com/5130095/41607832-591d14dc-73bd-11e8-9a8c-9edc7bb39b5c.png)

After:
![image 1](https://user-images.githubusercontent.com/5130095/41607821-52387fd0-73bd-11e8-9241-c272df0e0328.png)

## How to test
Download the [patch](https://gist.github.com/nabilsafatli/cc492a6ba4fe4b65358b51f7ef9d8f9d), and apply it by running the command `git apply {patch file}`

With this [patch](https://gist.github.com/nabilsafatli/cc492a6ba4fe4b65358b51f7ef9d8f9d), you will be able to open Clappr sample, disable the option of `enter fullscreen` and play the video many times creating new instances with the button to make sure that everything is being deallocated.