### PR TITLE
Refactoring DVR to keep Clappr architecture consistency

### DIFF
--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -26,6 +26,6 @@ public enum Event: String {
     case seek
     case willSeek
     case didSeek
-    case usingDVR
+    case didChangeDvrStatus
     case seekableUpdate
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -28,4 +28,5 @@ public enum Event: String {
     case didSeek
     case didChangeDvrStatus
     case seekableUpdate
+    case didChangeDvrAvailability
 }

--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -110,6 +110,7 @@ open class Playback: UIBaseObject, Plugin {
     @objc open func pause() {}
     @objc open func stop() {}
     @objc open func seek(_: TimeInterval) {}
+    @objc open func seekToLivePosition() {}
 
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Playback")

--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -136,10 +136,6 @@ extension Playback {
         return false
     }
 
-    @objc open var dvrPosition: Double {
-        return 0
-    }
-
     @objc open var currentDate: Date? {
         return nil
     }

--- a/Sources/Clappr_iOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Playback.swift
@@ -127,19 +127,11 @@ extension Playback {
         return 0
     }
 
-    @objc open var usingDVR: Bool {
+    @objc open var isDvrInUse: Bool {
         return false
     }
 
-    @objc open var seekableTimeRanges: [NSValue] {
-        return []
-    }
-
-    @objc open var loadedTimeRanges: [NSValue] {
-       return []
-    }
-
-    @objc open var supportDVR: Bool {
+    @objc open var isDvrAvailable: Bool {
         return false
     }
 
@@ -149,5 +141,13 @@ extension Playback {
 
     @objc open var currentDate: Date? {
         return nil
+    }
+    
+    @objc open var seekableTimeRanges: [NSValue] {
+        return []
+    }
+    
+    @objc open var loadedTimeRanges: [NSValue] {
+        return []
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -131,6 +131,15 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override var position: Double {
+        if let start = dvrWindowStart,
+            let end = dvrWindowEnd,
+            let position = player?.currentItem?.currentTime().seconds {
+            var calculatedPosition = (position - start) * 100
+            calculatedPosition = calculatedPosition / ((end - start) / 100)
+            calculatedPosition = (calculatedPosition * duration) / 10000
+            return calculatedPosition
+        }
+        
         guard playbackType == .vod, let player = self.player else {
             return 0
         }
@@ -572,6 +581,7 @@ extension AVFoundationPlayback {
     open override var currentDate: Date? {
         return player?.currentItem?.currentDate()
     }
+
     open override var seekableTimeRanges: [NSValue] {
         guard let ranges = player?.currentItem?.seekableTimeRanges else { return [] }
         return ranges

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -593,10 +593,16 @@ extension AVFoundationPlayback {
     }
 
     private var dvrWindowStart: Double? {
-        return seekableTimeRanges.min { rangeA, rangeB in rangeA.timeRangeValue.start.seconds < rangeB.timeRangeValue.start.seconds }?.timeRangeValue.start.seconds
+        guard let end = dvrWindowEnd, isDvrAvailable, playbackType == .live else {
+            return nil
+        }
+        return end - duration
     }
 
     private var dvrWindowEnd: Double? {
+        guard isDvrAvailable, playbackType == .live else {
+            return nil
+        }
         return seekableTimeRanges.max { rangeA, rangeB in rangeA.timeRangeValue.end.seconds < rangeB.timeRangeValue.end.seconds }?.timeRangeValue.end.seconds
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -568,9 +568,9 @@ extension AVFoundationPlayback {
     }
 
     open override var isDvrInUse: Bool {
-        guard playbackType == .live else { return false }
+        guard let end = dvrWindowEnd, playbackType == .live else { return false }
         guard let currentTime = player?.currentTime().seconds else { return false }
-        return seekableTimeRanges.first(where: { $0.timeRangeValue.end.seconds > currentTime}) != nil
+        return end > currentTime
     }
 
     open override var isDvrAvailable: Bool {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -120,11 +120,11 @@ open class AVFoundationPlayback: Playback {
             return CMTimeGetSeconds(item.asset.duration)
         }
         
-        if playbackType == .live, isDvrAvailable {
-            var liveDuration: Double = 0
-            for seekableTimeRange in seekableTimeRanges {
-                liveDuration += seekableTimeRange.timeRangeValue.duration.seconds
-            }
+        if playbackType == .live {
+            let liveDuration = seekableTimeRanges.reduce(0.0, { previous, current in
+                return previous + current.timeRangeValue.duration.seconds
+            })
+
             return liveDuration
         }
 
@@ -572,13 +572,8 @@ extension AVFoundationPlayback {
 
     open override var isDvrAvailable: Bool {
         guard playbackType == .live else { return false }
-        var liveDuration: Double = 0
         
-        for seekableTimeRange in seekableTimeRanges {
-            liveDuration += seekableTimeRange.timeRangeValue.duration.seconds
-        }
-        
-        return liveDuration >= minDvrSize
+        return duration >= minDvrSize
     }
 
     open override var currentDate: Date? {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -120,7 +120,7 @@ open class AVFoundationPlayback: Playback {
         }
 
         if playbackType == .live {
-            if supportDVR, let duration = seekableTimeRanges.first?.timeRangeValue.duration.seconds {
+            if isDvrAvailable, let duration = seekableTimeRanges.first?.timeRangeValue.duration.seconds {
                 return duration
             } else {
                 return 0
@@ -281,7 +281,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override func seek(_ timeInterval: TimeInterval) {
-        if supportDVR {
+        if isDvrAvailable {
             var timeToSeek = timeInterval
 
             if let seekStartTime = dvrWindowStart {
@@ -541,23 +541,13 @@ extension AVFoundationPlayback {
         return self.options[kMinDvrSize] as? Double ?? 60.0
     }
 
-    open override var usingDVR: Bool {
+    open override var isDvrInUse: Bool {
         guard playbackType == .live else { return false }
         guard let currentTime = player?.currentTime().seconds else { return false }
         return seekableTimeRanges.first(where: { $0.timeRangeValue.end.seconds > currentTime}) != nil
     }
 
-    open override var seekableTimeRanges: [NSValue] {
-        guard let ranges = player?.currentItem?.seekableTimeRanges else { return [] }
-        return ranges
-    }
-
-    open override var loadedTimeRanges: [NSValue] {
-        guard let ranges = player?.currentItem?.loadedTimeRanges else { return [] }
-        return ranges
-    }
-
-    open override var supportDVR: Bool {
+    open override var isDvrAvailable: Bool {
         guard playbackType == .live else { return false }
         return seekableTimeRanges.first(where: { $0.timeRangeValue.duration.seconds >= minDvrSize}) != nil
     }
@@ -576,6 +566,15 @@ extension AVFoundationPlayback {
 
     open override var currentDate: Date? {
         return player?.currentItem?.currentDate()
+    }
+    open override var seekableTimeRanges: [NSValue] {
+        guard let ranges = player?.currentItem?.seekableTimeRanges else { return [] }
+        return ranges
+    }
+
+    open override var loadedTimeRanges: [NSValue] {
+        guard let ranges = player?.currentItem?.loadedTimeRanges else { return [] }
+        return ranges
     }
 
     private var dvrWindowStart: Double? {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -38,7 +38,7 @@ open class AVFoundationPlayback: Playback {
     }
     fileprivate var timeObserver: Any?
     fileprivate var asset: AVURLAsset?
-    private var lastDvrAvailability: Bool?
+    var lastDvrAvailability: Bool?
 
     private var backgroundSessionBackup: String?
 
@@ -486,7 +486,7 @@ open class AVFoundationPlayback: Playback {
         handleDvrAvailabilityChange()
     }
 
-    fileprivate func handleDvrAvailabilityChange() {
+    func handleDvrAvailabilityChange() {
         if lastDvrAvailability != isDvrAvailable {
             trigger(.didChangeDvrAvailability, userInfo: ["available": isDvrAvailable])
             lastDvrAvailability = isDvrAvailable

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -372,6 +372,9 @@ open class AVFoundationPlayback: Playback {
             trigger(.stalled)
         case .paused:
             trigger(.didPause)
+            if isDvrAvailable {
+                triggerDvrStatusIfNeeded()
+            }
         case .playing:
             trigger(.playing)
         default:

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -299,13 +299,15 @@ open class AVFoundationPlayback: Playback {
             }
 
             seek(timeToSeek) { [weak self] in
-                if let usingDVR = self?.isDvrInUse {
-                    self?.trigger(.didChangeDvrStatus, userInfo: ["inUse": usingDVR])
-                }
+                self?.triggerDvrStatusIfNeeded()
             }
         } else {
             seek(timeInterval, nil)
         }
+    }
+
+    private func triggerDvrStatusIfNeeded() {
+        trigger(.didChangeDvrStatus, userInfo: ["inUse": isDvrInUse])
     }
 
     private func seek(_ timeInterval: TimeInterval, _ triggerEvent: (() -> Void)?) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -575,18 +575,6 @@ extension AVFoundationPlayback {
         return seekableTimeRanges.first(where: { $0.timeRangeValue.duration.seconds >= minDvrSize}) != nil
     }
 
-    open override var dvrPosition: Double {
-        if let start = dvrWindowStart,
-            let end = dvrWindowEnd,
-            let position = player?.currentItem?.currentTime().seconds {
-            var calculatedPosition = (position - start) * 100
-            calculatedPosition = calculatedPosition / ((end - start) / 100)
-            calculatedPosition = (calculatedPosition * duration) / 10000
-            return calculatedPosition
-        }
-        return position
-    }
-
     open override var currentDate: Date? {
         return player?.currentItem?.currentDate()
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -289,8 +289,8 @@ open class AVFoundationPlayback: Playback {
             }
 
             seek(timeToSeek) { [weak self] in
-                if let usingDVR = self?.usingDVR {
-                    self?.trigger(.usingDVR, userInfo: ["enabled": usingDVR])
+                if let usingDVR = self?.isDvrInUse {
+                    self?.trigger(.didChangeDvrStatus, userInfo: ["enabled": usingDVR])
                 }
             }
         } else {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -133,12 +133,8 @@ open class AVFoundationPlayback: Playback {
 
     open override var position: Double {
         if let start = dvrWindowStart,
-            let end = dvrWindowEnd,
             let position = player?.currentItem?.currentTime().seconds {
-            var calculatedPosition = (position - start) * 100
-            calculatedPosition = calculatedPosition / ((end - start) / 100)
-            calculatedPosition = (calculatedPosition * duration) / 10000
-            return calculatedPosition
+            return position - start
         }
         
         guard playbackType == .vod, let player = self.player else {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -321,6 +321,11 @@ open class AVFoundationPlayback: Playback {
         trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
     }
 
+    open override func seekToLivePosition() {
+        guard let livePosition = (seekableTimeRanges.last as? CMTimeRange)?.end.seconds else { return }
+        seek(livePosition)
+    }
+
     open override func observeValue(forKeyPath keyPath: String?, of _: Any?,
                                     change _: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -300,7 +300,7 @@ open class AVFoundationPlayback: Playback {
 
             seek(timeToSeek) { [weak self] in
                 if let usingDVR = self?.isDvrInUse {
-                    self?.trigger(.didChangeDvrStatus, userInfo: ["enabled": usingDVR])
+                    self?.trigger(.didChangeDvrStatus, userInfo: ["inUse": usingDVR])
                 }
             }
         } else {
@@ -480,7 +480,7 @@ open class AVFoundationPlayback: Playback {
         trigger(.seekableUpdate, userInfo: ["seekableTimeRanges": seekableTimeRanges])
         print("## lastDvrAvailability:\(lastDvrAvailability) - isDvrAvailable:\(isDvrAvailable)")
         if lastDvrAvailability != isDvrAvailable {
-            trigger(.didChangeDvrAvailability, userInfo: ["isDvrAvailable": isDvrAvailable])
+            trigger(.didChangeDvrAvailability, userInfo: ["available": isDvrAvailable])
             lastDvrAvailability = isDvrAvailable
         }
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -563,6 +563,7 @@ extension AVFoundationPlayback {
     }
 
     open override var isDvrInUse: Bool {
+        if isPaused && isDvrAvailable { return true }
         guard let end = dvrWindowEnd, playbackType == .live else { return false }
         guard let currentTime = player?.currentTime().seconds else { return false }
         return end > currentTime

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -478,7 +478,10 @@ open class AVFoundationPlayback: Playback {
     fileprivate func handleSeekableTimeRangesEvent() {
         guard !seekableTimeRanges.isEmpty else { return }
         trigger(.seekableUpdate, userInfo: ["seekableTimeRanges": seekableTimeRanges])
-        print("## lastDvrAvailability:\(lastDvrAvailability) - isDvrAvailable:\(isDvrAvailable)")
+        handleDvrAvailabilityChange()
+    }
+
+    fileprivate func handleDvrAvailabilityChange() {
         if lastDvrAvailability != isDvrAvailable {
             trigger(.didChangeDvrAvailability, userInfo: ["available": isDvrAvailable])
             lastDvrAvailability = isDvrAvailable

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -38,6 +38,7 @@ open class AVFoundationPlayback: Playback {
     }
     fileprivate var timeObserver: Any?
     fileprivate var asset: AVURLAsset?
+    private var lastDvrAvailability: Bool?
 
     private var backgroundSessionBackup: String?
 
@@ -477,6 +478,11 @@ open class AVFoundationPlayback: Playback {
     fileprivate func handleSeekableTimeRangesEvent() {
         guard !seekableTimeRanges.isEmpty else { return }
         trigger(.seekableUpdate, userInfo: ["seekableTimeRanges": seekableTimeRanges])
+        print("## lastDvrAvailability:\(lastDvrAvailability) - isDvrAvailable:\(isDvrAvailable)")
+        if lastDvrAvailability != isDvrAvailable {
+            trigger(.didChangeDvrAvailability, userInfo: ["isDvrAvailable": isDvrAvailable])
+            lastDvrAvailability = isDvrAvailable
+        }
     }
 
     fileprivate func handleBufferingEvent(_ keyPath: String?) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -575,7 +575,13 @@ extension AVFoundationPlayback {
 
     open override var isDvrAvailable: Bool {
         guard playbackType == .live else { return false }
-        return seekableTimeRanges.first(where: { $0.timeRangeValue.duration.seconds >= minDvrSize}) != nil
+        var liveDuration: Double = 0
+        
+        for seekableTimeRange in seekableTimeRanges {
+            liveDuration += seekableTimeRange.timeRangeValue.duration.seconds
+        }
+        
+        return liveDuration >= minDvrSize
     }
 
     open override var currentDate: Date? {

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -330,8 +330,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override func seekToLivePosition() {
-        guard let livePosition = (seekableTimeRanges.last as? CMTimeRange)?.end.seconds else { return }
-        seek(livePosition)
+        seek(Double.infinity)
     }
 
     open override func observeValue(forKeyPath keyPath: String?, of _: Any?,

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -132,7 +132,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override var position: Double {
-        if let start = dvrWindowStart,
+        if isDvrAvailable, let start = dvrWindowStart,
             let position = player?.currentItem?.currentTime().seconds {
             return position - start
         }

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -119,13 +119,13 @@ open class AVFoundationPlayback: Playback {
         if playbackType == .vod {
             return CMTimeGetSeconds(item.asset.duration)
         }
-
-        if playbackType == .live {
-            if isDvrAvailable, let duration = seekableTimeRanges.first?.timeRangeValue.duration.seconds {
-                return duration
-            } else {
-                return 0
+        
+        if playbackType == .live, isDvrAvailable {
+            var liveDuration: Double = 0
+            for seekableTimeRange in seekableTimeRanges {
+                liveDuration += seekableTimeRange.timeRangeValue.duration.seconds
             }
+            return liveDuration
         }
 
         return 0

--- a/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -330,6 +330,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override func seekToLivePosition() {
+        play()
         seek(Double.infinity)
     }
 
@@ -566,7 +567,7 @@ extension AVFoundationPlayback {
         if isPaused && isDvrAvailable { return true }
         guard let end = dvrWindowEnd, playbackType == .live else { return false }
         guard let currentTime = player?.currentTime().seconds else { return false }
-        return end > currentTime
+        return end - liveHeadTolerance > currentTime
     }
 
     open override var isDvrAvailable: Bool {
@@ -606,5 +607,9 @@ extension AVFoundationPlayback {
             return nil
         }
         return seekableTimeRanges.max { rangeA, rangeB in rangeA.timeRangeValue.end.seconds < rangeB.timeRangeValue.end.seconds }?.timeRangeValue.end.seconds
+    }
+
+    fileprivate var liveHeadTolerance: Double {
+        return 5
     }
 }

--- a/Sources/Clappr_tvOS/Classes/Base/Playback.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Playback.swift
@@ -136,7 +136,11 @@ extension Playback {
         return 0
     }
     
-    @objc open var usingDVR: Bool {
+    @objc open var isDvrInUse: Bool {
+        return false
+    }
+    
+    @objc open var isDvrAvailable: Bool {
         return false
     }
     
@@ -146,14 +150,6 @@ extension Playback {
     
     @objc open var loadedTimeRanges: [NSValue] {
         return []
-    }
-    
-    @objc open var supportDVR: Bool {
-        return false
-    }
-    
-    @objc open var dvrPosition: Double {
-        return 0
     }
 
     @objc open var currentDate: Date? {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -96,11 +96,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                             }
 
                             context("when dvr is not being used") {
-<<<<<<< HEAD
-                                it("triggers usingDVR with enabled false") {
-=======
                                 it("triggers didChangeDvrStatus with inUse false") {
->>>>>>> test: adjust tests with new names and create test case for changeDvrAvailability
                                     player.set(currentTime: CMTime(seconds: 60, preferredTimescale: 1))
                                     item.setSeekableTimeRange(with: 60)
                                     var usingDVR: Bool?

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -205,7 +205,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                         item._currentTime = CMTime(seconds: 125, preferredTimescale: 1)
                         item.setWindow(start: 100, end: 150)
 
-                        expect(playback.dvrPosition).to(equal(25))
+                        expect(playback.position).to(equal(25))
                     }
                 }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -97,7 +97,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                             }
 
                             context("when dvr is not being used") {
-                                it("triggers usinDVR with enabled false") {
+                                it("triggers usingDVR with enabled false") {
                                     player.set(currentTime: CMTime(seconds: 60, preferredTimescale: 1))
                                     item.setSeekableTimeRange(with: 60)
                                     var usingDVR: Bool?

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -343,9 +343,9 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                 describe("#position") {
                     it("returns the position inside the DVR window") {
-                        asset.set(duration: CMTime(seconds: 50, preferredTimescale: 1))
+                        asset.set(duration: kCMTimeIndefinite)
+                        item.setWindow(start: 100, end: 160)
                         item._currentTime = CMTime(seconds: 125, preferredTimescale: 1)
-                        item.setWindow(start: 100, end: 150)
 
                         expect(playback.position).to(equal(25))
                     }
@@ -744,7 +744,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
 
                     playback.seekToLivePosition()
-                    
+
                     expect(updatedPosition).to(equal(Double.infinity))
                 }
             }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -341,7 +341,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
                 }
 
-                fdescribe("#position") {
+                describe("#position") {
                     context("when live") {
                         context("and DVR is available") {
                             it("returns the position inside the DVR window") {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -134,6 +134,41 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
                 }
 
+                describe("#pause") {
+                    beforeEach {
+                        asset.set(duration: kCMTimeIndefinite)
+                    }
+
+                    context("video has dvr") {
+                        it("triggers usinDVR with enabled true") {
+                            player.set(currentTime: CMTime(seconds: 59, preferredTimescale: 1))
+                            item.setSeekableTimeRange(with: 60)
+                            var didChangeDvrStatusTriggered = false
+                            playback.on(Event.didChangeDvrStatus.rawValue) { info in
+                                didChangeDvrStatusTriggered = true
+                            }
+
+                            playback.pause()
+
+                            expect(didChangeDvrStatusTriggered).toEventually(beTrue())
+                        }
+                    }
+
+                    context("whe video does not have dvr") {
+                        it("doesn't trigger usingDVR event") {
+                            player.set(currentTime: CMTime(seconds: 59, preferredTimescale: 1))
+                            var didChangeDvrStatusTriggered = false
+                            playback.on(Event.didChangeDvrStatus.rawValue) { info in
+                                didChangeDvrStatusTriggered = true
+                            }
+
+                            playback.pause()
+
+                            expect(didChangeDvrStatusTriggered).toEventually(beFalse())
+                        }
+                    }
+                }
+
                 describe("#seekableTimeRanges") {
                     context("when player is nil") {
                         it("is empty") {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -79,7 +79,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                         context("video has dvr") {
                             context("when dvr is being used") {
                                 it("triggers didChangeDvrStatus with inUse true") {
-                                    player.set(currentTime: CMTime(seconds: 59, preferredTimescale: 1))
+                                    player.set(currentTime: CMTime(seconds: 54, preferredTimescale: 1))
                                     item.setSeekableTimeRange(with: 60)
                                     var usingDVR: Bool?
                                     playback.on(Event.didChangeDvrStatus.rawValue) { info in
@@ -772,13 +772,39 @@ class AVFoundationPlaybackTests: QuickSpec {
             }
 
             describe("#isDvrInUse") {
-                it("returns false when video is paused") {
-                    asset.set(duration: kCMTimeIndefinite)
-                    item.setSeekableTimeRange(with: 60)
+                context("when video is paused") {
+                    it("returns true") {
+                        asset.set(duration: kCMTimeIndefinite)
+                        item.setSeekableTimeRange(with: 160)
 
-                    playback.pause()
+                        playback.pause()
 
-                    expect(playback.isDvrInUse).to(beTrue())
+                        expect(playback.isDvrInUse).to(beTrue())
+                    }
+                }
+                
+                context("when currentTime is lower then dvrWindowEnd - liveHeadTolerance") {
+                    it("returns true") {
+                        asset.set(duration: kCMTimeIndefinite)
+                        item.setSeekableTimeRange(with: 160)
+                        player.set(currentTime: CMTime(seconds: 154, preferredTimescale: 1))
+                        
+                        player.play()
+                        
+                        expect(playback.isDvrInUse).toEventually(beTrue())
+                    }
+                }
+                
+                context("when currentTime is higher or equal then dvrWindowEnd - liveHeadTolerance") {
+                    it("returns false") {
+                        asset.set(duration: kCMTimeIndefinite)
+                        item.setSeekableTimeRange(with: 160)
+                        player.set(currentTime: CMTime(seconds: 156, preferredTimescale: 1))
+                        
+                        player.play()
+                        
+                        expect(playback.isDvrInUse).toEventually(beFalse())
+                    }
                 }
             }
         }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -341,13 +341,35 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
                 }
 
-                describe("#position") {
-                    it("returns the position inside the DVR window") {
-                        asset.set(duration: kCMTimeIndefinite)
-                        item.setWindow(start: 100, end: 160)
-                        item._currentTime = CMTime(seconds: 125, preferredTimescale: 1)
+                fdescribe("#position") {
+                    context("when live") {
+                        context("and DVR is available") {
+                            it("returns the position inside the DVR window") {
+                                asset.set(duration: kCMTimeIndefinite)
+                                item.setSeekableTimeRange(with: 200)
+                                item.setWindow(start: 100, end: 160)
+                                item._currentTime = CMTime(seconds: 125, preferredTimescale: 1)
 
-                        expect(playback.position).to(equal(25))
+                                expect(playback.position).to(equal(25))
+                            }
+                        }
+                        context("and dvr is not available") {
+                            it("returns 0") {
+                                asset.set(duration: kCMTimeIndefinite)
+                                item.setSeekableTimeRange(with: 0)
+                                
+                                expect(playback.position).to(equal(0))
+                            }
+                        }
+                    }
+                    
+                    context("when vod") {
+                        it("returns current time") {
+                            asset.set(duration: CMTime(seconds: 160, preferredTimescale: 1))
+                            player.set(currentTime: CMTime(seconds: 125, preferredTimescale: 1))
+                            
+                            expect(playback.position).to(equal(125))
+                        }
                     }
                 }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -745,8 +745,7 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     playback.seekToLivePosition()
                     
-                    let livePosition = (playerItem.seekableTimeRanges.last as? CMTimeRange)?.end.seconds
-                    expect(updatedPosition).to(equal(livePosition))
+                    expect(updatedPosition).to(equal(Double.infinity))
                 }
             }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -710,6 +710,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     expect(updatedPosition).to(equal(5))
                 }
             }
+
             describe("#seekToLivePosition") {
                 var playback: AVFoundationPlayback!
                 var playerItem: AVPlayerItemStub!
@@ -741,12 +742,22 @@ class AVFoundationPlaybackTests: QuickSpec {
                     playback.on(Event.positionUpdate.rawValue) { (userInfo: EventUserInfo) in
                         updatedPosition = userInfo!["position"] as? Float64
                     }
-                    
-                    
+
                     playback.seekToLivePosition()
                     
                     let livePosition = (playerItem.seekableTimeRanges.last as? CMTimeRange)?.end.seconds
                     expect(updatedPosition).to(equal(livePosition))
+                }
+            }
+
+            describe("#isDvrInUse") {
+                it("returns false when video is paused") {
+                    asset.set(duration: kCMTimeIndefinite)
+                    item.setSeekableTimeRange(with: 60)
+
+                    playback.pause()
+
+                    expect(playback.isDvrInUse).to(beTrue())
                 }
             }
         }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -84,7 +84,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                                     item.setSeekableTimeRange(with: 60)
                                     var usingDVR: Bool?
                                     playback.on(Event.didChangeDvrStatus.rawValue) { info in
-                                        if let enabled = info?["enabled"] as? Bool {
+                                        if let enabled = info?["inUse"] as? Bool {
                                             usingDVR = enabled
                                         }
                                     }
@@ -102,7 +102,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                                     item.setSeekableTimeRange(with: 60)
                                     var usingDVR: Bool?
                                     playback.on(Event.didChangeDvrStatus.rawValue) { info in
-                                        if let enabled = info?["enabled"] as? Bool {
+                                        if let enabled = info?["inUse"] as? Bool {
                                             usingDVR = enabled
                                         }
                                     }
@@ -120,7 +120,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                                 player.set(currentTime: CMTime(seconds: 59, preferredTimescale: 1))
                                 var usingDVR: Bool?
                                 playback.on(Event.didChangeDvrStatus.rawValue) { info in
-                                    if let enabled = info?["enabled"] as? Bool {
+                                    if let enabled = info?["inUse"] as? Bool {
                                         usingDVR = enabled
                                     }
                                 }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -67,7 +67,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                         it("returns false") {
                             asset.set(duration: CMTime(seconds: 60, preferredTimescale: 1))
 
-                            expect(playback.usingDVR).to(beFalse())
+                            expect(playback.isDvrInUse).to(beFalse())
                         }
                     }
 
@@ -83,7 +83,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                                     player.set(currentTime: CMTime(seconds: 59, preferredTimescale: 1))
                                     item.setSeekableTimeRange(with: 60)
                                     var usingDVR: Bool?
-                                    playback.on(Event.usingDVR.rawValue) { info in
+                                    playback.on(Event.didChangeDvrStatus.rawValue) { info in
                                         if let enabled = info?["enabled"] as? Bool {
                                             usingDVR = enabled
                                         }
@@ -101,7 +101,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                                     player.set(currentTime: CMTime(seconds: 60, preferredTimescale: 1))
                                     item.setSeekableTimeRange(with: 60)
                                     var usingDVR: Bool?
-                                    playback.on(Event.usingDVR.rawValue) { info in
+                                    playback.on(Event.didChangeDvrStatus.rawValue) { info in
                                         if let enabled = info?["enabled"] as? Bool {
                                             usingDVR = enabled
                                         }
@@ -119,7 +119,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                             it("doesn't trigger usingDVR event") {
                                 player.set(currentTime: CMTime(seconds: 59, preferredTimescale: 1))
                                 var usingDVR: Bool?
-                                playback.on(Event.usingDVR.rawValue) { info in
+                                playback.on(Event.didChangeDvrStatus.rawValue) { info in
                                     if let enabled = info?["enabled"] as? Bool {
                                         usingDVR = enabled
                                     }
@@ -185,7 +185,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                         it("returns false") {
                             asset.set(duration: CMTime(seconds: 60, preferredTimescale: 1))
 
-                            expect(playback.supportDVR).to(beFalse())
+                            expect(playback.isDvrAvailable).to(beFalse())
                         }
                     }
 
@@ -194,7 +194,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                             asset.set(duration: kCMTimeIndefinite)
                             item.setSeekableTimeRange(with: 60)
 
-                            expect(playback.supportDVR).to(beTrue())
+                            expect(playback.isDvrAvailable).to(beTrue())
                         }
                     }
                 }

--- a/Tests/Clappr_Tests/AVPlayerItemStub.swift
+++ b/Tests/Clappr_Tests/AVPlayerItemStub.swift
@@ -10,6 +10,7 @@ class AVPlayerItemStub: AVPlayerItem {
     var _currentTime: CMTime = CMTime(seconds: 0, preferredTimescale: 0)
     
     var didCallSeekWithCompletionHandler = false
+    var didCallSeekWithTime: CMTime?
 
     var _status: AVPlayerItemStatus = AVPlayerItemStatus.unknown
 
@@ -17,6 +18,7 @@ class AVPlayerItemStub: AVPlayerItem {
 
     override func seek(to time: CMTime, completionHandler: ((Bool) -> Void)?) {
         didCallSeekWithCompletionHandler = true
+        didCallSeekWithTime = time
         completionHandler!(true)
     }
 


### PR DESCRIPTION
### Goal

After talking with the Clappr team, some names were changed to inform better the DVR availability and status.

- Create an event to indicate the change of DVR availability - didChangeDvrAvailability
- Change the property `supportDvr` to `isDvrAvailable`
- Change the property `isUsingDvr` to `isDvrInUse`
- Change the event `usingDvr` to `didChangeDvrStatus`
- Create a method `seekToLivePosition()` to make possible for plugins to redirect a live playback to last live moment available