### PR TITLE
Adds a property to return the position inside a DVR window

### DIFF
--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -142,4 +142,8 @@ extension Playback {
     @objc open var supportDVR: Bool {
         return false
     }
+
+    @objc open var dvrPosition: Double {
+        return 0
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -127,7 +127,7 @@ extension Playback {
         return 0
     }
 
-    @objc var usingDVR: Bool {
+    @objc open var usingDVR: Bool {
         return false
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -565,4 +565,16 @@ extension AVFoundationPlayback {
         guard playbackType == .live else { return false }
         return seekableTimeRanges.first(where: { $0.timeRangeValue.duration.seconds >= minDvrSize}) != nil
     }
+
+    open override var dvrPosition: Double {
+        if let start = seekableTimeRanges.first?.timeRangeValue.start.seconds,
+            let end = seekableTimeRanges.first?.timeRangeValue.end.seconds {
+            let position = player?.currentItem?.currentTime().seconds
+            var calculatedPosition = (position! - start) * 100
+            calculatedPosition = calculatedPosition / ((end - start) / 100)
+            calculatedPosition = (calculatedPosition * duration) / 10000
+            return calculatedPosition
+        }
+        return position
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -568,9 +568,9 @@ extension AVFoundationPlayback {
 
     open override var dvrPosition: Double {
         if let start = seekableTimeRanges.first?.timeRangeValue.start.seconds,
-            let end = seekableTimeRanges.first?.timeRangeValue.end.seconds {
-            let position = player?.currentItem?.currentTime().seconds
-            var calculatedPosition = (position! - start) * 100
+            let end = seekableTimeRanges.first?.timeRangeValue.end.seconds,
+            let position = player?.currentItem?.currentTime().seconds {
+            var calculatedPosition = (position - start) * 100
             calculatedPosition = calculatedPosition / ((end - start) / 100)
             calculatedPosition = (calculatedPosition * duration) / 10000
             return calculatedPosition

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -284,7 +284,7 @@ open class AVFoundationPlayback: Playback {
         if supportDVR {
             var timeToSeek = timeInterval
 
-            if let seekStartTime = seekableTimeRanges.first?.timeRangeValue.start.seconds {
+            if let seekStartTime = dvrWindowStart {
                 timeToSeek = timeToSeek + seekStartTime
             }
 
@@ -563,8 +563,8 @@ extension AVFoundationPlayback {
     }
 
     open override var dvrPosition: Double {
-        if let start = seekableTimeRanges.first?.timeRangeValue.start.seconds,
-            let end = seekableTimeRanges.first?.timeRangeValue.end.seconds,
+        if let start = dvrWindowStart,
+            let end = dvrWindowEnd,
             let position = player?.currentItem?.currentTime().seconds {
             var calculatedPosition = (position - start) * 100
             calculatedPosition = calculatedPosition / ((end - start) / 100)
@@ -572,5 +572,13 @@ extension AVFoundationPlayback {
             return calculatedPosition
         }
         return position
+    }
+
+    private var dvrWindowStart: Double? {
+        return seekableTimeRanges.min { rangeA, rangeB in rangeA.timeRangeValue.start.seconds < rangeB.timeRangeValue.start.seconds }?.timeRangeValue.start.seconds
+    }
+
+    private var dvrWindowEnd: Double? {
+        return seekableTimeRanges.max { rangeA, rangeB in rangeA.timeRangeValue.end.seconds < rangeB.timeRangeValue.end.seconds }?.timeRangeValue.end.seconds
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -280,15 +280,11 @@ open class AVFoundationPlayback: Playback {
         return player?.currentItem?.status == .readyToPlay
     }
 
-    private func getSeekableTimeRange(with timeInterval: TimeInterval) -> CMTimeRange? {
-        return seekableTimeRanges.first(where: { $0.timeRangeValue.start.seconds >= timeInterval && timeInterval < $0.timeRangeValue.end.seconds })?.timeRangeValue
-    }
-
     open override func seek(_ timeInterval: TimeInterval) {
         if supportDVR {
             var timeToSeek = timeInterval
 
-            if let seekStartTime = getSeekableTimeRange(with: timeInterval)?.start.seconds {
+            if let seekStartTime = seekableTimeRanges.first?.timeRangeValue.start.seconds {
                 timeToSeek = timeToSeek + seekStartTime
             }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -180,6 +180,16 @@ class AVFoundationPlaybackTests: QuickSpec {
                         }
                     }
                 }
+
+                describe("#dvrPosition") {
+                    it("returns the position inside the DVR window") {
+                        asset.set(duration: CMTime(seconds: 50, preferredTimescale: 1))
+                        item._currentTime = CMTime(seconds: 125, preferredTimescale: 1)
+                        item.setWindow(start: 100, end: 150)
+
+                        expect(playback.dvrPosition).to(equal(25))
+                    }
+                }
             }
 
             describe("#duration") {

--- a/Tests/Clappr_Tests/AVPlayerItemStub.swift
+++ b/Tests/Clappr_Tests/AVPlayerItemStub.swift
@@ -6,6 +6,8 @@ class AVPlayerItemStub: AVPlayerItem {
     var _loadedTimeRanges: [NSValue] = []
 
     var _duration: CMTime = CMTime(seconds: 0, preferredTimescale: 0)
+
+    var _currentTime: CMTime = CMTime(seconds: 0, preferredTimescale: 0)
     
     var didCallSeekWithCompletionHandler = false
 
@@ -28,14 +30,18 @@ class AVPlayerItemStub: AVPlayerItem {
         return _status
     }
 
-    func createTimeRangeValue(with duration: Double) -> CMTimeRange {
-        let startCMTime = CMTime(seconds: 0, preferredTimescale: 1)
+    func createTimeRangeValue(with duration: Double, start: Double = 0) -> CMTimeRange {
+        let startCMTime = CMTime(seconds: start, preferredTimescale: 1)
         let durationCMTime = CMTime(seconds: duration, preferredTimescale: 1)
         return CMTimeRange(start: startCMTime, duration: durationCMTime)
     }
 
-    func setSeekableTimeRange(with duration: Double) {        
+    func setSeekableTimeRange(with duration: Double) {
         _seekableTimeRanges = [NSValue(timeRange: createTimeRangeValue(with: duration))]
+    }
+
+    func setWindow(start: Double, end: Double) {
+        _seekableTimeRanges = [NSValue(timeRange: createTimeRangeValue(with: end - start, start: start))]
     }
 
     func setLoadedTimeRanges(with duration: Double) {
@@ -44,5 +50,9 @@ class AVPlayerItemStub: AVPlayerItem {
 
     override var duration: CMTime {
         return _duration
+    }
+
+    override func currentTime() -> CMTime {
+        return _currentTime
     }
 }


### PR DESCRIPTION
# Goal

Adds a property that returns the position inside a DVR window. Let's say we have a window of 60 seconds, starting at the second 120 and ending in 180.

If the position is `150` the `dvrPosition` should return `30` (a value between `0` and the duration of the window)