### PR TITLE
Refactoring Loader

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -58,7 +58,6 @@
 		3293659C212DC9CE001B4B15 /* sub-por.webvtt in Resources */ = {isa = PBXBuildFile; fileRef = 32624C9E212C7740004C26ED /* sub-por.webvtt */; };
 		3293659D212DC9CE001B4B15 /* sub0.webvtt in Resources */ = {isa = PBXBuildFile; fileRef = 32624C98212C773E004C26ED /* sub0.webvtt */; };
 		3293659E212DC9CE001B4B15 /* subtitles.m3u8 in Resources */ = {isa = PBXBuildFile; fileRef = 32624C93212C773D004C26ED /* subtitles.m3u8 */; };
-		3293659F212DE462001B4B15 /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9603A06B1C05E6D100B55D8F /* PlayerTests.swift */; };
 		329624A82051ECFF0062AE32 /* MediaOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329624A72051ECFF0062AE32 /* MediaOptionTests.swift */; };
 		32A7A297215EA27F00296DE3 /* NoOpPlayback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362B41D41339400CCB866 /* NoOpPlayback.swift */; };
 		32A7A298215EA49700296DE3 /* NoOpPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5226781FBA207C008C4A15 /* NoOpPlaybackTests.swift */; };
@@ -203,6 +202,8 @@
 		B4D817711E8ADCE600DC07AE /* Kingfisher.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 96D362F01D41345E00CCB866 /* Kingfisher.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652211D467CCA00627C48 /* UICorePluginTests.swift */; };
 		EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652231D46829100627C48 /* UIContainerPluginTests.swift */; };
+		FB0A223C2175492E00D2180F /* Loader+Plugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */; };
+		FB0A223F21754CBD00D2180F /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0A223D21754C1700D2180F /* PlayerTests.swift */; };
 		FB3A8F1A209F8D7000CEFC3D /* FullscreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB61A3F2209F885800BDF267 /* FullscreenTests.swift */; };
 		FBE6A3E42163EEAE0083C9CC /* Loader+Plugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */; };
 		FC6418DE2007DB9100E81B7C /* ClapprDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6418DD2007DB9100E81B7C /* ClapprDateFormatter.swift */; };
@@ -435,6 +436,7 @@
 		D8810057D2C05E1F7A2759D7 /* Clappr.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = Clappr.podspec; sourceTree = "<group>"; };
 		EDF652211D467CCA00627C48 /* UICorePluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICorePluginTests.swift; sourceTree = "<group>"; };
 		EDF652231D46829100627C48 /* UIContainerPluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIContainerPluginTests.swift; sourceTree = "<group>"; };
+		FB0A223D21754C1700D2180F /* PlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerTests.swift; sourceTree = "<group>"; };
 		FB61A3F2209F885800BDF267 /* FullscreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenTests.swift; sourceTree = "<group>"; };
 		FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Loader+Plugins.swift"; sourceTree = "<group>"; };
 		FC6418DB2007DA6200E81B7C /* ClapprDateFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClapprDateFormatterTests.swift; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 				32E402171FF433FA001C2096 /* BaseObjectTests.swift */,
 				32E402161FF433FA001C2096 /* EventDispatcherTests.swift */,
 				32E4020E1FF43262001C2096 /* Info.plist */,
+				FB0A223D21754C1700D2180F /* PlayerTests.swift */,
 			);
 			path = Clappr_tvOS_Tests;
 			sourceTree = "<group>";
@@ -1565,7 +1568,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3293659F212DE462001B4B15 /* PlayerTests.swift in Sources */,
 				FC7785C2200526D900EC879F /* AVFoundationPlaybackNowPlayingServiceTests.swift in Sources */,
 				32E402191FF433FB001C2096 /* EventDispatcherTests.swift in Sources */,
 				571B7B2B2175015F005C0942 /* AVURLAssetStub.swift in Sources */,
@@ -1580,6 +1582,9 @@
 				571B7B2D21750173005C0942 /* AVPlayerStub.swift in Sources */,
 				571B7B32217503BB005C0942 /* NowPlayingServiceStub.swift in Sources */,
 				32A7A298215EA49700296DE3 /* NoOpPlaybackTests.swift in Sources */,
+				FB0A223F21754CBD00D2180F /* PlayerTests.swift in Sources */,
+				FB0A223C2175492E00D2180F /* Loader+Plugins.swift in Sources */,
+				FC7785C3200526DC00EC879F /* AVFoundationPlaybackTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652211D467CCA00627C48 /* UICorePluginTests.swift */; };
 		EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652231D46829100627C48 /* UIContainerPluginTests.swift */; };
 		FB3A8F1A209F8D7000CEFC3D /* FullscreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB61A3F2209F885800BDF267 /* FullscreenTests.swift */; };
+		FBE6A3E42163EEAE0083C9CC /* Loader+Plugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */; };
 		FC6418DE2007DB9100E81B7C /* ClapprDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6418DD2007DB9100E81B7C /* ClapprDateFormatter.swift */; };
 		FC6418E12007DC2F00E81B7C /* ClapprDateFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6418DB2007DA6200E81B7C /* ClapprDateFormatterTests.swift */; };
 		FC7785A62005233D00EC879F /* BaseObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7785962005233D00EC879F /* BaseObject.swift */; };
@@ -435,6 +436,7 @@
 		EDF652211D467CCA00627C48 /* UICorePluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICorePluginTests.swift; sourceTree = "<group>"; };
 		EDF652231D46829100627C48 /* UIContainerPluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIContainerPluginTests.swift; sourceTree = "<group>"; };
 		FB61A3F2209F885800BDF267 /* FullscreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenTests.swift; sourceTree = "<group>"; };
+		FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Loader+Plugins.swift"; sourceTree = "<group>"; };
 		FC6418DB2007DA6200E81B7C /* ClapprDateFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClapprDateFormatterTests.swift; sourceTree = "<group>"; };
 		FC6418DD2007DB9100E81B7C /* ClapprDateFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClapprDateFormatter.swift; sourceTree = "<group>"; };
 		FC7785962005233D00EC879F /* BaseObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseObject.swift; sourceTree = "<group>"; };
@@ -547,6 +549,7 @@
 		323DF27A1FF4399600ECA3F3 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				FBE6A3E52163EF9C0083C9CC /* Extensions */,
 				57351C6620248D66007DEBBE /* Stub */,
 				607FACE81AFB9204008FA782 /* Clappr_Tests */,
 				9E692E001F9F898F006510BE /* Clappr_UITests */,
@@ -1001,6 +1004,14 @@
 				96D362F01D41345E00CCB866 /* Kingfisher.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FBE6A3E52163EF9C0083C9CC /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		FC7785942005233D00EC879F /* Classes */ = {
@@ -1593,6 +1604,7 @@
 				9E3F43FC1F31116100417919 /* AppStateManagerTests.swift in Sources */,
 				EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */,
 				96912C3E1C21A1AF003A4AFD /* PosterPluginTests.swift in Sources */,
+				FBE6A3E42163EEAE0083C9CC /* Loader+Plugins.swift in Sources */,
 				322EA4CA20F941300018973A /* AVURLAssetStub.swift in Sources */,
 				9EED97062088E48700D1C84A /* AVPlayerStub.swift in Sources */,
 				96B4656B1BF6028A0025975A /* UIPluginTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -75,6 +75,42 @@ let options = [kSourceUrl : "https://devstreaming-cdn.apple.com/videos/streaming
 let player = Player(options: options)
 ```
 
+#### Register Custom Plugins
+
+In order to register a custom plugin is necessary to pass the plugin type to Player before initialize it, using the static method `register` as the example below:
+
+
+```swift
+let plugins = [PluginExemplo.self]
+WMPlayer.register(plugins: plugins)
+
+var player = WMPlayer(options: options)
+
+player.attachTo(playerContainer, controller: self)
+```
+
+The Player does not support adding or removing plugins at runtime so it is necessary register the plugins before its initialization.
+In case player be destroyed and recreated, all plugins registered will be reused, like the example below:
+
+```swift
+let firstTimePlugins = [PluginExemploA.self]
+WMPlayer.register(plugins: firstTimePlugins)
+
+var player = WMPlayer(options: options)
+
+let secondTimePlugins = [PluginExemploB.self]
+WMPlayer.register(plugins: secondTimePlugins)
+
+// PluginExemploB will not be used in this instance of Player
+player.attachTo(playerContainer, controller: self) 
+
+player.destroy()
+
+// PluginExemploA and PluginExemploB will be used in this instance of Player
+player = WMPlayer(options: options)
+
+```
+
 #### Add to your controller
 
 ```swift

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -9,8 +9,6 @@ open class Container: UIBaseObject {
         }
     }
 
-    fileprivate var loader: Loader
-
     @objc open var mediaControlEnabled = false {
         didSet {
             let eventToTrigger: Event = mediaControlEnabled ? .enableMediaControl : .disableMediaControl
@@ -33,10 +31,9 @@ open class Container: UIBaseObject {
         }
     }
 
-    public init(loader: Loader = Loader(), options: Options = [:]) {
+    public init(options: Options = [:]) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
         self.options = options
-        self.loader = loader
         super.init(frame: CGRect.zero)
         self.sharedData.container = self
         backgroundColor = UIColor.clear
@@ -60,7 +57,7 @@ open class Container: UIBaseObject {
 
         self.playback?.destroy()
 
-        let playbackFactory = PlaybackFactory(loader: loader, options: playbackOptions)
+        let playbackFactory = PlaybackFactory(options: playbackOptions)
         self.playback = playbackFactory.createPlayback()
 
         if playback is NoOpPlayback {
@@ -93,7 +90,7 @@ open class Container: UIBaseObject {
     }
 
     fileprivate func loadPlugins() {
-        for type in loader.containerPlugins {
+        for type in Loader.shared.containerPlugins {
             if let plugin = type.init(context: self) as? UIContainerPlugin {
                 addPlugin(plugin)
             }

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -37,7 +37,7 @@ open class Container: UIBaseObject {
         super.init(frame: CGRect.zero)
         self.sharedData.container = self
         backgroundColor = UIColor.clear
-        loadPlugins()
+        Loader.shared.loadPlugins(in: self)
         accessibilityIdentifier = "Container"
         if let source = options[kSourceUrl] as? String {
             load(source, mimeType: options[kMimeType] as? String)
@@ -89,15 +89,7 @@ open class Container: UIBaseObject {
         plugin.render()
     }
 
-    fileprivate func loadPlugins() {
-        for type in Loader.shared.containerPlugins {
-            if let plugin = type.init(context: self) as? UIContainerPlugin {
-                addPlugin(plugin)
-            }
-        }
-    }
-
-    private func addPlugin(_ plugin: UIContainerPlugin) {
+    func addPlugin(_ plugin: UIContainerPlugin) {
         plugins.append(plugin)
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -75,7 +75,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         #endif
 
         bindEventListeners()
-        loadPlugins()
+        Loader.shared.loadPlugins(in: self)
 
         containers.append(Container(options: options))
 
@@ -88,14 +88,6 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     fileprivate func setActive(container: Container) {
         if activeContainer != container {
             activeContainer = container
-        }
-    }
-
-    fileprivate func loadPlugins() {
-        for plugin in Loader.shared.corePlugins {
-            if let corePlugin = plugin.init(context: self) as? UICorePlugin {
-                addPlugin(corePlugin)
-            }
         }
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -54,7 +54,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         fatalError("Should be using init(sources:[NSURL]) instead")
     }
 
-    public required init(loader: Loader = Loader(), options: Options = [:]) {
+    public required init(options: Options = [:]) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
 
         self.options = options
@@ -64,15 +64,15 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         backgroundColor = UIColor.black
 
         #if os(iOS)
-        mediaControl = loader.mediaControl.create()
-        mediaControl?.core = self
+        mediaControl = MediaControl.create()
+        mediaControl?.core = self        
         addTapRecognizer()
         #endif
 
         bindEventListeners()
-        loadPlugins(loader)
+        loadPlugins()
 
-        containers.append(Container(loader: loader, options: options))
+        containers.append(Container(options: options))
 
         if let container = containers.first {
             setActive(container: container)
@@ -86,8 +86,8 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         }
     }
 
-    fileprivate func loadPlugins(_ loader: Loader) {
-        for plugin in loader.corePlugins {
+    fileprivate func loadPlugins() {
+        for plugin in Loader.shared.corePlugins {
             if let corePlugin = plugin.init(context: self) as? UICorePlugin {
                 addPlugin(corePlugin)
             }

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -64,8 +64,13 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         backgroundColor = UIColor.black
 
         #if os(iOS)
-        mediaControl = MediaControl.create()
-        mediaControl?.core = self        
+        if let externalMediaControl = options[kMediaControl] as? MediaControl.Type {
+            mediaControl = externalMediaControl.create()
+        } else {
+            mediaControl = MediaControl.create()
+        }
+        mediaControl?.core = self
+        
         addTapRecognizer()
         #endif
 

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -1,7 +1,7 @@
 open class Loader {
 
-    static let shared = Loader()
-    var plugins: [String: Plugin.Type] = [:]
+    public static let shared = Loader()
+    public var plugins: [String: Plugin.Type] = [:]
 
     var playbacks: [Plugin.Type] {
         return plugins.filter { $0.value.type == .playback }.map { return $0.value }

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -1,17 +1,20 @@
 open class Loader {
-    
+
     static let shared = Loader()
-    
-    internal(set) open var playbacks: [Plugin.Type] = [AVFoundationPlayback.self, NoOpPlayback.self]
-    #if os (iOS)
-    internal(set) open var containerPlugins: [Plugin.Type] = [PosterPlugin.self, SpinnerPlugin.self]
-    #else
-    internal(set) open var containerPlugins: [Plugin.Type] = []
-    #endif
-    internal(set) open var corePlugins = [Plugin.Type]()
-    
-    var externalPlugins: [Plugin.Type] = []
-    
+    var plugins: [String: Plugin.Type] = [:]
+
+    var playbacks: [Plugin.Type] {
+        return plugins.filter { $0.value.type == .playback }.map { return $0.value }
+    }
+
+    var containerPlugins: [Plugin.Type] {
+        return plugins.filter { $0.value.type == .container }.map { return $0.value }
+    }
+
+    var corePlugins: [Plugin.Type] {
+        return plugins.filter { $0.value.type == .core }.map { return $0.value }
+    }
+
     private init() {
         Logger.logInfo("plugins:" +
             "\n - playback: \(playbacks.map({ $0.name }))" +
@@ -20,27 +23,9 @@ open class Loader {
     }
     
     open func addExternalPlugins(_ externalPlugins: [Plugin.Type]) {
-        self.externalPlugins.append(contentsOf: externalPlugins)
-        self.externalPlugins = self.removeDuplicate(self.externalPlugins)
-        playbacks = getPlugins(.playback, defaultPlugins: playbacks)
-        containerPlugins = getPlugins(.container, defaultPlugins: containerPlugins)
-        corePlugins = getPlugins(.core, defaultPlugins: corePlugins)
-    }
-    
-    private func getPlugins(_ type: PluginType, defaultPlugins: [Plugin.Type]) -> [Plugin.Type] {
-        let filteredPlugins = externalPlugins.filter({ $0.type == type })
-        return removeDuplicate(filteredPlugins + defaultPlugins)
-    }
-    
-    private func removeDuplicate(_ plugins: [Plugin.Type]) -> [Plugin.Type] {
-        var result = [Plugin.Type]()
-        
-        for plugin in plugins {
-            if !result.contains(where: { $0.name == plugin.name }) {
-                result.append(plugin)
-            }
+        externalPlugins.forEach { plugin in
+            self.plugins[plugin.name] = plugin
         }
-        
-        return result
     }
+
 }

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -9,20 +9,10 @@ open class Loader {
 
     internal(set) open var mediaControl: MediaControl.Type = MediaControl.self
 
-    fileprivate var externalPlugins = [Plugin.Type]()
+    fileprivate var externalPlugins: [Plugin.Type]?
 
-    public convenience init() {
-        self.init(externalPlugins: [])
-    }
-
-    public init(externalPlugins: [Plugin.Type], options: Options = [:]) {
-        self.externalPlugins = externalPlugins
-
+    public init(options: Options = [:]) {
         loadExternalMediaControl(options)
-
-        if !externalPlugins.isEmpty {
-            addExternalPlugins(externalPlugins)
-        }
 
         Logger.logInfo("plugins:" +
             "\n - playback: \(playbackPlugins.map({ $0.name }))" +
@@ -45,6 +35,7 @@ open class Loader {
     }
 
     fileprivate func getPlugins(_ type: PluginType, defaultPlugins: [Plugin.Type]) -> [Plugin.Type] {
+        guard let externalPlugins = externalPlugins else { return [] }
         let filteredPlugins = externalPlugins.filter({ $0.type == type })
         return removeDuplicate(filteredPlugins + defaultPlugins)
     }

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -1,54 +1,46 @@
 open class Loader {
-    internal(set) open var playbackPlugins: [Plugin.Type] = [AVFoundationPlayback.self, NoOpPlayback.self]
+    
+    static let shared = Loader()
+    
+    internal(set) open var playbacks: [Plugin.Type] = [AVFoundationPlayback.self, NoOpPlayback.self]
     #if os (iOS)
     internal(set) open var containerPlugins: [Plugin.Type] = [PosterPlugin.self, SpinnerPlugin.self]
     #else
     internal(set) open var containerPlugins: [Plugin.Type] = []
     #endif
     internal(set) open var corePlugins = [Plugin.Type]()
-
-    internal(set) open var mediaControl: MediaControl.Type = MediaControl.self
-
-    fileprivate var externalPlugins: [Plugin.Type]?
-
-    public init(options: Options = [:]) {
-        loadExternalMediaControl(options)
-
+    
+    private var externalPlugins: [Plugin.Type]?
+    
+    private init() {
         Logger.logInfo("plugins:" +
-            "\n - playback: \(playbackPlugins.map({ $0.name }))" +
+            "\n - playback: \(playbacks.map({ $0.name }))" +
             "\n - container: \(containerPlugins.map({ $0.name }))" +
-            "\n - core: \(corePlugins.map({ $0.name }))" +
-            "\n - mediaControl: \(mediaControl)", scope: "\(type(of: self))")
+            "\n - core: \(corePlugins.map({ $0.name }))")
     }
-
-    fileprivate func loadExternalMediaControl(_ options: Options) {
-        if let externalMediaControl = options[kMediaControl] as? MediaControl.Type {
-            mediaControl = externalMediaControl
-        }
-    }
-
+    
     open func addExternalPlugins(_ externalPlugins: [Plugin.Type]) {
         self.externalPlugins = externalPlugins
-        playbackPlugins = getPlugins(.playback, defaultPlugins: playbackPlugins)
+        playbacks = getPlugins(.playback, defaultPlugins: playbacks)
         containerPlugins = getPlugins(.container, defaultPlugins: containerPlugins)
         corePlugins = getPlugins(.core, defaultPlugins: corePlugins)
     }
-
-    fileprivate func getPlugins(_ type: PluginType, defaultPlugins: [Plugin.Type]) -> [Plugin.Type] {
+    
+    private func getPlugins(_ type: PluginType, defaultPlugins: [Plugin.Type]) -> [Plugin.Type] {
         guard let externalPlugins = externalPlugins else { return [] }
         let filteredPlugins = externalPlugins.filter({ $0.type == type })
         return removeDuplicate(filteredPlugins + defaultPlugins)
     }
-
-    fileprivate func removeDuplicate(_ plugins: [Plugin.Type]) -> [Plugin.Type] {
+    
+    private func removeDuplicate(_ plugins: [Plugin.Type]) -> [Plugin.Type] {
         var result = [Plugin.Type]()
-
+        
         for plugin in plugins {
             if !result.contains(where: { $0.name == plugin.name }) {
                 result.append(plugin)
             }
         }
-
+        
         return result
     }
 }

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -22,8 +22,8 @@ open class Loader {
             "\n - core: \(corePlugins.map({ $0.name }))")
     }
     
-    open func addExternalPlugins(_ externalPlugins: [Plugin.Type]) {
-        externalPlugins.forEach { plugin in
+    open func register(plugins: [Plugin.Type]) {
+        plugins.forEach { plugin in
             self.plugins[plugin.name] = plugin
         }
     }

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -10,7 +10,7 @@ open class Loader {
     #endif
     internal(set) open var corePlugins = [Plugin.Type]()
     
-    private var externalPlugins: [Plugin.Type]?
+    var externalPlugins: [Plugin.Type] = []
     
     private init() {
         Logger.logInfo("plugins:" +
@@ -20,14 +20,14 @@ open class Loader {
     }
     
     open func addExternalPlugins(_ externalPlugins: [Plugin.Type]) {
-        self.externalPlugins = externalPlugins
+        self.externalPlugins.append(contentsOf: externalPlugins)
+        self.externalPlugins = self.removeDuplicate(self.externalPlugins)
         playbacks = getPlugins(.playback, defaultPlugins: playbacks)
         containerPlugins = getPlugins(.container, defaultPlugins: containerPlugins)
         corePlugins = getPlugins(.core, defaultPlugins: corePlugins)
     }
     
     private func getPlugins(_ type: PluginType, defaultPlugins: [Plugin.Type]) -> [Plugin.Type] {
-        guard let externalPlugins = externalPlugins else { return [] }
         let filteredPlugins = externalPlugins.filter({ $0.type == type })
         return removeDuplicate(filteredPlugins + defaultPlugins)
     }

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -27,5 +27,20 @@ open class Loader {
             self.plugins[plugin.name] = plugin
         }
     }
-
+    
+    open func loadPlugins(in core: Core) {
+        for plugin in Loader.shared.corePlugins {
+            if let corePlugin = plugin.init(context: core) as? UICorePlugin {
+                core.addPlugin(corePlugin)
+            }
+        }
+    }
+    
+    open func loadPlugins(in container: Container) {
+        for plugin in Loader.shared.containerPlugins {
+            if let containerPlugin = plugin.init(context: container) as? UIContainerPlugin {
+                container.addPlugin(containerPlugin)
+            }
+        }
+    }
 }

--- a/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
+++ b/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
@@ -6,7 +6,7 @@ open class PlaybackFactory {
     }
 
     open func createPlayback() -> Playback {
-        let availablePlaybacks = Loader.shared.playbacks.first { type in canPlay(type) }
+        let availablePlaybacks = Loader.shared.playbacks.first { playback in canPlay(playback) }
         if let playback = availablePlaybacks as? Playback.Type {
             return playback.init(options: options)
         }

--- a/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
+++ b/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
@@ -1,14 +1,12 @@
 open class PlaybackFactory {
-    fileprivate var loader: Loader
     fileprivate var options: Options
 
-    public init(loader: Loader = Loader(), options: Options = [:]) {
-        self.loader = loader
+    public init(options: Options = [:]) {
         self.options = options
     }
 
     open func createPlayback() -> Playback {
-        let availablePlaybacks = loader.playbackPlugins.first { type in canPlay(type) }
+        let availablePlaybacks = Loader.shared.playbacks.first { type in canPlay(type) }
         if let playback = availablePlaybacks as? Playback.Type {
             return playback.init(options: options)
         }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -83,10 +83,9 @@ open class Player: BaseObject {
              Event.seek.rawValue, Event.didSeek.rawValue,
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
-        let loader = Loader(options: options)
-        loader.addExternalPlugins(externalPlugins)
+        Loader.shared.addExternalPlugins(externalPlugins)
         
-        setCore(Core(loader: loader, options: options))
+        setCore(Core(options: options))
     }
 
     fileprivate func setCore(_ core: Core) {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -164,11 +164,13 @@ open class Player: BaseObject {
     }
     
     public static func register(plugins: [Plugin.Type]) {
-        if(!hasAlreadyRegisteredPlugins) {
+        if !hasAlreadyRegisteredPlugins {
             var builtInPlugins: [Plugin.Type] = [AVFoundationPlayback.self]
+            
             #if os (iOS)
             builtInPlugins.append(contentsOf: [PosterPlugin.self, SpinnerPlugin.self])
             #endif
+            
             Loader.shared.register(plugins: builtInPlugins)
             hasAlreadyRegisteredPlugins = true
         }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -3,7 +3,7 @@ open class Player: BaseObject {
     @objc open var playbackEventsToListen: [String] = []
     fileprivate var playbackEventsListenIds: [String] = []
     @objc fileprivate(set) open var core: Core?
-    private var plugins: [Plugin.Type] = []
+    private static var plugins: [Plugin.Type] = []
 
     @objc open var activeContainer: Container? {
         return core?.activeContainer
@@ -85,7 +85,7 @@ open class Player: BaseObject {
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
         Loader.shared.addExternalPlugins(externalPlugins)
-        Loader.shared.addExternalPlugins(plugins)
+        Loader.shared.addExternalPlugins(Player.plugins)
 
         setCore(Core(options: options))
     }
@@ -169,7 +169,7 @@ open class Player: BaseObject {
         trigger(event.rawValue, userInfo: userInfo)
     }
     
-    func register(plugin: Plugin.Type) {
+    public static func register(plugin: Plugin.Type) {
         plugins.append(plugin.self)
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -84,6 +84,12 @@ open class Player: BaseObject {
              Event.seek.rawValue, Event.didSeek.rawValue,
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
+        var basePlugins: [Plugin.Type] = [AVFoundationPlayback.self]
+        #if os (iOS)
+        basePlugins.append(contentsOf: [PosterPlugin.self, SpinnerPlugin.self])
+        #endif
+
+        Loader.shared.addExternalPlugins(basePlugins)
         Loader.shared.addExternalPlugins(externalPlugins)
         Loader.shared.addExternalPlugins(Player.appPlugins)
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -166,11 +166,11 @@ open class Player: BaseObject {
     public static func register(plugins: [Plugin.Type]) {
         if !hasAlreadyRegisteredPlugins {
             var builtInPlugins: [Plugin.Type] = [AVFoundationPlayback.self]
-            
+
             #if os (iOS)
             builtInPlugins.append(contentsOf: [PosterPlugin.self, SpinnerPlugin.self])
             #endif
-            
+
             Loader.shared.register(plugins: builtInPlugins)
             hasAlreadyRegisteredPlugins = true
         }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -83,8 +83,9 @@ open class Player: BaseObject {
              Event.seek.rawValue, Event.didSeek.rawValue,
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
-        let loader = Loader(externalPlugins: externalPlugins, options: options)
-
+        let loader = Loader(options: options)
+        loader.addExternalPlugins(externalPlugins)
+        
         setCore(Core(loader: loader, options: options))
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -3,6 +3,7 @@ open class Player: BaseObject {
     @objc open var playbackEventsToListen: [String] = []
     fileprivate var playbackEventsListenIds: [String] = []
     @objc fileprivate(set) open var core: Core?
+    private var plugins: [Plugin.Type] = []
 
     @objc open var activeContainer: Container? {
         return core?.activeContainer
@@ -84,7 +85,8 @@ open class Player: BaseObject {
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
         Loader.shared.addExternalPlugins(externalPlugins)
-        
+        Loader.shared.addExternalPlugins(plugins)
+
         setCore(Core(options: options))
     }
 
@@ -165,6 +167,10 @@ open class Player: BaseObject {
 
     fileprivate func forward(_ event: Event, userInfo: EventUserInfo) {
         trigger(event.rawValue, userInfo: userInfo)
+    }
+    
+    func register(plugin: Plugin.Type) {
+        plugins.append(plugin.self)
     }
 
     @objc open func destroy() {

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -117,10 +117,9 @@ open class Player: UIViewController, BaseObject {
              Event.seek.rawValue,Event.didSeek.rawValue,
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
-        let loader = Loader(options: options)
-        loader.addExternalPlugins(externalPlugins)
+        Loader.shared.addExternalPlugins(externalPlugins)
         
-        setCore(Core(loader: loader, options: options))
+        setCore(Core(options: options))
     }
 
     required public init?(coder aDecoder: NSCoder) {

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -117,8 +117,9 @@ open class Player: UIViewController, BaseObject {
              Event.seek.rawValue,Event.didSeek.rawValue,
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
-        let loader = Loader(externalPlugins: externalPlugins, options: options)
-
+        let loader = Loader(options: options)
+        loader.addExternalPlugins(externalPlugins)
+        
         setCore(Core(loader: loader, options: options))
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -117,7 +117,7 @@ open class Player: UIViewController, BaseObject {
              Event.seek.rawValue,Event.didSeek.rawValue,
              Event.subtitleSelected.rawValue, Event.audioSelected.rawValue])
 
-        Loader.shared.addExternalPlugins(externalPlugins)
+        Loader.shared.register(plugins: externalPlugins)
         
         setCore(Core(options: options))
     }

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -14,18 +14,13 @@ class ContainerTests: QuickSpec {
         describe(".Container") {
 
             var container: Container!
-            var loader: Loader!
-
-            beforeEach {
-                loader = Loader()
-            }
 
             describe("#Init") {
 
                 context("with a invalid resource") {
 
                     beforeEach {
-                        container = Container(loader: loader, options: Resource.invalid)
+                        container = Container(options: Resource.invalid)
                     }
 
                     it("creates a container with invalid playback") {
@@ -36,7 +31,7 @@ class ContainerTests: QuickSpec {
                 context("with a valid resource") {
 
                     beforeEach {
-                        container = Container(loader: loader, options: Resource.valid)
+                        container = Container(options: Resource.valid)
                     }
 
                     it("creates a container with valid playback") {
@@ -47,14 +42,14 @@ class ContainerTests: QuickSpec {
                 context("when resource is not empty") {
 
                     beforeEach {
-                        container = Container(loader: loader, options: Resource.valid)
+                        container = Container(options: Resource.valid)
                     }
 
                     context("and add container plugins from loader") {
 
                         beforeEach {
-                            loader.addExternalPlugins([FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
-                            container = Container(loader: loader, options: [:])
+                            Loader.shared.addExternalPlugins([FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
+                            container = Container(options: [:])
                         }
 
                         it("saves plugins on container") {
@@ -102,7 +97,7 @@ class ContainerTests: QuickSpec {
                 context("when resource is empty") {
 
                     beforeEach {
-                        container = Container(loader: loader, options: [:])
+                        container = Container(options: [:])
                     }
 
                     it("set playback as subview") {
@@ -118,7 +113,7 @@ class ContainerTests: QuickSpec {
             describe("#Destroy") {
 
                 beforeEach {
-                    container = Container(loader: loader, options: [:])
+                    container = Container(options: [:])
                 }
 
                 it("remove container from superview") {
@@ -170,8 +165,8 @@ class ContainerTests: QuickSpec {
                 }
 
                 it("destroy all plugins and clear plugins list") {
-                    loader.addExternalPlugins([FakeContainerPlugin.self])
-                    let container = Container(loader: loader, options: [:])
+                    Loader.shared.addExternalPlugins([FakeContainerPlugin.self])
+                    let container = Container(options: [:])
                     var countOfDestroyedPlugins = 0
 
                     container.plugins.forEach { plugin in
@@ -194,7 +189,7 @@ class ContainerTests: QuickSpec {
                     let source: String = Resource.valid[kSourceUrl]!
 
                     beforeEach {
-                        container = Container(loader: loader, options: [:])
+                        container = Container(options: [:])
                     }
 
                     it("loads a valid playback") {
@@ -217,7 +212,7 @@ class ContainerTests: QuickSpec {
                     let source: String = Resource.invalid[kSourceUrl]!
 
                     beforeEach {
-                        container = Container(loader: loader, options: [:])
+                        container = Container(options: [:])
                     }
 
                     it("set playback as a 'noop' playback") {
@@ -248,15 +243,14 @@ class ContainerTests: QuickSpec {
             context("when play event is trigger") {
 
                 beforeEach {
-                    loader = Loader()
-                    loader.addExternalPlugins([StubPlayback.self])
-                    container = Container(loader: loader, options: [kSourceUrl: "http://clappr.com/video.mp4"])
+                    Loader.shared.addExternalPlugins([StubPlayback.self])
+                    container = Container(options: [kSourceUrl: "http://clappr.com/video.mp4"])
                 }
 
                 it("reset startAt after first play event") {
 
                     let options = [kSourceUrl: "someUrl", kStartAt: 15.0] as Options
-                    let container = Container(loader: loader, options: options)
+                    let container = Container(options: options)
 
                     expect(container.options[kStartAt] as? TimeInterval) == 15.0
                     expect(container.playback?.startAt) == 15.0
@@ -287,7 +281,7 @@ class ContainerTests: QuickSpec {
                 context("when stores a value on sharedData") {
 
                     beforeEach {
-                        container = Container(loader: loader, options: Resource.valid)
+                        container = Container(options: Resource.valid)
                         container.sharedData.storeDictionary["testKey"] = "testValue"
                     }
 

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -32,6 +32,7 @@ class ContainerTests: QuickSpec {
                 context("with a valid resource") {
 
                     beforeEach {
+                        Loader.shared.addExternalPlugins([AVFoundationPlayback.self])
                         container = Container(options: Resource.valid)
                     }
 
@@ -83,6 +84,9 @@ class ContainerTests: QuickSpec {
                         let options = ["aOption": "option"]
                         let container = Container(options: options)
                         let option = container.options["aOption"] as! String
+                        let plugins: [Plugin.Type] = [AVFoundationPlayback.self, SpinnerPlugin.self]
+
+                        Loader.shared.addExternalPlugins(plugins)
 
                         expect(option) == "option"
                     }
@@ -191,6 +195,7 @@ class ContainerTests: QuickSpec {
                     let source: String = Resource.valid[kSourceUrl]!
 
                     beforeEach {
+                        Loader.shared.addExternalPlugins([AVFoundationPlayback.self])
                         container = Container(options: [:])
                     }
 

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -32,7 +32,7 @@ class ContainerTests: QuickSpec {
                 context("with a valid resource") {
 
                     beforeEach {
-                        Loader.shared.addExternalPlugins([AVFoundationPlayback.self])
+                        Loader.shared.register(plugins: [AVFoundationPlayback.self])
                         container = Container(options: Resource.valid)
                     }
 
@@ -50,7 +50,7 @@ class ContainerTests: QuickSpec {
                     context("and add container plugins from loader") {
 
                         beforeEach {
-                            Loader.shared.addExternalPlugins([FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
+                            Loader.shared.register(plugins: [FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
                             container = Container(options: [:])
                         }
 
@@ -86,7 +86,7 @@ class ContainerTests: QuickSpec {
                         let option = container.options["aOption"] as! String
                         let plugins: [Plugin.Type] = [AVFoundationPlayback.self, SpinnerPlugin.self]
 
-                        Loader.shared.addExternalPlugins(plugins)
+                        Loader.shared.register(plugins: plugins)
 
                         expect(option) == "option"
                     }
@@ -171,7 +171,7 @@ class ContainerTests: QuickSpec {
                 }
 
                 it("destroy all plugins and clear plugins list") {
-                    Loader.shared.addExternalPlugins([FakeContainerPlugin.self])
+                    Loader.shared.register(plugins: [FakeContainerPlugin.self])
                     let container = Container(options: [:])
                     var countOfDestroyedPlugins = 0
 
@@ -195,7 +195,7 @@ class ContainerTests: QuickSpec {
                     let source: String = Resource.valid[kSourceUrl]!
 
                     beforeEach {
-                        Loader.shared.addExternalPlugins([AVFoundationPlayback.self])
+                        Loader.shared.register(plugins: [AVFoundationPlayback.self])
                         container = Container(options: [:])
                     }
 
@@ -251,7 +251,7 @@ class ContainerTests: QuickSpec {
 
                 beforeEach {
                     Loader.shared.resetPlugins()
-                    Loader.shared.addExternalPlugins([StubPlayback.self])
+                    Loader.shared.register(plugins: [StubPlayback.self])
                     container = Container(options: [kSourceUrl: "http://clappr.com/video.mp4"])
                 }
 

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -21,6 +21,7 @@ class ContainerTests: QuickSpec {
 
                     beforeEach {
                         container = Container(options: Resource.invalid)
+                        Loader.shared.resetPlugins()
                     }
 
                     it("creates a container with invalid playback") {
@@ -114,6 +115,7 @@ class ContainerTests: QuickSpec {
 
                 beforeEach {
                     container = Container(options: [:])
+                    Loader.shared.resetPlugins()
                 }
 
                 it("remove container from superview") {
@@ -243,6 +245,7 @@ class ContainerTests: QuickSpec {
             context("when play event is trigger") {
 
                 beforeEach {
+                    Loader.shared.resetPlugins()
                     Loader.shared.addExternalPlugins([StubPlayback.self])
                     container = Container(options: [kSourceUrl: "http://clappr.com/video.mp4"])
                 }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -19,10 +19,11 @@ class CoreTests: QuickSpec {
 
         let options = [kSourceUrl: "http//test.com"]
         var core: Core!
-        Loader.shared.addExternalPlugins([StubPlayback.self])
 
         beforeEach {
             core = Core(options: options as Options)
+            Loader.shared.resetPlugins()
+            Loader.shared.addExternalPlugins([StubPlayback.self])
         }
 
         describe(".Core") {

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -23,7 +23,7 @@ class CoreTests: QuickSpec {
         beforeEach {
             core = Core(options: options as Options)
             Loader.shared.resetPlugins()
-            Loader.shared.addExternalPlugins([StubPlayback.self])
+            Loader.shared.register(plugins: [StubPlayback.self])
         }
 
         describe(".Core") {
@@ -665,7 +665,7 @@ class CoreTests: QuickSpec {
 
             context("core position") {
                 it("is positioned in front of Container view") {
-                    Loader.shared.addExternalPlugins([FakeCorePlugin.self])
+                    Loader.shared.register(plugins: [FakeCorePlugin.self])
                     let core = Core(options: options as Options)
 
                     core.render()

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -19,10 +19,10 @@ class CoreTests: QuickSpec {
 
         let options = [kSourceUrl: "http//test.com"]
         var core: Core!
-        let loader = Loader(externalPlugins: [StubPlayback.self])
+        Loader.shared.addExternalPlugins([StubPlayback.self])
 
         beforeEach {
-            core = Core(loader: loader, options: options as Options)
+            core = Core(options: options as Options)
         }
 
         describe(".Core") {
@@ -30,7 +30,7 @@ class CoreTests: QuickSpec {
             describe("#init") {
 
                 beforeEach {
-                    core = Core(loader: loader, options: options as Options)
+                    core = Core(options: options as Options)
                 }
                 
                 it("set backgroundColor to black") {
@@ -43,7 +43,7 @@ class CoreTests: QuickSpec {
 
                 it("save options passed on parameter") {
                     let options = ["SomeOption": true]
-                    let core = Core(loader: loader, options: options as Options)
+                    let core = Core(options: options as Options)
 
                     expect(core.options["SomeOption"] as? Bool) == true
                 }
@@ -664,8 +664,8 @@ class CoreTests: QuickSpec {
 
             context("core position") {
                 it("is positioned in front of Container view") {
-                    let loader = Loader(externalPlugins: [FakeCorePlugin.self])
-                    let core = Core(loader: loader, options: options as Options)
+                    Loader.shared.addExternalPlugins([FakeCorePlugin.self])
+                    let core = Core(options: options as Options)
 
                     core.render()
 

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -7,36 +7,29 @@ class LoaderTests: QuickSpec {
     override func spec() {
         context("Loader") {
             it("adds external plugins to default plugins") {
-                let loader = Loader()
 
-                let nativePlaybackPluginsCount = loader.playbackPlugins.count
-                let nativeContainerPluginsCount = loader.containerPlugins.count
-                let nativeCorePluginsCount = loader.corePlugins.count
+                let playbacksCount = Loader.shared.playbacks.count
+                let containerPluginsCount = Loader.shared.containerPlugins.count
+                let corePluginsCount = Loader.shared.corePlugins.count
 
-                loader.addExternalPlugins([StubPlayback.self, StubContainerPlugin.self, StubCorePlugin.self])
+                Loader.shared.addExternalPlugins([StubPlayback.self, StubContainerPlugin.self, StubCorePlugin.self])
 
-                expect(loader.playbackPlugins.count) == nativePlaybackPluginsCount + 1
-                expect(loader.containerPlugins.count) == nativeContainerPluginsCount + 1
-                expect(loader.corePlugins.count) == nativeCorePluginsCount + 1
+                expect(Loader.shared.playbacks.count) == playbacksCount + 1
+                expect(Loader.shared.containerPlugins.count) == containerPluginsCount + 1
+                expect(Loader.shared.corePlugins.count) == corePluginsCount + 1
             }
 
             it("gives more priority for external plugin if names colide") {
-                let loader = Loader()
 
-                expect(loader.containerPlugins.filter({ $0.name == "spinner" }).count) == 1
+                expect(Loader.shared.containerPlugins.filter({ $0.name == "spinner" }).count) == 1
 
-                loader.addExternalPlugins([StubSpinnerPlugin.self])
+                Loader.shared.addExternalPlugins([StubSpinnerPlugin.self])
 
-                let spinnerPlugins = loader.containerPlugins.filter({ $0.name == "spinner" })
+                let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
                 let spinner = spinnerPlugins[0].init() as? StubSpinnerPlugin
 
                 expect(spinnerPlugins.count) == 1
                 expect(spinner).toNot(beNil())
-            }
-
-            it("sets custom Media Control") {
-                let loader = Loader(externalPlugins: [], options: [kMediaControl: StubMediaControl.self])
-                expect(loader.mediaControl.loadNib()?.accessibilityHint).to(equal("StubMediaControl"))
             }
         }
     }

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -1,36 +1,75 @@
 import Quick
 import Nimble
+
 @testable import Clappr
 
 class LoaderTests: QuickSpec {
 
     override func spec() {
-        context("Loader") {
-            it("adds external plugins to default plugins") {
+        describe(".Loader") {
 
+            beforeEach {
                 Loader.shared.resetPlugins()
-                let playbacksCount = Loader.shared.playbacks.count
-                let containerPluginsCount = Loader.shared.containerPlugins.count
-                let corePluginsCount = Loader.shared.corePlugins.count
-
-                Loader.shared.addExternalPlugins([StubPlayback.self, StubContainerPlugin.self, StubCorePlugin.self])
-
-                expect(Loader.shared.playbacks.count) == playbacksCount + 1
-                expect(Loader.shared.containerPlugins.count) == containerPluginsCount + 1
-                expect(Loader.shared.corePlugins.count) == corePluginsCount + 1
             }
 
-            it("gives more priority for external plugin if names colide") {
+            context("when adds external playbacks") {
+                it("adds only playback to the correct array in Loader") {
+                    let numberOfInitialPlaybacks = Loader.shared.playbacks.count
+                    let numberOfContainerPlugins = Loader.shared.containerPlugins.count
+                    let numberOfCorePlugins = Loader.shared.corePlugins.count
 
-                expect(Loader.shared.containerPlugins.filter({ $0.name == "spinner" }).count) == 1
+                    Loader.shared.addExternalPlugins([StubPlayback.self])
 
-                Loader.shared.addExternalPlugins([StubSpinnerPlugin.self])
+                    expect(Loader.shared.playbacks.count).to(equal(numberOfInitialPlaybacks + 1))
+                    expect(Loader.shared.containerPlugins.count).to(equal(numberOfContainerPlugins))
+                    expect(Loader.shared.corePlugins.count).to(equal(numberOfCorePlugins))
+                }
+            }
 
-                let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
-                let spinner = spinnerPlugins[0].init() as? StubSpinnerPlugin
+            context("when adds container plugins") {
+                it("adds only container to the correct array in Loader") {
+                    let numberOfInitialPlaybacks = Loader.shared.playbacks.count
+                    let numberOfContainerPlugins = Loader.shared.containerPlugins.count
+                    let numberOfCorePlugins = Loader.shared.corePlugins.count
 
-                expect(spinnerPlugins.count) == 1
-                expect(spinner).toNot(beNil())
+                    Loader.shared.addExternalPlugins([StubContainerPlugin.self])
+
+                    expect(Loader.shared.playbacks.count).to(equal(numberOfInitialPlaybacks))
+                    expect(Loader.shared.containerPlugins.count).to(equal(numberOfContainerPlugins + 1))
+                    expect(Loader.shared.corePlugins.count).to(equal(numberOfCorePlugins))
+                }
+            }
+            
+            context("when adds core plugins") {
+                it("adds only core to the correct array in Loader") {
+                    let numberOfInitialPlaybacks = Loader.shared.playbacks.count
+                    let numberOfContainerPlugins = Loader.shared.containerPlugins.count
+                    let numberOfCorePlugins = Loader.shared.corePlugins.count
+
+                    Loader.shared.addExternalPlugins([StubCorePlugin.self])
+
+                    expect(Loader.shared.playbacks.count).to(equal(numberOfInitialPlaybacks))
+                    expect(Loader.shared.containerPlugins.count).to(equal(numberOfContainerPlugins))
+                    expect(Loader.shared.corePlugins.count).to(equal(numberOfCorePlugins + 1))
+                }
+            }
+            
+            context("when adds plugin with same name") {
+                it("has one previous plugin with the same name") {
+                    let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
+
+                    expect(spinnerPlugins.count).to(equal(1))
+                }
+
+                it("gives priority to external plugin") {
+                    Loader.shared.addExternalPlugins([StubSpinnerPlugin.self])
+
+                    let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
+                    let spinner = spinnerPlugins.first?.init() as? StubSpinnerPlugin
+
+                    expect(spinnerPlugins.count).to(equal(1))
+                    expect(spinner).to(beAKindOf(StubSpinnerPlugin.self))
+                }
             }
         }
     }

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -18,7 +18,7 @@ class LoaderTests: QuickSpec {
                     let numberOfContainerPlugins = Loader.shared.containerPlugins.count
                     let numberOfCorePlugins = Loader.shared.corePlugins.count
 
-                    Loader.shared.addExternalPlugins([StubPlayback.self])
+                    Loader.shared.register(plugins: [StubPlayback.self])
 
                     expect(Loader.shared.playbacks.count).to(equal(numberOfInitialPlaybacks + 1))
                     expect(Loader.shared.containerPlugins.count).to(equal(numberOfContainerPlugins))
@@ -32,7 +32,7 @@ class LoaderTests: QuickSpec {
                     let numberOfContainerPlugins = Loader.shared.containerPlugins.count
                     let numberOfCorePlugins = Loader.shared.corePlugins.count
 
-                    Loader.shared.addExternalPlugins([StubContainerPlugin.self])
+                    Loader.shared.register(plugins: [StubContainerPlugin.self])
 
                     expect(Loader.shared.playbacks.count).to(equal(numberOfInitialPlaybacks))
                     expect(Loader.shared.containerPlugins.count).to(equal(numberOfContainerPlugins + 1))
@@ -46,7 +46,7 @@ class LoaderTests: QuickSpec {
                     let numberOfContainerPlugins = Loader.shared.containerPlugins.count
                     let numberOfCorePlugins = Loader.shared.corePlugins.count
 
-                    Loader.shared.addExternalPlugins([StubCorePlugin.self])
+                    Loader.shared.register(plugins: [StubCorePlugin.self])
 
                     expect(Loader.shared.playbacks.count).to(equal(numberOfInitialPlaybacks))
                     expect(Loader.shared.containerPlugins.count).to(equal(numberOfContainerPlugins))
@@ -56,14 +56,14 @@ class LoaderTests: QuickSpec {
             
             context("when adds plugin with same name") {
                 it("has one previous plugin with the same name") {
-                    Loader.shared.addExternalPlugins([StubSpinnerPlugin.self])
+                    Loader.shared.register(plugins: [StubSpinnerPlugin.self])
                     let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
 
                     expect(spinnerPlugins.count).to(equal(1))
                 }
 
                 it("gives priority to external plugin") {
-                    Loader.shared.addExternalPlugins([StubSpinnerPlugin.self])
+                    Loader.shared.register(plugins: [StubSpinnerPlugin.self])
                     let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
                     let spinner = spinnerPlugins.first?.init() as? StubSpinnerPlugin
 

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -56,6 +56,7 @@ class LoaderTests: QuickSpec {
             
             context("when adds plugin with same name") {
                 it("has one previous plugin with the same name") {
+                    Loader.shared.addExternalPlugins([StubSpinnerPlugin.self])
                     let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
 
                     expect(spinnerPlugins.count).to(equal(1))
@@ -63,7 +64,6 @@ class LoaderTests: QuickSpec {
 
                 it("gives priority to external plugin") {
                     Loader.shared.addExternalPlugins([StubSpinnerPlugin.self])
-
                     let spinnerPlugins = Loader.shared.containerPlugins.filter({ $0.name == "spinner" })
                     let spinner = spinnerPlugins.first?.init() as? StubSpinnerPlugin
 

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -8,6 +8,7 @@ class LoaderTests: QuickSpec {
         context("Loader") {
             it("adds external plugins to default plugins") {
 
+                Loader.shared.resetPlugins()
                 let playbacksCount = Loader.shared.playbacks.count
                 let containerPluginsCount = Loader.shared.containerPlugins.count
                 let corePluginsCount = Loader.shared.corePlugins.count

--- a/Tests/Clappr_Tests/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/MediaControlTests.swift
@@ -11,6 +11,7 @@ class MediaControlTests: QuickSpec {
             var playback: StubedPlayback!
 
             beforeEach {
+                Loader.shared.resetPlugins()
                 Loader.shared.addExternalPlugins([StubedPlayback.self])
                 container = Container(options: options as Options)
                 playback = container.playback as! StubedPlayback

--- a/Tests/Clappr_Tests/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/MediaControlTests.swift
@@ -11,9 +11,8 @@ class MediaControlTests: QuickSpec {
             var playback: StubedPlayback!
 
             beforeEach {
-                let loader = Loader()
-                loader.addExternalPlugins([StubedPlayback.self])
-                container = Container(loader: loader, options: options as Options)
+                Loader.shared.addExternalPlugins([StubedPlayback.self])
+                container = Container(options: options as Options)
                 playback = container.playback as! StubedPlayback
             }
 

--- a/Tests/Clappr_Tests/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/MediaControlTests.swift
@@ -12,7 +12,7 @@ class MediaControlTests: QuickSpec {
 
             beforeEach {
                 Loader.shared.resetPlugins()
-                Loader.shared.addExternalPlugins([StubedPlayback.self])
+                Loader.shared.register(plugins: [StubedPlayback.self])
                 container = Container(options: options as Options)
                 playback = container.playback as! StubedPlayback
             }

--- a/Tests/Clappr_Tests/PlaybackFactoryTests.swift
+++ b/Tests/Clappr_Tests/PlaybackFactoryTests.swift
@@ -9,7 +9,7 @@ class PlaybackFactoryTests: QuickSpec {
         let optionsWithInvalidSource = [kSourceUrl: "invalid"]
 
         beforeEach {
-            Loader.shared.playbacks = []
+            Loader.shared.resetPlugins()
             Loader.shared.addExternalPlugins([StubPlayback.self])
         }
 

--- a/Tests/Clappr_Tests/PlaybackFactoryTests.swift
+++ b/Tests/Clappr_Tests/PlaybackFactoryTests.swift
@@ -7,22 +7,21 @@ class PlaybackFactoryTests: QuickSpec {
     override func spec() {
         let optionsWithValidSource = [kSourceUrl: "http://test.com"]
         let optionsWithInvalidSource = [kSourceUrl: "invalid"]
-        var loader: Loader!
 
         beforeEach {
-            loader = Loader()
-            loader.addExternalPlugins([StubPlayback.self])
+            Loader.shared.playbacks = []
+            Loader.shared.addExternalPlugins([StubPlayback.self])
         }
 
         context("Playback creation") {
             it("Should create a valid playback for a valid source") {
-                let factory = PlaybackFactory(loader: loader, options: optionsWithValidSource as Options)
+                let factory = PlaybackFactory(options: optionsWithValidSource as Options)
 
                 expect(factory.createPlayback().pluginName) == "AVPlayback"
             }
 
             it("Should create an invalid playback for url that cannot be played") {
-                let factory = PlaybackFactory(loader: loader, options: optionsWithInvalidSource as Options)
+                let factory = PlaybackFactory(options: optionsWithInvalidSource as Options)
 
                 expect(factory.createPlayback().pluginName) == "NoOp"
             }

--- a/Tests/Clappr_Tests/PlaybackFactoryTests.swift
+++ b/Tests/Clappr_Tests/PlaybackFactoryTests.swift
@@ -10,7 +10,7 @@ class PlaybackFactoryTests: QuickSpec {
 
         beforeEach {
             Loader.shared.resetPlugins()
-            Loader.shared.addExternalPlugins([StubPlayback.self])
+            Loader.shared.register(plugins: [StubPlayback.self])
         }
 
         context("Playback creation") {

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -18,7 +18,7 @@ class PlayerTests: QuickSpec {
                     var callbackWasCalled = false
 
                     beforeEach {
-                        self.resetPlugins()
+                        Loader.shared.resetPlugins()
                         Player.register(plugins: [SpecialStubPlayback.self, StubPlayback.self])
                         player = Player(options: options)
                         playback = player.activePlayback
@@ -220,7 +220,7 @@ class PlayerTests: QuickSpec {
 
                 context("external playbacks") {
                     it("sets external playback as active") {
-                        self.resetPlugins()
+                        Loader.shared.resetPlugins()
                         Player.register(plugins: [StubPlayback.self])
                         player = Player(options: options)
                         playback = player.activePlayback
@@ -229,7 +229,7 @@ class PlayerTests: QuickSpec {
                     }
 
                     it("changes external playback based on source") {
-                        self.resetPlugins()
+                        Loader.shared.resetPlugins()
                         Player.register(plugins: [SpecialStubPlayback.self])
                         player = Player(options: options)
                         
@@ -243,7 +243,7 @@ class PlayerTests: QuickSpec {
 
                 context("third party plugins") {
                     it("pass plugins to core") {
-                        self.resetPlugins()
+                        Loader.shared.resetPlugins()
 
                         Player.register(plugins: [LoggerPlugin.self])
                         player = Player(options: options)
@@ -253,7 +253,7 @@ class PlayerTests: QuickSpec {
                     }
                     
                     it("pass plugins to Loader") {
-                        self.resetPlugins()
+                        Loader.shared.resetPlugins()
                         
                         Player.register(plugins: [LoggerPlugin.self])
                         player = Player(options: options)
@@ -263,7 +263,7 @@ class PlayerTests: QuickSpec {
                     }
 
                     it("ignore plugins registered after player initialization") {
-                        self.resetPlugins()
+                        Loader.shared.resetPlugins()
                         Player.register(plugins: [SpecialStubPlayback.self, StubPlayback.self])
                         player = Player(options: options)
 
@@ -277,7 +277,7 @@ class PlayerTests: QuickSpec {
 
             describe("#configure") {
                 it("changes Core options") {
-                    self.resetPlugins()
+                    Loader.shared.resetPlugins()
                     Player.register(plugins: [SpecialStubPlayback.self, StubPlayback.self])
                     player = Player(options: options)
                     player.configure(options: ["foo": "bar"])
@@ -288,12 +288,6 @@ class PlayerTests: QuickSpec {
                 }
             }
         }
-    }
-
-    private func resetPlugins() {
-        Loader.shared.resetPlugins()
-        Player.hasAlreadyRegisteredPlugins = false
-        
     }
 
     class StubPlayback: Playback {

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -8,85 +8,281 @@ class PlayerTests: QuickSpec {
     static let specialSource = "specialSource"
     
     override func spec() {
-        describe("Player") {
-            
-            let options = [kSourceUrl: "http://clappr.com/video.mp4"]
-            
+        describe(".Player") {
+            let options: Options = [kSourceUrl: "http://clappr.com/video.mp4"]
             var player: Player!
-            var playback: StubPlayback!
-            
-            beforeEach {
-                Loader.shared.resetPlugins()
-                player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
-                playback = player.activePlayback as! StubPlayback
-            }
-            
-            it("Should load source on core when initializing") {
-                let player = Player(options: options as Options)
-                
-                if let core = player.core {
-                    expect(core.activeContainer).toNot(beNil())
-                } else {
-                    fail("player.core is nil")
+            var playback: Playback!
+
+            context("#init") {
+                context("when listening Playback events") {
+                    var callbackWasCalled = false
+
+                    beforeEach {
+                        self.resetPlugins()
+                        player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+                        playback = player.activePlayback
+                        callbackWasCalled = false
+                    }
+
+                    it("calls a callback function to handle ready event") {
+                        player.on(.ready) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.ready)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle error event") {
+                        player.on(.error) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.error)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle didComplete event") {
+                        player.on(.didComplete) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.didComplete)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle didPause event") {
+                        player.on(.didPause) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.didPause)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle didStop event") {
+                        player.on(.didStop) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.didStop)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle stalled event") {
+                        player.on(.stalled) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.stalled)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle bufferUpdate event") {
+                        player.on(.bufferUpdate) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.bufferUpdate)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle positionUpdate event") {
+                        player.on(.positionUpdate) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.positionUpdate)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle airPlayStatusUpdate event") {
+                        player.on(.airPlayStatusUpdate) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.airPlayStatusUpdate)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle willPlay event") {
+                        player.on(.willPlay) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.willPlay)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle playing event") {
+                        player.on(.playing) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.playing)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle willPause event") {
+                        player.on(.willPause) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.willPause)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle willStop event") {
+                        player.on(.willStop) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.willStop)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle willSeek event") {
+                        player.on(.willSeek) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.willSeek)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle seek event") {
+                        player.on(.seek) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.seek)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle didSeek event") {
+                        player.on(.didSeek) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.didSeek)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle subtitleSelected event") {
+                        player.on(.subtitleSelected) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.subtitleSelected)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle audioSelected event") {
+                        player.on(.audioSelected) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.audioSelected)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle requestFullscreen event") {
+                        player.on(.requestFullscreen) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.requestFullscreen)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+
+                    it("calls a callback function to handle exitFullscreen event") {
+                        player.on(.exitFullscreen) { _ in
+                            callbackWasCalled = true
+                        }
+                        playback.trigger(.exitFullscreen)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                }
+
+                context("core dependency") {
+                    it("is initialized") {
+                        let player = Player(options: options)
+                        expect(player.core).toNot(beNil())
+                    }
+
+                    it("has active container") {
+                        let player = Player(options: options)
+                        expect(player.core?.activeContainer).toNot(beNil())
+                    }
+                }
+
+                context("external playbacks") {
+                    it("sets external playback as active") {
+                        self.resetPlugins()
+                        player = Player(options: options, externalPlugins: [StubPlayback.self])
+                        playback = player.activePlayback
+
+                        expect(player.activePlayback).to(beAKindOf(StubPlayback.self))
+                    }
+
+                    it("changes external playback based on source") {
+                        self.resetPlugins()
+                        player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+                        playback = player.activePlayback
+
+                        player.load(PlayerTests.specialSource)
+
+                        expect(player.activePlayback).to(beAKindOf(SpecialStubPlayback.self))
+                    }
+                }
+
+                context("plugins in loader") {
+                    it("pass only player plugins to loader") {
+                        self.resetPlugins()
+
+                        player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+
+                        expect(Loader.shared.externalPlugins.count).to(equal(2))
+                    }
+
+                    it("pass third party plugins to loader") {
+                        self.resetPlugins()
+
+                        Player.register(plugin: LoggerPlugin.self)
+                        player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+
+                        expect(Loader.shared.externalPlugins.count).to(equal(3))
+                    }
+
+                    it("ignore plugins registered after player initialization") {
+                        self.resetPlugins()
+                        player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+
+                        Player.register(plugin: LoggerPlugin.self)
+
+                        expect(Loader.shared.externalPlugins.count).to(equal(2))
+                    }
                 }
             }
             
-            it("Should listen to playing event") {
-                var callbackWasCalled = false
-                
-                player.on(.playing) { _ in
-                    callbackWasCalled = true
-                }
-                
-                playback.trigger(.playing)
-                expect(callbackWasCalled).to(beTrue())
-            }
-            
-            it("Should route events after new playback is created") {
-                var callbackWasCalled = false
-                
-                player.on(.playing) { _ in
-                    callbackWasCalled = true
-                }
-                
-                expect(player.activePlayback is StubPlayback).to(beTrue())
-                player.load(PlayerTests.specialSource)
-                expect(player.activePlayback is SpecialStubPlayback).to(beTrue())
-                
-                player.activePlayback?.trigger(.playing)
-                expect(callbackWasCalled).to(beTrue())
-            }
-            
-            describe("configure") {
+            describe("#configure") {
                 it("changes Core options") {
+                    self.resetPlugins()
+                    player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
                     player.configure(options: ["foo": "bar"])
+
+                    let playerOptionValue = player.core?.options["foo"] as? String
                     
-                    expect(player.core!.options["foo"] as? String).to(equal("bar"))
+                    expect(playerOptionValue).to(equal("bar"))
                 }
-            }
-            
-            it("Should listen to subtitleSelected event") {
-                var callbackWasCalled = false
-                
-                player.on(.subtitleSelected) { _ in
-                    callbackWasCalled = true
-                }
-                
-                playback.trigger(.subtitleSelected)
-                expect(callbackWasCalled).to(beTrue())
-            }
-            
-            it("Should listen to audioSelected event") {
-                var callbackWasCalled = false
-                
-                player.on(.audioSelected) { _ in
-                    callbackWasCalled = true
-                }
-                
-                playback.trigger(.audioSelected)
-                expect(callbackWasCalled).to(beTrue())
             }
         }
+    }
+
+    private func resetPlugins() {
+        Loader.shared.resetPlugins()
+        Player.appPlugins = []
     }
     
     class StubPlayback: Playback {
@@ -106,6 +302,36 @@ class PlayerTests: QuickSpec {
         
         override class func canPlay(_ options: Options) -> Bool {
             return options[kSourceUrl] as! String == PlayerTests.specialSource
+        }
+    }
+
+    class LoggerPlugin: UICorePlugin {
+        override var pluginName: String { return "Logger" }
+
+        required init(context: UIBaseObject) {
+            super.init(context: context)
+            bindEvents()
+        }
+
+        required init() {
+            super.init()
+        }
+
+        required init?(coder argument: NSCoder) {
+            super.init(coder: argument)
+        }
+
+        private func bindEvents() {
+            stopListening()
+            bindPlaybackEvents()
+        }
+
+        private func bindPlaybackEvents() {
+            if let core = self.core {
+                listenTo(core, eventName: InternalEvent.didChangeActivePlayback.rawValue) {  (_: EventUserInfo) in
+                    print("Log didChangeActivePlayback!!!!")
+                }
+            }
         }
     }
 }

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -243,7 +243,7 @@ class PlayerTests: QuickSpec {
 
                         player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
 
-                        expect(Loader.shared.externalPlugins.count).to(equal(2))
+                        expect(Loader.shared.plugins.count).to(equal(5))
                     }
 
                     it("pass third party plugins to loader") {
@@ -252,7 +252,7 @@ class PlayerTests: QuickSpec {
                         Player.register(plugin: LoggerPlugin.self)
                         player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
 
-                        expect(Loader.shared.externalPlugins.count).to(equal(3))
+                        expect(Loader.shared.plugins.count).to(equal(6))
                     }
 
                     it("ignore plugins registered after player initialization") {
@@ -261,7 +261,7 @@ class PlayerTests: QuickSpec {
 
                         Player.register(plugin: LoggerPlugin.self)
 
-                        expect(Loader.shared.externalPlugins.count).to(equal(2))
+                        expect(Loader.shared.plugins.count).to(equal(5))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -16,6 +16,7 @@ class PlayerTests: QuickSpec {
             var playback: StubPlayback!
             
             beforeEach {
+                Loader.shared.resetPlugins()
                 player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
                 playback = player.activePlayback as! StubPlayback
             }

--- a/Tests/Clappr_Tests/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/PosterPluginTests.swift
@@ -1,150 +1,150 @@
-//import Quick
-//import Nimble
-//@testable import Clappr
-//
-//class PosterPluginTests: QuickSpec {
-//
-//    override func spec() {
-//
-//        describe(".PosterPlugin") {
-//            var container: Container!
-//            let options = [
-//                kSourceUrl: "http://globo.com/video.mp4",
-//                kPosterUrl: "http://clappr.io/poster.png",
-//            ]
-//
-//            context("when container has no options") {
-//                it("hides itself") {
-//                    container = Container()
-//                    container.render()
-//
-//                    let posterPlugin = self.getPosterPlugin(container)
-//
-//                    expect(posterPlugin.isHidden).to(beTrue())
-//                }
-//            }
-//
-//            context("when container doesnt have posterUrl option") {
-//                it("hides itself") {
-//                    container = Container(options: ["anotherOption": true])
-//                    container.render()
-//
-//                    let posterPlugin = self.getPosterPlugin(container)
-//
-//                    expect(posterPlugin.isHidden).to(beTrue())
-//                }
-//            }
-//
-//            context("when container has posterUrl option") {
-//                it("it renders itself") {
-//                    container = Container(options: options)
-//                    container.render()
-//
-//                    let posterPlugin = self.getPosterPlugin(container)
-//
-//                    expect(posterPlugin.superview) == container
-//                }
-//            }
-//
-//            context("when changes the activePlayback") {
-//
-//                var posterPlugin: PosterPlugin!
-//
-//                beforeEach {
-//                    container = Container()
-//                }
-//
-//                context("to NoOpPlayback") {
-//
-//                    beforeEach {
-//                        container.playback = NoOpPlayback()
-//                        posterPlugin = self.getPosterPlugin(container)
-//                    }
-//
-//                    it("hides itself") {
-//                        expect(posterPlugin.isHidden).toEventually(beTrue())
-//                    }
-//
-//                    it("isNoOpPlayback is true") {
-//                        expect(posterPlugin.isNoOpPlayback) == true
-//                    }
-//
-//                    context("and change again to another playback") {
-//
-//                        beforeEach {
-//                            container.playback = AVFoundationPlayback()
-//                            posterPlugin = self.getPosterPlugin(container)
-//                        }
-//
-//                        it("hides itself") {
-//                            expect(posterPlugin.isHidden).toEventually(beTrue())
-//                        }
-//                    }
-//                }
-//
-//                context("to another a playback diferent from NoOpPlayback") {
-//
-//                    beforeEach {
-//                        container.playback = AVFoundationPlayback()
-//                        posterPlugin = self.getPosterPlugin(container)
-//                    }
-//
-//                    it("reveal itself") {
-//                        expect(posterPlugin.isHidden).toEventually(beFalse())
-//                    }
-//
-//                    it("isNoOpPlayback is true") {
-//                        expect(posterPlugin.isNoOpPlayback) == false
-//                    }
-//                }
-//            }
-//
-//            describe("Playback Events") {
-//                var posterPlugin: PosterPlugin!
-//
-//                beforeEach {
-//                    container = Container(options: options)
-//                    container.render()
-//                    posterPlugin = self.getPosterPlugin(container)
-//                }
-//
-//                context("when playback trigger a play event") {
-//                    it("hides itself") {
-//                        expect(posterPlugin.isHidden).to(beFalse())
-//                        container.playback?.trigger(Event.playing.rawValue)
-//                        expect(posterPlugin.isHidden).to(beTrue())
-//                    }
-//                }
-//
-//                context("when playback trigger a end event") {
-//                    it("reveal itself") {
-//                        container.playback?.trigger(Event.playing.rawValue)
-//                        container.playback?.trigger(Event.didComplete.rawValue)
-//
-//                        expect(posterPlugin.isHidden).to(beFalse())
-//                    }
-//                }
-//            }
-//
-//            describe("When receiving didUpdateOptions event") {
-//                var posterPlugin: PosterPlugin!
-//
-//                beforeEach {
-//                    container = Container(options: options)
-//                    container.render()
-//                    posterPlugin = self.getPosterPlugin(container)
-//                }
-//
-//                it("updates the poster") {
-//                    container.options[kPosterUrl] = "https://clappr.io/another-poster.png"
-//
-//                    expect(posterPlugin.poster.kf.webURL?.absoluteString).to(equal("https://clappr.io/another-poster.png"))
-//                }
-//            }
-//        }
-//    }
-//
-//    private func getPosterPlugin(_ container: Container) -> PosterPlugin {
-//        return container.plugins.filter({ $0.isKind(of: PosterPlugin.self) }).first as! PosterPlugin
-//    }
-//}
+import Quick
+import Nimble
+@testable import Clappr
+
+class PosterPluginTests: QuickSpec {
+
+    override func spec() {
+
+        describe(".PosterPlugin") {
+            var container: Container!
+            let options = [
+                kSourceUrl: "http://globo.com/video.mp4",
+                kPosterUrl: "http://clappr.io/poster.png",
+            ]
+
+            context("when container has no options") {
+                it("hides itself") {
+                    container = Container()
+                    container.render()
+
+                    let posterPlugin = self.getPosterPlugin(container)
+
+                    expect(posterPlugin.isHidden).to(beTrue())
+                }
+            }
+
+            context("when container doesnt have posterUrl option") {
+                it("hides itself") {
+                    container = Container(options: ["anotherOption": true])
+                    container.render()
+
+                    let posterPlugin = self.getPosterPlugin(container)
+
+                    expect(posterPlugin.isHidden).to(beTrue())
+                }
+            }
+
+            context("when container has posterUrl option") {
+                it("it renders itself") {
+                    container = Container(options: options)
+                    container.render()
+
+                    let posterPlugin = self.getPosterPlugin(container)
+
+                    expect(posterPlugin.superview) == container
+                }
+            }
+
+            context("when changes the activePlayback") {
+
+                var posterPlugin: PosterPlugin!
+
+                beforeEach {
+                    container = Container()
+                }
+
+                context("to NoOpPlayback") {
+
+                    beforeEach {
+                        container.playback = NoOpPlayback()
+                        posterPlugin = self.getPosterPlugin(container)
+                    }
+
+                    it("hides itself") {
+                        expect(posterPlugin.isHidden).toEventually(beTrue())
+                    }
+
+                    it("isNoOpPlayback is true") {
+                        expect(posterPlugin.isNoOpPlayback) == true
+                    }
+
+                    context("and change again to another playback") {
+
+                        beforeEach {
+                            container.playback = AVFoundationPlayback()
+                            posterPlugin = self.getPosterPlugin(container)
+                        }
+
+                        it("hides itself") {
+                            expect(posterPlugin.isHidden).toEventually(beTrue())
+                        }
+                    }
+                }
+
+                context("to another a playback diferent from NoOpPlayback") {
+
+                    beforeEach {
+                        container.playback = AVFoundationPlayback()
+                        posterPlugin = self.getPosterPlugin(container)
+                    }
+
+                    it("reveal itself") {
+                        expect(posterPlugin.isHidden).toEventually(beFalse())
+                    }
+
+                    it("isNoOpPlayback is true") {
+                        expect(posterPlugin.isNoOpPlayback) == false
+                    }
+                }
+            }
+
+            describe("Playback Events") {
+                var posterPlugin: PosterPlugin!
+
+                beforeEach {
+                    container = Container(options: options)
+                    container.render()
+                    posterPlugin = self.getPosterPlugin(container)
+                }
+
+                context("when playback trigger a play event") {
+                    it("hides itself") {
+                        expect(posterPlugin.isHidden).to(beFalse())
+                        container.playback?.trigger(Event.playing.rawValue)
+                        expect(posterPlugin.isHidden).to(beTrue())
+                    }
+                }
+
+                context("when playback trigger a end event") {
+                    it("reveal itself") {
+                        container.playback?.trigger(Event.playing.rawValue)
+                        container.playback?.trigger(Event.didComplete.rawValue)
+
+                        expect(posterPlugin.isHidden).to(beFalse())
+                    }
+                }
+            }
+
+            describe("When receiving didUpdateOptions event") {
+                var posterPlugin: PosterPlugin!
+
+                beforeEach {
+                    container = Container(options: options)
+                    container.render()
+                    posterPlugin = self.getPosterPlugin(container)
+                }
+
+                it("updates the poster") {
+                    container.options[kPosterUrl] = "https://clappr.io/another-poster.png"
+
+                    expect(posterPlugin.poster.kf.webURL?.absoluteString).to(equal("https://clappr.io/another-poster.png"))
+                }
+            }
+        }
+    }
+
+    private func getPosterPlugin(_ container: Container) -> PosterPlugin {
+        return container.plugins.filter({ $0.isKind(of: PosterPlugin.self) }).first as! PosterPlugin
+    }
+}

--- a/Tests/Clappr_Tests/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/PosterPluginTests.swift
@@ -1,150 +1,150 @@
-import Quick
-import Nimble
-@testable import Clappr
-
-class PosterPluginTests: QuickSpec {
-
-    override func spec() {
-
-        describe(".PosterPlugin") {
-            var container: Container!
-            let options = [
-                kSourceUrl: "http://globo.com/video.mp4",
-                kPosterUrl: "http://clappr.io/poster.png",
-            ]
-
-            context("when container has no options") {
-                it("hides itself") {
-                    container = Container()
-                    container.render()
-
-                    let posterPlugin = self.getPosterPlugin(container)
-
-                    expect(posterPlugin.isHidden).to(beTrue())
-                }
-            }
-
-            context("when container doesnt have posterUrl option") {
-                it("hides itself") {
-                    container = Container(options: ["anotherOption": true])
-                    container.render()
-
-                    let posterPlugin = self.getPosterPlugin(container)
-
-                    expect(posterPlugin.isHidden).to(beTrue())
-                }
-            }
-
-            context("when container has posterUrl option") {
-                it("it renders itself") {
-                    container = Container(options: options)
-                    container.render()
-
-                    let posterPlugin = self.getPosterPlugin(container)
-
-                    expect(posterPlugin.superview) == container
-                }
-            }
-
-            context("when changes the activePlayback") {
-
-                var posterPlugin: PosterPlugin!
-
-                beforeEach {
-                    container = Container()
-                }
-
-                context("to NoOpPlayback") {
-
-                    beforeEach {
-                        container.playback = NoOpPlayback()
-                        posterPlugin = self.getPosterPlugin(container)
-                    }
-
-                    it("hides itself") {
-                        expect(posterPlugin.isHidden).toEventually(beTrue())
-                    }
-
-                    it("isNoOpPlayback is true") {
-                        expect(posterPlugin.isNoOpPlayback) == true
-                    }
-
-                    context("and change again to another playback") {
-
-                        beforeEach {
-                            container.playback = AVFoundationPlayback()
-                            posterPlugin = self.getPosterPlugin(container)
-                        }
-
-                        it("hides itself") {
-                            expect(posterPlugin.isHidden).toEventually(beTrue())
-                        }
-                    }
-                }
-
-                context("to another a playback diferent from NoOpPlayback") {
-
-                    beforeEach {
-                        container.playback = AVFoundationPlayback()
-                        posterPlugin = self.getPosterPlugin(container)
-                    }
-
-                    it("reveal itself") {
-                        expect(posterPlugin.isHidden).toEventually(beFalse())
-                    }
-
-                    it("isNoOpPlayback is true") {
-                        expect(posterPlugin.isNoOpPlayback) == false
-                    }
-                }
-            }
-
-            describe("Playback Events") {
-                var posterPlugin: PosterPlugin!
-
-                beforeEach {
-                    container = Container(options: options)
-                    container.render()
-                    posterPlugin = self.getPosterPlugin(container)
-                }
-
-                context("when playback trigger a play event") {
-                    it("hides itself") {
-                        expect(posterPlugin.isHidden).to(beFalse())
-                        container.playback?.trigger(Event.playing.rawValue)
-                        expect(posterPlugin.isHidden).to(beTrue())
-                    }
-                }
-
-                context("when playback trigger a end event") {
-                    it("reveal itself") {
-                        container.playback?.trigger(Event.playing.rawValue)
-                        container.playback?.trigger(Event.didComplete.rawValue)
-
-                        expect(posterPlugin.isHidden).to(beFalse())
-                    }
-                }
-            }
-
-            describe("When receiving didUpdateOptions event") {
-                var posterPlugin: PosterPlugin!
-
-                beforeEach {
-                    container = Container(options: options)
-                    container.render()
-                    posterPlugin = self.getPosterPlugin(container)
-                }
-
-                it("updates the poster") {
-                    container.options[kPosterUrl] = "https://clappr.io/another-poster.png"
-
-                    expect(posterPlugin.poster.kf.webURL?.absoluteString).to(equal("https://clappr.io/another-poster.png"))
-                }
-            }
-        }
-    }
-
-    private func getPosterPlugin(_ container: Container) -> PosterPlugin {
-        return container.plugins.filter({ $0.isKind(of: PosterPlugin.self) }).first as! PosterPlugin
-    }
-}
+//import Quick
+//import Nimble
+//@testable import Clappr
+//
+//class PosterPluginTests: QuickSpec {
+//
+//    override func spec() {
+//
+//        describe(".PosterPlugin") {
+//            var container: Container!
+//            let options = [
+//                kSourceUrl: "http://globo.com/video.mp4",
+//                kPosterUrl: "http://clappr.io/poster.png",
+//            ]
+//
+//            context("when container has no options") {
+//                it("hides itself") {
+//                    container = Container()
+//                    container.render()
+//
+//                    let posterPlugin = self.getPosterPlugin(container)
+//
+//                    expect(posterPlugin.isHidden).to(beTrue())
+//                }
+//            }
+//
+//            context("when container doesnt have posterUrl option") {
+//                it("hides itself") {
+//                    container = Container(options: ["anotherOption": true])
+//                    container.render()
+//
+//                    let posterPlugin = self.getPosterPlugin(container)
+//
+//                    expect(posterPlugin.isHidden).to(beTrue())
+//                }
+//            }
+//
+//            context("when container has posterUrl option") {
+//                it("it renders itself") {
+//                    container = Container(options: options)
+//                    container.render()
+//
+//                    let posterPlugin = self.getPosterPlugin(container)
+//
+//                    expect(posterPlugin.superview) == container
+//                }
+//            }
+//
+//            context("when changes the activePlayback") {
+//
+//                var posterPlugin: PosterPlugin!
+//
+//                beforeEach {
+//                    container = Container()
+//                }
+//
+//                context("to NoOpPlayback") {
+//
+//                    beforeEach {
+//                        container.playback = NoOpPlayback()
+//                        posterPlugin = self.getPosterPlugin(container)
+//                    }
+//
+//                    it("hides itself") {
+//                        expect(posterPlugin.isHidden).toEventually(beTrue())
+//                    }
+//
+//                    it("isNoOpPlayback is true") {
+//                        expect(posterPlugin.isNoOpPlayback) == true
+//                    }
+//
+//                    context("and change again to another playback") {
+//
+//                        beforeEach {
+//                            container.playback = AVFoundationPlayback()
+//                            posterPlugin = self.getPosterPlugin(container)
+//                        }
+//
+//                        it("hides itself") {
+//                            expect(posterPlugin.isHidden).toEventually(beTrue())
+//                        }
+//                    }
+//                }
+//
+//                context("to another a playback diferent from NoOpPlayback") {
+//
+//                    beforeEach {
+//                        container.playback = AVFoundationPlayback()
+//                        posterPlugin = self.getPosterPlugin(container)
+//                    }
+//
+//                    it("reveal itself") {
+//                        expect(posterPlugin.isHidden).toEventually(beFalse())
+//                    }
+//
+//                    it("isNoOpPlayback is true") {
+//                        expect(posterPlugin.isNoOpPlayback) == false
+//                    }
+//                }
+//            }
+//
+//            describe("Playback Events") {
+//                var posterPlugin: PosterPlugin!
+//
+//                beforeEach {
+//                    container = Container(options: options)
+//                    container.render()
+//                    posterPlugin = self.getPosterPlugin(container)
+//                }
+//
+//                context("when playback trigger a play event") {
+//                    it("hides itself") {
+//                        expect(posterPlugin.isHidden).to(beFalse())
+//                        container.playback?.trigger(Event.playing.rawValue)
+//                        expect(posterPlugin.isHidden).to(beTrue())
+//                    }
+//                }
+//
+//                context("when playback trigger a end event") {
+//                    it("reveal itself") {
+//                        container.playback?.trigger(Event.playing.rawValue)
+//                        container.playback?.trigger(Event.didComplete.rawValue)
+//
+//                        expect(posterPlugin.isHidden).to(beFalse())
+//                    }
+//                }
+//            }
+//
+//            describe("When receiving didUpdateOptions event") {
+//                var posterPlugin: PosterPlugin!
+//
+//                beforeEach {
+//                    container = Container(options: options)
+//                    container.render()
+//                    posterPlugin = self.getPosterPlugin(container)
+//                }
+//
+//                it("updates the poster") {
+//                    container.options[kPosterUrl] = "https://clappr.io/another-poster.png"
+//
+//                    expect(posterPlugin.poster.kf.webURL?.absoluteString).to(equal("https://clappr.io/another-poster.png"))
+//                }
+//            }
+//        }
+//    }
+//
+//    private func getPosterPlugin(_ container: Container) -> PosterPlugin {
+//        return container.plugins.filter({ $0.isKind(of: PosterPlugin.self) }).first as! PosterPlugin
+//    }
+//}

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -1,0 +1,95 @@
+import Quick
+import Nimble
+import AVFoundation
+
+@testable import Clappr
+
+class PlayerTests: QuickSpec {
+    static let specialSource = "specialSource"
+    
+    override func spec() {
+        describe("Player") {
+            
+            let options = [kSourceUrl: "http://clappr.com/video.mp4"]
+            
+            var player: Player!
+            var playback: StubPlayback!
+            
+            beforeEach {
+                player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+                playback = player.activePlayback as! StubPlayback
+            }
+            
+            it("Should load source on core when initializing") {
+                let player = Player(options: options as Options)
+                
+                if let core = player.core {
+                    expect(core.activeContainer).toNot(beNil())
+                } else {
+                    fail("player.core is nil")
+                }
+            }
+            
+            it("Should listen to playing event") {
+                var callbackWasCalled = false
+                
+                player.on(.playing) { _ in
+                    callbackWasCalled = true
+                }
+                
+                playback.trigger(.playing)
+                expect(callbackWasCalled).to(beTrue())
+            }
+
+            describe("configure") {
+                it("changes Core options") {
+                    player.configure(options: ["foo": "bar"])
+                    
+                    expect(player.core!.options["foo"] as? String).to(equal("bar"))
+                }
+            }
+            
+            it("Should listen to subtitleSelected event") {
+                var callbackWasCalled = false
+                
+                player.on(.subtitleSelected) { _ in
+                    callbackWasCalled = true
+                }
+                
+                playback.trigger(.subtitleSelected)
+                expect(callbackWasCalled).to(beTrue())
+            }
+            
+            it("Should listen to audioSelected event") {
+                var callbackWasCalled = false
+                
+                player.on(.audioSelected) { _ in
+                    callbackWasCalled = true
+                }
+                
+                playback.trigger(.audioSelected)
+                expect(callbackWasCalled).to(beTrue())
+            }
+        }
+    }
+    
+    class StubPlayback: Playback {
+        override var pluginName: String {
+            return "StubPlayback"
+        }
+        
+        override class func canPlay(_: Options) -> Bool {
+            return true
+        }
+    }
+    
+    class SpecialStubPlayback: Playback {
+        override var pluginName: String {
+            return "SpecialStubPlayback"
+        }
+        
+        override class func canPlay(_ options: Options) -> Bool {
+            return options[kSourceUrl] as! String == PlayerTests.specialSource
+        }
+    }
+}

--- a/Tests/Extensions/Loader+Plugins.swift
+++ b/Tests/Extensions/Loader+Plugins.swift
@@ -3,13 +3,6 @@
 extension Loader {
 
     func resetPlugins() {
-        Loader.shared.playbacks = [AVFoundationPlayback.self, NoOpPlayback.self]
-        #if os (iOS)
-        Loader.shared.containerPlugins = [PosterPlugin.self, SpinnerPlugin.self]
-        #else
-        Loader.shared.containerPlugins = []
-        #endif
-        Loader.shared.corePlugins = []
-        Loader.shared.externalPlugins = []
+        Loader.shared.plugins = [:]
     }
 }

--- a/Tests/Extensions/Loader+Plugins.swift
+++ b/Tests/Extensions/Loader+Plugins.swift
@@ -4,5 +4,8 @@ extension Loader {
 
     func resetPlugins() {
         Loader.shared.plugins = [:]
+        #if os(iOS)
+            Player.hasAlreadyRegisteredPlugins = false
+        #endif
     }
 }

--- a/Tests/Extensions/Loader+Plugins.swift
+++ b/Tests/Extensions/Loader+Plugins.swift
@@ -1,0 +1,15 @@
+@testable import Clappr
+
+extension Loader {
+
+    func resetPlugins() {
+        Loader.shared.playbacks = [AVFoundationPlayback.self, NoOpPlayback.self]
+        #if os (iOS)
+        Loader.shared.containerPlugins = [PosterPlugin.self, SpinnerPlugin.self]
+        #else
+        Loader.shared.containerPlugins = []
+        #endif
+        Loader.shared.corePlugins = []
+        Loader.shared.externalPlugins = []
+    }
+}


### PR DESCRIPTION
### Goal

The objective is to change `Loaders` class responsibility in the architecture.
Instead of holding the `MediaControl` and `Options` reference, the `Loader` now is responsible for managing and holding plugins reference across the Player lifecycle.

[ ------- **Loader** ------- ]
| _containerPlugins_ 
| _corePlugins_
| _playbacks_ **changed the name from playbackPlugins to playback
| _mediaControl_ **removed
| _externalPlugins_
[---------------------------]

The `Loader` is now a Singleton and won't receive the external plugins and options in its constructor.

### How to test

- Open the player and check if all controls are available correctly without any problem
- Run all tests and make sure they pass