### PR TITLE
DVR Integration and Events

### DIFF
--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -26,4 +26,6 @@ public enum Event: String {
     case seek
     case willSeek
     case didSeek
+    case supportDVR
+    case usingDVR
 }

--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -16,6 +16,4 @@ public enum InternalEvent: String {
     case didDestroy
     case userRequestEnterInFullscreen
     case userRequestExitFullscreen
-    case supportDVR
-    case usingDVR
 }

--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -16,6 +16,6 @@ public enum InternalEvent: String {
     case didDestroy
     case userRequestEnterInFullscreen
     case userRequestExitFullscreen
-    case detectDVR
+    case supportDVR
     case usingDVR
 }

--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -17,4 +17,5 @@ public enum InternalEvent: String {
     case userRequestEnterInFullscreen
     case userRequestExitFullscreen
     case detectDVR
+    case usingDVR
 }

--- a/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
@@ -45,6 +45,7 @@ extension DVRPlugin {
     private func bindPlaybackEvents() {
         guard let playback = playback else { return }
         listenToOnce(playback, eventName: Event.bufferUpdate.rawValue) { [weak self] _ in self?.triggerDvrEvent() }
+        listenTo(playback, eventName: Event.didSeek.rawValue) { [weak self] (info: EventUserInfo) in self?.triggerDvrUsageEvent(info: info) }
     }
     
     private func bindContainerEvents() {
@@ -60,6 +61,13 @@ extension DVRPlugin {
         let userInfo = ["dvrEnabled": dvrEnabled,
                         "duration": duration] as [String : Any]
         playback?.trigger(InternalEvent.detectDVR.rawValue, userInfo: userInfo)
+    }
+    
+    func triggerDvrUsageEvent(info: EventUserInfo) {
+        guard let position = playback?.position else { return }
+        let dvrUsage = position < minDvrSize
+        let userInfo = ["dvrUsage": dvrUsage] as [String : Any]
+        playback?.trigger(InternalEvent.usingDVR.rawValue, userInfo: userInfo)
     }
 }
 

--- a/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
@@ -60,7 +60,7 @@ extension DVRPlugin {
         guard let duration = duration else { return }
         let userInfo = ["enabled": supportDVR,
                         "duration": duration] as [String : Any]
-        playback?.trigger(InternalEvent.supportDVR.rawValue, userInfo: userInfo)
+        playback?.trigger(Event.supportDVR.rawValue, userInfo: userInfo)
     }
 
     func triggerDvrUsageEvent(info: EventUserInfo) {
@@ -69,7 +69,7 @@ extension DVRPlugin {
         guard let currentTime = duration else { return }
         let dvrUsage = position < currentTime
         let userInfo = ["enabled": dvrUsage] as [String : Any]
-        playback?.trigger(InternalEvent.usingDVR.rawValue, userInfo: userInfo)
+        playback?.trigger(Event.usingDVR.rawValue, userInfo: userInfo)
     }
 }
 

--- a/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
@@ -55,20 +55,20 @@ extension DVRPlugin {
             self?.triggerDvrEvent()
         }
     }
-    
+
     func triggerDvrEvent() {
         guard let duration = duration else { return }
-        let userInfo = ["dvrEnabled": dvrEnabled,
+        let userInfo = ["enabled": supportDVR,
                         "duration": duration] as [String : Any]
-        playback?.trigger(InternalEvent.detectDVR.rawValue, userInfo: userInfo)
+        playback?.trigger(InternalEvent.supportDVR.rawValue, userInfo: userInfo)
     }
-    
+
     func triggerDvrUsageEvent(info: EventUserInfo) {
-        guard dvrEnabled else { return }
+        guard supportDVR else { return }
         guard let position = position else { return }
         guard let currentTime = duration else { return }
         let dvrUsage = position < currentTime
-        let userInfo = ["dvrUsage": dvrUsage] as [String : Any]
+        let userInfo = ["enabled": dvrUsage] as [String : Any]
         playback?.trigger(InternalEvent.usingDVR.rawValue, userInfo: userInfo)
     }
 }
@@ -91,7 +91,7 @@ extension DVRPlugin {
         return CMTimeGetSeconds(range.duration)
     }
     
-    private var dvrEnabled: Bool {
+    private var supportDVR: Bool {
         guard let duration = duration else { return false }
         return playback?.playbackType == .live && duration >= minDvrSize
     }

--- a/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
@@ -65,7 +65,8 @@ extension DVRPlugin {
     
     func triggerDvrUsageEvent(info: EventUserInfo) {
         guard let position = playback?.position else { return }
-        let dvrUsage = position < minDvrSize
+        guard let currentTime = duration else { return }
+        let dvrUsage = position < currentTime
         let userInfo = ["dvrUsage": dvrUsage] as [String : Any]
         playback?.trigger(InternalEvent.usingDVR.rawValue, userInfo: userInfo)
     }

--- a/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/DVRPlugin.swift
@@ -64,7 +64,8 @@ extension DVRPlugin {
     }
     
     func triggerDvrUsageEvent(info: EventUserInfo) {
-        guard let position = playback?.position else { return }
+        guard dvrEnabled else { return }
+        guard let position = position else { return }
         guard let currentTime = duration else { return }
         let dvrUsage = position < currentTime
         let userInfo = ["dvrUsage": dvrUsage] as [String : Any]
@@ -78,9 +79,16 @@ extension DVRPlugin {
         return 60
     }
     
-    var duration: Double? {
+    var position: Double? {
         guard let currentTime = playback?.player?.currentTime() else { return nil }
         return CMTimeGetSeconds(currentTime)
+    }
+    
+    var duration: Double? {
+        guard let range = playback?.player?.currentItem?.seekableTimeRanges.compactMap({ $0.timeRangeValue }).first else {
+            return nil
+        }
+        return CMTimeGetSeconds(range.duration)
     }
     
     private var dvrEnabled: Bool {

--- a/Tests/Clappr_Tests/AVPlayerItemStub.swift
+++ b/Tests/Clappr_Tests/AVPlayerItemStub.swift
@@ -2,10 +2,8 @@ import AVFoundation
 
 class AVPlayerItemStub: AVPlayerItem {
 
-    override var status: AVPlayerItemStatus {
-        return _status
-    }
-
+    var _seekableTimeRanges: [NSValue] = []
+    
     var didCallSeekWithCompletionHandler = false
 
     var _status: AVPlayerItemStatus = AVPlayerItemStatus.unknown
@@ -13,5 +11,22 @@ class AVPlayerItemStub: AVPlayerItem {
     override func seek(to time: CMTime, completionHandler: ((Bool) -> Void)?) {
         didCallSeekWithCompletionHandler = true
         completionHandler!(true)
+    }
+
+    override var seekableTimeRanges: [NSValue] {
+        return _seekableTimeRanges
+    }
+
+    override var status: AVPlayerItemStatus {
+        return _status
+    }
+    
+    func setSeekableTimeRange(with duration: Double) {        
+        let startCMTime = CMTime(seconds: 0, preferredTimescale: 1)
+        let durationCMTime = CMTime(seconds: duration, preferredTimescale: 1)
+        let cmTimeRange = CMTimeRange(start: startCMTime, duration: durationCMTime)
+        let timeRangeValue = NSValue(timeRange: cmTimeRange)
+        let seekableTimeRanges = [timeRangeValue]
+        _seekableTimeRanges = seekableTimeRanges
     }
 }

--- a/Tests/Clappr_Tests/AVPlayerStub.swift
+++ b/Tests/Clappr_Tests/AVPlayerStub.swift
@@ -2,6 +2,9 @@ import AVFoundation
 
 class AVPlayerStub: AVPlayer {
 
+    private var _currentTime: CMTime = CMTime(seconds: 0, preferredTimescale: 0)
+    var _item = AVPlayerItemStub(url: URL(string: "https://clappr.io/highline.mp4")!)
+
     override var currentItem: AVPlayerItem? {
         return _item
     }
@@ -9,10 +12,6 @@ class AVPlayerStub: AVPlayer {
     override func currentTime() -> CMTime {
         return _currentTime
     }
-    
-    private var _currentTime: CMTime = CMTime(seconds: 0, preferredTimescale: 0)
-    
-    var _item = AVPlayerItemStub(url: URL(string: "https://clappr.io/highline.mp4")!)
 
     func setStatus(to newStatus: AVPlayerItemStatus) {
         _item._status = newStatus
@@ -20,5 +19,9 @@ class AVPlayerStub: AVPlayer {
     
     func set(currentTime: CMTime) {
         _currentTime = currentTime
+    }
+    
+    func set(currentItem: AVPlayerItemStub) {
+        _item = currentItem
     }
 }

--- a/Tests/Clappr_Tests/DVRPluginTests.swift
+++ b/Tests/Clappr_Tests/DVRPluginTests.swift
@@ -77,6 +77,12 @@ class DVRPluginTests: QuickSpec {
                             expect(expectedDuration).toEventually(equal(duration))
                         }
                     }
+                    
+                    context("and has position less than current time") {
+                        it("triggers dvrUsage with enabled true") {
+                            
+                        }
+                    }
                 }
                 
                 context("and core triggers didChangeActivePlayback") {

--- a/Tests/Clappr_Tests/DVRPluginTests.swift
+++ b/Tests/Clappr_Tests/DVRPluginTests.swift
@@ -95,7 +95,7 @@ class DVRPluginTests: QuickSpec {
                         }
                     }
                     context("and has position more or equal to the current time") {
-                        fit("triggers dvrUsage with enabled false") {
+                        it("triggers dvrUsage with enabled false") {
                             let dvrPlugin = buildPlugin(duration: getMinDvrSize(),position: 60, playbackType: .live)
                             var didTriggerUsingDVR = true
                             var expectedUsingDvr: Bool? = true

--- a/Tests/Clappr_Tests/DVRPluginTests.swift
+++ b/Tests/Clappr_Tests/DVRPluginTests.swift
@@ -27,7 +27,7 @@ class DVRPluginTests: QuickSpec {
                     let dvrPlugin = buildPlugin(duration: getMinDvrSize(), playbackType: .live)
                     var didTriggerDetectDvr = false
                     var expectedDuration: Double?
-                    dvrPlugin.core?.activePlayback?.on(InternalEvent.detectDVR.rawValue) { (userInfo: EventUserInfo) in
+                    dvrPlugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                         didTriggerDetectDvr = true
                         expectedDuration = userInfo?["duration"] as? Double
                     }
@@ -48,8 +48,8 @@ class DVRPluginTests: QuickSpec {
                             let dvrPlugin = buildPlugin(duration: getMinDvrSize(), playbackType: .live)
                             var didHaveDvr = false
                             var expectedDuration: Double?
-                            dvrPlugin.core?.activePlayback?.on(InternalEvent.detectDVR.rawValue) { (userInfo: EventUserInfo) in
-                                didHaveDvr = (userInfo?["dvrEnabled"] as? Bool) ?? false
+                            dvrPlugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                                didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
                             
@@ -66,8 +66,8 @@ class DVRPluginTests: QuickSpec {
                             let plugin = buildPlugin(duration: getMinDvrSize() - 10, playbackType: .live)
                             var didHaveDvr = true
                             var expectedDuration: Double?
-                            plugin.core?.activePlayback?.on(InternalEvent.detectDVR.rawValue) { (userInfo: EventUserInfo) in
-                                didHaveDvr = (userInfo?["dvrEnabled"] as? Bool) ?? false
+                            plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                                didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
                             
@@ -85,7 +85,7 @@ class DVRPluginTests: QuickSpec {
                             var expectedUsingDvr: Bool? = false
                             dvrPlugin.core?.activePlayback?.on(InternalEvent.usingDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didTriggerUsingDVR = true
-                                expectedUsingDvr = userInfo?["dvrUsage"] as? Bool
+                                expectedUsingDvr = userInfo?["enabled"] as? Bool
                             }
                             
                             dvrPlugin.core?.activePlayback?.trigger(Event.didSeek.rawValue)
@@ -101,7 +101,7 @@ class DVRPluginTests: QuickSpec {
                             var expectedUsingDvr: Bool? = true
                             dvrPlugin.core?.activePlayback?.on(InternalEvent.usingDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didTriggerUsingDVR = true
-                                expectedUsingDvr = userInfo?["dvrUsage"] as? Bool
+                                expectedUsingDvr = userInfo?["enabled"] as? Bool
                             }
                             
                             dvrPlugin.core?.activePlayback?.trigger(Event.didSeek.rawValue)
@@ -120,8 +120,8 @@ class DVRPluginTests: QuickSpec {
                             let plugin = buildPlugin(duration: getMinDvrSize(), playbackType: .live)
                             var didHaveDvr = false
                             var expectedDuration: Double?
-                            plugin.core?.activePlayback?.on(InternalEvent.detectDVR.rawValue) { (userInfo: EventUserInfo) in
-                                didHaveDvr = (userInfo?["dvrEnabled"] as? Bool) ?? false
+                            plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                                didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
                             
@@ -139,8 +139,8 @@ class DVRPluginTests: QuickSpec {
                             let plugin = buildPlugin(duration: duration, playbackType: .live)
                             var didHaveDvr = true
                             var expectedDuration: Double?
-                            plugin.core?.activePlayback?.on(InternalEvent.detectDVR.rawValue) { (userInfo: EventUserInfo) in
-                                didHaveDvr = (userInfo?["dvrEnabled"] as? Bool) ?? false
+                            plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                                didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
                             
@@ -160,8 +160,8 @@ class DVRPluginTests: QuickSpec {
                         let plugin = buildPlugin(duration: getMinDvrSize(), playbackType: .vod)
                         var didHaveDvr = true
                         var expectedDuration: Double?
-                        plugin.core?.activePlayback?.on(InternalEvent.detectDVR.rawValue) { (userInfo: EventUserInfo) in
-                            didHaveDvr = (userInfo?["dvrEnabled"] as? Bool) ?? false
+                        plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                            didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                             expectedDuration = userInfo?["duration"] as? Double
                         }
                         
@@ -177,36 +177,42 @@ class DVRPluginTests: QuickSpec {
                         let plugin = buildPlugin(duration: getMinDvrSize(), playbackType: .vod)
                         var didHaveDvr = true
                         var expectedDuration: Double?
-                        plugin.core?.activePlayback?.on(InternalEvent.detectDVR.rawValue) { (userInfo: EventUserInfo) in
-                            didHaveDvr = (userInfo?["dvrEnabled"] as? Bool) ?? false
+                        plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                            didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                             expectedDuration = userInfo?["duration"] as? Double
                         }
-                        
+
                         plugin.core?.trigger(InternalEvent.didChangeActiveContainer.rawValue)
-                        
+
                         expect(didHaveDvr).toEventually(beFalse())
                         expect(expectedDuration).toEventually(equal(getMinDvrSize()))
                     }
                 }
             }
-            
+
             func getMinDvrSize() -> Double {
                 return DVRPlugin().minDvrSize
             }
             
-            func buildPlugin(duration seconds: Double, position: Double = 0, playbackType: PlaybackType) -> DVRPlugin {
+            func buildPlugin(duration: Double, position: Double = 0, playbackType: PlaybackType) -> DVRPlugin {
                 core = Core()
                 container = Container()
                 core.activeContainer = container
                 
                 let playback = AVFoundationPlaybackStub()
                 let player = AVPlayerStub()
-                player.set(currentTime: CMTime(seconds: seconds, preferredTimescale: 1))
+                let item = AVPlayerItemStub(url: URL(string: "https://www.google.com")!)
+                let positionCMTime = CMTime(seconds: position, preferredTimescale: 1)
+                
+                item.setSeekableTimeRange(with: duration)
+                player.set(currentItem: item)
+                player.set(currentTime: positionCMTime)
                 playback.player = player
                 playback.set(playbackType: playbackType)
                 playback.set(position: position)
-                core.activeContainer?.playback = playback
                 
+                core.activeContainer?.playback = playback
+
                 return DVRPlugin(context: core)
             }
         }

--- a/Tests/Clappr_Tests/DVRPluginTests.swift
+++ b/Tests/Clappr_Tests/DVRPluginTests.swift
@@ -106,7 +106,7 @@ class DVRPluginTests: QuickSpec {
                             
                             dvrPlugin.core?.activePlayback?.trigger(Event.didSeek.rawValue)
                             
-                            expect(didTriggerUsingDVR).toEventually(beFalse())
+                            expect(didTriggerUsingDVR).toEventually(beTrue())
                             expect(expectedUsingDvr).toEventually(beFalse())
                         }
                     }

--- a/Tests/Clappr_Tests/DVRPluginTests.swift
+++ b/Tests/Clappr_Tests/DVRPluginTests.swift
@@ -27,7 +27,7 @@ class DVRPluginTests: QuickSpec {
                     let dvrPlugin = buildPlugin(duration: getMinDvrSize(), playbackType: .live)
                     var didTriggerDetectDvr = false
                     var expectedDuration: Double?
-                    dvrPlugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                    dvrPlugin.core?.activePlayback?.on(Event.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                         didTriggerDetectDvr = true
                         expectedDuration = userInfo?["duration"] as? Double
                     }
@@ -48,7 +48,7 @@ class DVRPluginTests: QuickSpec {
                             let dvrPlugin = buildPlugin(duration: getMinDvrSize(), playbackType: .live)
                             var didHaveDvr = false
                             var expectedDuration: Double?
-                            dvrPlugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                            dvrPlugin.core?.activePlayback?.on(Event.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
@@ -66,7 +66,7 @@ class DVRPluginTests: QuickSpec {
                             let plugin = buildPlugin(duration: getMinDvrSize() - 10, playbackType: .live)
                             var didHaveDvr = true
                             var expectedDuration: Double?
-                            plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                            plugin.core?.activePlayback?.on(Event.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
@@ -83,7 +83,7 @@ class DVRPluginTests: QuickSpec {
                             let dvrPlugin = buildPlugin(duration: getMinDvrSize(),position: -10, playbackType: .live)
                             var didTriggerUsingDVR = false
                             var expectedUsingDvr: Bool? = false
-                            dvrPlugin.core?.activePlayback?.on(InternalEvent.usingDVR.rawValue) { (userInfo: EventUserInfo) in
+                            dvrPlugin.core?.activePlayback?.on(Event.usingDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didTriggerUsingDVR = true
                                 expectedUsingDvr = userInfo?["enabled"] as? Bool
                             }
@@ -99,7 +99,7 @@ class DVRPluginTests: QuickSpec {
                             let dvrPlugin = buildPlugin(duration: getMinDvrSize(),position: 60, playbackType: .live)
                             var didTriggerUsingDVR = true
                             var expectedUsingDvr: Bool? = true
-                            dvrPlugin.core?.activePlayback?.on(InternalEvent.usingDVR.rawValue) { (userInfo: EventUserInfo) in
+                            dvrPlugin.core?.activePlayback?.on(Event.usingDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didTriggerUsingDVR = true
                                 expectedUsingDvr = userInfo?["enabled"] as? Bool
                             }
@@ -120,7 +120,7 @@ class DVRPluginTests: QuickSpec {
                             let plugin = buildPlugin(duration: getMinDvrSize(), playbackType: .live)
                             var didHaveDvr = false
                             var expectedDuration: Double?
-                            plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                            plugin.core?.activePlayback?.on(Event.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
@@ -139,7 +139,7 @@ class DVRPluginTests: QuickSpec {
                             let plugin = buildPlugin(duration: duration, playbackType: .live)
                             var didHaveDvr = true
                             var expectedDuration: Double?
-                            plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                            plugin.core?.activePlayback?.on(Event.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                                 didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                                 expectedDuration = userInfo?["duration"] as? Double
                             }
@@ -160,7 +160,7 @@ class DVRPluginTests: QuickSpec {
                         let plugin = buildPlugin(duration: getMinDvrSize(), playbackType: .vod)
                         var didHaveDvr = true
                         var expectedDuration: Double?
-                        plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                        plugin.core?.activePlayback?.on(Event.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                             didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                             expectedDuration = userInfo?["duration"] as? Double
                         }
@@ -177,7 +177,7 @@ class DVRPluginTests: QuickSpec {
                         let plugin = buildPlugin(duration: getMinDvrSize(), playbackType: .vod)
                         var didHaveDvr = true
                         var expectedDuration: Double?
-                        plugin.core?.activePlayback?.on(InternalEvent.supportDVR.rawValue) { (userInfo: EventUserInfo) in
+                        plugin.core?.activePlayback?.on(Event.supportDVR.rawValue) { (userInfo: EventUserInfo) in
                             didHaveDvr = (userInfo?["enabled"] as? Bool) ?? false
                             expectedDuration = userInfo?["duration"] as? Double
                         }

--- a/Tests/Clappr_Tests/DVRPluginTests.swift
+++ b/Tests/Clappr_Tests/DVRPluginTests.swift
@@ -94,6 +94,22 @@ class DVRPluginTests: QuickSpec {
                             expect(expectedUsingDvr).toEventually(beTrue())
                         }
                     }
+                    context("and has position more or equal to the current time") {
+                        fit("triggers dvrUsage with enabled false") {
+                            let dvrPlugin = buildPlugin(duration: getMinDvrSize(),position: 60, playbackType: .live)
+                            var didTriggerUsingDVR = true
+                            var expectedUsingDvr: Bool? = true
+                            dvrPlugin.core?.activePlayback?.on(InternalEvent.usingDVR.rawValue) { (userInfo: EventUserInfo) in
+                                didTriggerUsingDVR = true
+                                expectedUsingDvr = userInfo?["dvrUsage"] as? Bool
+                            }
+                            
+                            dvrPlugin.core?.activePlayback?.trigger(Event.didSeek.rawValue)
+                            
+                            expect(didTriggerUsingDVR).toEventually(beFalse())
+                            expect(expectedUsingDvr).toEventually(beFalse())
+                        }
+                    }
                 }
                 
                 context("and core triggers didChangeActivePlayback") {


### PR DESCRIPTION
### Goal

Implement two events to make sure that DVR works in the player and other plugins have what they need of information to change when necessary

- `supportDVR` The current live media being played, supports DVR
- `usingDVR` The current live media being played is using the DVR ( it means that the scrubber is not in the end of the scrubber)