### PR TITLE
Add DVR minimum size to Options

### DIFF
--- a/Sources/Clappr_iOS/Classes/Base/Options.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Options.swift
@@ -11,7 +11,7 @@ public let kPlaybackNotSupportedMessage = "playbackNotSupportedMessage"
 public let kMimeType = "mimeType"
 public let kDefaultSubtitle = "defaultSubtitle"
 public let kDefaultAudioSource = "defaultAudioSource"
-public let kMinDvrOption = "minDvrTime"
+public let kMinDvrSize = "minDvrSize"
 
 struct OptionsUnboxer {
     let options: Options

--- a/Sources/Clappr_iOS/Classes/Base/Options.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Options.swift
@@ -11,6 +11,7 @@ public let kPlaybackNotSupportedMessage = "playbackNotSupportedMessage"
 public let kMimeType = "mimeType"
 public let kDefaultSubtitle = "defaultSubtitle"
 public let kDefaultAudioSource = "defaultAudioSource"
+public let kMinDvrOption = "minDvrTime"
 
 struct OptionsUnboxer {
     let options: Options

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -542,7 +542,7 @@ open class AVFoundationPlayback: Playback {
 // MARK: - DVR
 extension AVFoundationPlayback {
     open override var minDvrSize: Double {
-        return self.options[kMinDvrOption] as? Double ?? 60.0
+        return self.options[kMinDvrSize] as? Double ?? 60.0
     }
 
     open override var usingDVR: Bool {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -542,7 +542,7 @@ open class AVFoundationPlayback: Playback {
 // MARK: - DVR
 extension AVFoundationPlayback {
     open override var minDvrSize: Double {
-        return 60.0
+        return self.options[kMinDvrOption] as? Double ?? 60.0
     }
 
     open override var usingDVR: Bool {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -41,7 +41,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 describe("#minDvrSize") {
                     context("when minDvrOption has correct type value") {
                         it("return minDvrOption value") {
-                            let options = [kMinDvrOption: 15.1]
+                            let options = [kMinDvrSize: 15.1]
                             let playback = AVFoundationPlayback(options: options)
 
                             expect(playback.minDvrSize).to(equal(15.1))
@@ -49,7 +49,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
                     context("when minDvrOption has wrong type value") {
                         it("return default value") {
-                            let options = [kMinDvrOption: 15]
+                            let options = [kMinDvrSize: 15]
                             let playback = AVFoundationPlayback(options: options)
 
                             expect(playback.minDvrSize).to(equal(60))

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -39,8 +39,26 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 describe("#minDvrSize") {
-                    it("returns 60") {
-                        expect(playback.minDvrSize).to(equal(60))
+                    context("when minDvrOption has correct type value") {
+                        it("return minDvrOption value") {
+                            let options = [kMinDvrOption: 15.1]
+                            let playback = AVFoundationPlayback(options: options)
+
+                            expect(playback.minDvrSize).to(equal(15.1))
+                        }
+                    }
+                    context("when minDvrOption has wrong type value") {
+                        it("return default value") {
+                            let options = [kMinDvrOption: 15]
+                            let playback = AVFoundationPlayback(options: options)
+
+                            expect(playback.minDvrSize).to(equal(60))
+                        }
+                    }
+                    context("when minDvrOption has no value") {
+                        it("returns default value") {
+                            expect(playback.minDvrSize).to(equal(60))
+                        }
                     }
                 }
 


### PR DESCRIPTION
### Goal
Enable minDvrTime be set by options

### How to test
1 - In Example app set the option[kMinDvrOption] to 15
2 - Run the app and check if is possible make a seek in a Live video
3 - Run all tests