### PR TITLE
Expose property to inform media current date

### DIFF
--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -146,4 +146,8 @@ extension Playback {
     @objc open var dvrPosition: Double {
         return 0
     }
+
+    @objc open var currentDate: Date? {
+        return nil
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -574,7 +574,7 @@ extension AVFoundationPlayback {
         return position
     }
 
-    open var currentDate: Date? {
+    open override var currentDate: Date? {
         return player?.currentItem?.currentDate()
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -574,6 +574,10 @@ extension AVFoundationPlayback {
         return position
     }
 
+    open var currentDate: Date? {
+        return player?.currentItem?.currentDate()
+    }
+
     private var dvrWindowStart: Double? {
         return seekableTimeRanges.min { rangeA, rangeB in rangeA.timeRangeValue.start.seconds < rangeB.timeRangeValue.start.seconds }?.timeRangeValue.start.seconds
     }

--- a/Sources/Clappr_tvOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Playback.swift
@@ -155,4 +155,8 @@ extension Playback {
     @objc open var dvrPosition: Double {
         return 0
     }
+
+    @objc open var currentDate: Date? {
+        return nil
+    }
 }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -208,6 +208,15 @@ class AVFoundationPlaybackTests: QuickSpec {
                         expect(playback.dvrPosition).to(equal(25))
                     }
                 }
+
+                describe("#currentDate") {
+                    it("returns the currentDate of the video") {
+                        let date = Date()
+                        item.set(currentDate: date)
+                        
+                        expect(playback.currentDate).to(equal(date))
+                    }
+                }
             }
 
             describe("#duration") {

--- a/Tests/Clappr_Tests/AVPlayerItemStub.swift
+++ b/Tests/Clappr_Tests/AVPlayerItemStub.swift
@@ -13,6 +13,8 @@ class AVPlayerItemStub: AVPlayerItem {
 
     var _status: AVPlayerItemStatus = AVPlayerItemStatus.unknown
 
+    var _currentDate: Date = Date()
+
     override func seek(to time: CMTime, completionHandler: ((Bool) -> Void)?) {
         didCallSeekWithCompletionHandler = true
         completionHandler!(true)
@@ -48,11 +50,19 @@ class AVPlayerItemStub: AVPlayerItem {
         _loadedTimeRanges = [NSValue(timeRange: createTimeRangeValue(with: duration))]
     }
 
+    func set(currentDate: Date) {
+        _currentDate = currentDate
+    }
+
     override var duration: CMTime {
         return _duration
     }
 
     override func currentTime() -> CMTime {
         return _currentTime
+    }
+
+    override func currentDate() -> Date? {
+        return _currentDate
     }
 }


### PR DESCRIPTION
### Goal

To get the thumbseek image for a live video with dvr, it is necessary to obtain the date of the media. So, we need to expose a property informing the media current date. 

### Additional Information

This property is loaded from master playlist tag `#EXT-X-PROGRAM-DATE-TIME`. 

### How to test

Run `make test`.