### PR TITLE
Fix pod push in fastlane script to allow warnings

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,7 +131,9 @@ platform :ios do
       description: "TODO: write release notes here"
     )
 
-    pod_push
+    pod_push(
+      allow_warnings: true
+    )
   end
 
   # You can define as many lanes as you want


### PR DESCRIPTION
### Goal
Allow coocoapods publication when the framework has warnings. 