### PR TITLE
Remove unnecessary events rethrow

### DIFF
--- a/Sources/Clappr/Classes/Base/MediaControl.swift
+++ b/Sources/Clappr/Classes/Base/MediaControl.swift
@@ -211,12 +211,10 @@ open class MediaControl: UIBaseObject {
     @objc open func triggerPlay() {
         playbackControlState = .playing
         playbackControlButton?.isHidden = false
-        trigger(Event.playing)
     }
 
     @objc open func triggerPause() {
         playbackControlState = .paused
-        trigger(Event.didPause)
     }
 
     @objc open func disable() {
@@ -287,25 +285,21 @@ open class MediaControl: UIBaseObject {
 
     @objc open func hide() {
         hideControlsTimer?.invalidate()
-        trigger(Event.disableMediaControl.rawValue)
         setSubviewsVisibility(hidden: true)
     }
 
     @objc open func show() {
-        trigger(Event.enableMediaControl.rawValue)
         setSubviewsVisibility(hidden: false)
         scheduleTimerToHideControls()
     }
 
     @objc open func showAnimated() {
-        trigger(Event.enableMediaControl.rawValue)
         setSubviewsVisibility(hidden: false, animated: true)
         scheduleTimerToHideControls()
     }
 
     @objc open func hideAnimated() {
         hideControlsTimer?.invalidate()
-        trigger(Event.disableMediaControl.rawValue)
         setSubviewsVisibility(hidden: true, animated: true)
     }
 
@@ -352,19 +346,16 @@ open class MediaControl: UIBaseObject {
     fileprivate func pause() {
         playbackControlState = .paused
         container?.playback?.pause()
-        trigger(Event.didPause.rawValue)
     }
 
     fileprivate func play() {
         playbackControlState = .playing
         container?.playback?.play()
-        trigger(Event.playing.rawValue)
     }
 
     fileprivate func stop() {
         playbackControlState = .stopped
         container?.playback?.stop()
-        trigger(Event.didStop.rawValue)
     }
 
     @objc open func scheduleTimerToHideControls() {

--- a/Tests/Clappr_Tests/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/MediaControlTests.swift
@@ -69,6 +69,29 @@ class MediaControlTests: QuickSpec {
                         expect(mediaControl.controlsWrapperView!.alpha) == 1
                         expect(mediaControl.controlsHidden).to(beFalse())
                     }
+
+                }
+                context("Animated Visibility"){
+                    beforeEach {
+                        container.mediaControlEnabled = true
+                    }
+                    it("Should hide it's control after hideAnimated is called and media control is enabled") {
+                        mediaControl.hideAnimated()
+
+                        expect(mediaControl.controlsOverlayView!.alpha) == 0
+                        expect(mediaControl.controlsWrapperView!.alpha) == 0
+                        expect(mediaControl.controlsHidden).to(beTrue())
+                    }
+
+                    it("Should show it's control after showAnimated is called and media control is enabled") {
+                        container.mediaControlEnabled = true
+                        mediaControl.hide()
+                        mediaControl.showAnimated()
+
+                        expect(mediaControl.controlsOverlayView!.alpha) == 1
+                        expect(mediaControl.controlsWrapperView!.alpha) == 1
+                        expect(mediaControl.controlsHidden).to(beFalse())
+                    }
                 }
 
                 context("Play") {

--- a/Tests/Clappr_Tests/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/MediaControlTests.swift
@@ -83,17 +83,6 @@ class MediaControlTests: QuickSpec {
                         mediaControl.playbackControlButton!.sendActions(for: UIControlEvents.touchUpInside)
                         expect(container.playback?.isPlaying).to(beTrue())
                     }
-
-                    it("Should trigger playing event ") {
-                        var callbackWasCalled = false
-                        mediaControl.once(Event.playing.rawValue) { _ in
-                            callbackWasCalled = true
-                        }
-
-                        mediaControl.playbackControlButton!.sendActions(for: UIControlEvents.touchUpInside)
-
-                        expect(callbackWasCalled).to(beTrue())
-                    }
                 }
 
                 context("Pause") {
@@ -110,17 +99,6 @@ class MediaControlTests: QuickSpec {
                     it("Should change playback control state to paused") {
                         mediaControl.playbackControlButton!.sendActions(for: UIControlEvents.touchUpInside)
                         expect(mediaControl.playbackControlState) == PlaybackControlState.paused
-                    }
-
-                    it("Should trigger didPause event when selecting button") {
-                        var callbackWasCalled = false
-                        mediaControl.once(Event.didPause.rawValue) { _ in
-                            callbackWasCalled = true
-                        }
-
-                        mediaControl.playbackControlButton!.sendActions(for: UIControlEvents.touchUpInside)
-
-                        expect(callbackWasCalled).to(beTrue())
                     }
                 }
 
@@ -139,17 +117,6 @@ class MediaControlTests: QuickSpec {
                     it("Should change playback control state to stopped") {
                         mediaControl.playbackControlButton!.sendActions(for: UIControlEvents.touchUpInside)
                         expect(mediaControl.playbackControlState) == PlaybackControlState.stopped
-                    }
-
-                    it("Should trigger didStop event when selecting button") {
-                        var callbackWasCalled = false
-                        mediaControl.once(Event.didStop.rawValue) { _ in
-                            callbackWasCalled = true
-                        }
-
-                        mediaControl.playbackControlButton!.sendActions(for: UIControlEvents.touchUpInside)
-
-                        expect(callbackWasCalled).to(beTrue())
                     }
                 }
 


### PR DESCRIPTION
### Goal
After the study to find duplicated triggered events at our code. We found some unnecessary events been throw by our MediaPlayer. To fix that and be sure that our users do not listen events from the wrong place, we decided to remove these unnecessary event triggers.

### How to test
1. Run clappr tests
