### PR TITLE
Exit full screen when player is destroyed

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -16,7 +16,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     #if os(iOS)
     @objc private (set) var fullscreenController: FullscreenController? = FullscreenController(nibName: nil, bundle: nil)
 
-    lazy var fullscreenHandler: FullscreenStateHandler = {
+    lazy var fullscreenHandler: FullscreenStateHandler? = {
         return self.optionsUnboxer.fullscreenControledByApp ? FullscreenByApp(core: self) : FullscreenByPlayer(core: self) as FullscreenStateHandler
     }()
     #endif
@@ -106,8 +106,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         }
 
         #if os(iOS)
-        listenTo(mediaControl, eventName: InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler.enterInFullscreen() }
-        listenTo(mediaControl, eventName: InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler.exitFullscreen() }
+        listenTo(mediaControl, eventName: InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler?.enterInFullscreen() }
+        listenTo(mediaControl, eventName: InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler?.exitFullscreen() }
         #endif
     }
 
@@ -130,7 +130,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     fileprivate func addToContainer() {
         #if os(iOS)
         if optionsUnboxer.fullscreen && !optionsUnboxer.fullscreenControledByApp {
-            fullscreenHandler.enterInFullscreen()
+            fullscreenHandler?.enterInFullscreen()
         } else {
             renderInContainerView()
         }
@@ -169,7 +169,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
 
     @objc open func setFullscreen(_ fullscreen: Bool) {
         #if os(iOS)
-        fullscreenHandler.set(fullscreen: fullscreen)
+        fullscreenHandler?.set(fullscreen: fullscreen)
         #endif
     }
 
@@ -198,6 +198,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         mediaControl?.removeFromSuperview()
         mediaControl = nil
         #if os(iOS)
+        fullscreenHandler?.destroy()
+        fullscreenHandler = nil
         fullscreenController = nil
         #endif
         removeFromSuperview()

--- a/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
+++ b/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
@@ -7,6 +7,7 @@ protocol FullscreenStateHandler {
     func set(fullscreen: Bool)
     func enterInFullscreen()
     func exitFullscreen()
+    func destroy()
 }
 
 struct FullscreenByApp: FullscreenStateHandler {
@@ -34,6 +35,8 @@ struct FullscreenByApp: FullscreenStateHandler {
         guard core.isFullscreen else { return }
         core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
     }
+
+    func destroy() { }
 }
 
 struct FullscreenByPlayer: FullscreenStateHandler {
@@ -62,9 +65,18 @@ struct FullscreenByPlayer: FullscreenStateHandler {
         guard core.isFullscreen else { return }
         core.trigger(InternalEvent.willExitFullscreen.rawValue)
         core.isFullscreen = false
-        core.parentView?.addSubviewMatchingConstraints(core)
-        core.fullscreenController?.dismiss(animated: false, completion: nil)
+        handleExit()
         core.trigger(InternalEvent.didExitFullscreen.rawValue)
         core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
+    }
+
+    private func handleExit() {
+        core.parentView?.addSubviewMatchingConstraints(core)
+        core.fullscreenController?.dismiss(animated: false, completion: nil)
+    }
+
+    func destroy() {
+        guard core.isFullscreen else { return }
+        handleExit()
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -172,6 +172,7 @@ open class Player: BaseObject {
         stopListening()
         Logger.logDebug("destroying core", scope: "Player")
         self.core?.destroy()
+        self.core = nil
         Logger.logDebug("destroyed", scope: "Player")
     }
 }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -556,10 +556,16 @@ class CoreTests: QuickSpec {
                 }
 
                 #if os(iOS)
-                it("clears fullscreen reference") {
+                it("clears fullscreenController reference") {
                     core.destroy()
                     
                     expect(core.fullscreenController).toEventually(beNil())
+                }
+
+                it("clears fullscreenHandler reference") {
+                    core.destroy()
+
+                    expect(core.fullscreenHandler).toEventually(beNil())
                 }
                 #endif
             }


### PR DESCRIPTION
### Goal
In full screen state, core is placed in another view. Before player destruction, we need to place it in the previous view to not create a memory leak. 

### Additional Info
`FullscreenStateHandler` was retaining `Core` avoiding its destruction.

### How to test
Run `make test`.