### PR TITLE
Handle MediaControl plugins in Loader

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -104,11 +104,12 @@
 		571B7B32217503BB005C0942 /* NowPlayingServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571B7B30217503BB005C0942 /* NowPlayingServiceStub.swift */; };
 		57351C6820248D78007DEBBE /* video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 57351C6720248D78007DEBBE /* video.mp4 */; };
 		57351C6A20248F08007DEBBE /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57351C6920248F08007DEBBE /* OHHTTPStubs.framework */; };
+		5753591C2187486900A88BE2 /* Array+appendOrReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */; };
 		57937C571FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */; };
 		57937C5A1FB0DD2C000A239E /* AVURLAssetWithCookiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */; };
 		57B0A1DF1FF40C3600891037 /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B0A1DE1FF40C3600891037 /* UIObject.swift */; };
 		57B2F823212AEFC600913EC1 /* Kingfisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96D362F01D41345E00CCB866 /* Kingfisher.framework */; };
-		57F1354921836EE000111BC6 /* Array+UniquePlugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F1354821836EE000111BC6 /* Array+UniquePlugins.swift */; };
+		57F1354921836EE000111BC6 /* Array+appendOrReplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */; };
 		96036D671CBD89500022CCCA /* PlaybackFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */; };
 		9603A06C1C05E6D100B55D8F /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9603A06B1C05E6D100B55D8F /* PlayerTests.swift */; };
 		963B19981E4B827700A0A6BA /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963B19971E4B827700A0A6BA /* Event.swift */; };
@@ -357,10 +358,11 @@
 		571B7B30217503BB005C0942 /* NowPlayingServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingServiceStub.swift; sourceTree = "<group>"; };
 		57351C6720248D78007DEBBE /* video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = video.mp4; sourceTree = "<group>"; };
 		57351C6920248F08007DEBBE /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
+		57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+appendOrReplaceTests.swift"; sourceTree = "<group>"; };
 		57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesBuilder.swift; sourceTree = "<group>"; };
 		57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesTests.swift; sourceTree = "<group>"; };
 		57B0A1DE1FF40C3600891037 /* UIObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIObject.swift; sourceTree = "<group>"; };
-		57F1354821836EE000111BC6 /* Array+UniquePlugins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+UniquePlugins.swift"; sourceTree = "<group>"; };
+		57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+appendOrReplace.swift"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* Clappr_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clappr_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACE51AFB9204008FA782 /* Clappr_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Clappr_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -841,7 +843,7 @@
 				96D362A31D41339400CCB866 /* UIView+Ext.swift */,
 				C9EDF8572163A9A900789E2F /* UIColor+ClapprAdditions.swift */,
 				C9177B2D21664D1C001D0292 /* UIImage+Ext.swift */,
-				57F1354821836EE000111BC6 /* Array+UniquePlugins.swift */,
+				57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1056,6 +1058,7 @@
 			isa = PBXGroup;
 			children = (
 				C92F1C99216F8F000059D860 /* UIViewExtensionTests.swift */,
+				57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1736,6 +1739,7 @@
 			files = (
 				96664E5E1BF0D5FB00095E6E /* PlaybackTests.swift in Sources */,
 				C92F1C9A216F8F000059D860 /* UIViewExtensionTests.swift in Sources */,
+				5753591C2187486900A88BE2 /* Array+appendOrReplaceTests.swift in Sources */,
 				96A9CE391C973A0600C21E80 /* LoaderTests.swift in Sources */,
 				FC6418E12007DC2F00E81B7C /* ClapprDateFormatterTests.swift in Sources */,
 				FB3A8F1A209F8D7000CEFC3D /* FullscreenTests.swift in Sources */,
@@ -1781,7 +1785,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				96D362CE1D41339400CCB866 /* Player.swift in Sources */,
-				57F1354921836EE000111BC6 /* Array+UniquePlugins.swift in Sources */,
+				57F1354921836EE000111BC6 /* Array+appendOrReplace.swift in Sources */,
 				96D362E81D41339400CCB866 /* BorderView.swift in Sources */,
 				96D362DC1D41339400CCB866 /* MediaOptionFactory.swift in Sources */,
 				96D362E01D41339400CCB866 /* PosterPlugin.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		57937C5A1FB0DD2C000A239E /* AVURLAssetWithCookiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */; };
 		57B0A1DF1FF40C3600891037 /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B0A1DE1FF40C3600891037 /* UIObject.swift */; };
 		57B2F823212AEFC600913EC1 /* Kingfisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96D362F01D41345E00CCB866 /* Kingfisher.framework */; };
+		57F1354921836EE000111BC6 /* Array+UniquePlugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F1354821836EE000111BC6 /* Array+UniquePlugins.swift */; };
 		96036D671CBD89500022CCCA /* PlaybackFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */; };
 		9603A06C1C05E6D100B55D8F /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9603A06B1C05E6D100B55D8F /* PlayerTests.swift */; };
 		963B19981E4B827700A0A6BA /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963B19971E4B827700A0A6BA /* Event.swift */; };
@@ -359,6 +360,7 @@
 		57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesBuilder.swift; sourceTree = "<group>"; };
 		57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesTests.swift; sourceTree = "<group>"; };
 		57B0A1DE1FF40C3600891037 /* UIObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIObject.swift; sourceTree = "<group>"; };
+		57F1354821836EE000111BC6 /* Array+UniquePlugins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+UniquePlugins.swift"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* Clappr_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clappr_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACE51AFB9204008FA782 /* Clappr_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Clappr_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -839,6 +841,7 @@
 				96D362A31D41339400CCB866 /* UIView+Ext.swift */,
 				C9EDF8572163A9A900789E2F /* UIColor+ClapprAdditions.swift */,
 				C9177B2D21664D1C001D0292 /* UIImage+Ext.swift */,
+				57F1354821836EE000111BC6 /* Array+UniquePlugins.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1732,12 +1735,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				96664E5E1BF0D5FB00095E6E /* PlaybackTests.swift in Sources */,
-				9684B6CA1D186E4700D012C2 /* AVFoundationPlaybackTests.swift in Sources */,
 				C92F1C9A216F8F000059D860 /* UIViewExtensionTests.swift in Sources */,
 				96A9CE391C973A0600C21E80 /* LoaderTests.swift in Sources */,
 				FC6418E12007DC2F00E81B7C /* ClapprDateFormatterTests.swift in Sources */,
 				FB3A8F1A209F8D7000CEFC3D /* FullscreenTests.swift in Sources */,
-				9E3F43FC1F31116100417919 /* AppStateManagerTests.swift in Sources */,
 				C9EDF84D2162CEF500789E2F /* UIViewControllerMock.swift in Sources */,
 				EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */,
 				C9EDF8482162C98D00789E2F /* MediaControlPluginTests.swift in Sources */,
@@ -1780,6 +1781,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				96D362CE1D41339400CCB866 /* Player.swift in Sources */,
+				57F1354921836EE000111BC6 /* Array+UniquePlugins.swift in Sources */,
 				96D362E81D41339400CCB866 /* BorderView.swift in Sources */,
 				96D362DC1D41339400CCB866 /* MediaOptionFactory.swift in Sources */,
 				96D362E01D41339400CCB866 /* PosterPlugin.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		57351C6820248D78007DEBBE /* video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 57351C6720248D78007DEBBE /* video.mp4 */; };
 		57351C6A20248F08007DEBBE /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57351C6920248F08007DEBBE /* OHHTTPStubs.framework */; };
 		5753591C2187486900A88BE2 /* Array+appendOrReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */; };
+		576786C02188A4B40046508C /* Array+appendOrReplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */; };
+		576786C12188A4C60046508C /* Array+appendOrReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */; };
 		57937C571FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */; };
 		57937C5A1FB0DD2C000A239E /* AVURLAssetWithCookiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */; };
 		57B0A1DF1FF40C3600891037 /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B0A1DE1FF40C3600891037 /* UIObject.swift */; };
@@ -1692,6 +1694,7 @@
 				FC7785A92005233D00EC879F /* EventHandler.swift in Sources */,
 				ABE7D3EF212C36200049773A /* SharedData.swift in Sources */,
 				32E401C71FF42351001C2096 /* SpinnerPlugin.swift in Sources */,
+				576786C02188A4B40046508C /* Array+appendOrReplace.swift in Sources */,
 				32DA34191FFBCFC400484C90 /* Container.swift in Sources */,
 				571B7B262174E324005C0942 /* AVFoundationPlayback+tvOS.swift in Sources */,
 				32E401BF1FF42321001C2096 /* MediaOptionType.swift in Sources */,
@@ -1709,6 +1712,7 @@
 				571B7B2B2175015F005C0942 /* AVURLAssetStub.swift in Sources */,
 				571B7B292175013F005C0942 /* AVFoundationPlaybackTests.swift in Sources */,
 				32755E2421503A830088724E /* PlaybackTests.swift in Sources */,
+				576786C12188A4C60046508C /* Array+appendOrReplaceTests.swift in Sources */,
 				571B7B2C21750169005C0942 /* AVPlayerItemStub.swift in Sources */,
 				32FC971C20B72C4200ABA0C2 /* AVURLAssetWithCookiesTests.swift in Sources */,
 				FC7785C1200526D500EC879F /* AVFoundationNowPlayingBuilderTests.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -101,17 +101,26 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
 
     open override func render() {
         containers.forEach(renderContainer)
-        installPlugins()
-        renderMediaControlPlugins()
+        renderPlugins()
 
         addToContainer()
     }
     
-    private func renderMediaControlPlugins() {
-        let mediaControlPlugin = plugins.filter { $0 is MediaControl }.first
-        if let mediaControl = mediaControlPlugin as? MediaControl {
-            mediaControl.renderPlugins(plugins)
+    private func renderPlugins() {
+        plugins.forEach { plugin in
+            if isNotMediaControlPlugin(plugin) {
+                addSubview(plugin)
+                plugin.render()
+            }
+
+            if plugin is MediaControl, let mediaControl = plugin as? MediaControl {
+                mediaControl.renderPlugins(plugins)
+            }
         }
+    }
+
+    private func isNotMediaControlPlugin(_ plugin: UICorePlugin) -> Bool {
+        return !(plugin is MediaControlPlugin)
     }
 
     fileprivate func addToContainer() {
@@ -124,13 +133,6 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         #else
         renderInContainerView()
         #endif
-    }
-
-    private func installPlugins() {
-        plugins.filter { !($0 is MediaControlPlugin) }.forEach { plugin in
-            addSubview(plugin)
-            plugin.render()
-        }
     }
 
     fileprivate func renderContainer(_ container: Container) {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -101,18 +101,33 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
 
     open override func render() {
         containers.forEach(renderContainer)
+        #if os(iOS)
+        renderCoreAndMediaControlPlugins()
+        #elseif os(tvOS)
         renderPlugins()
+        #endif
 
         addToContainer()
     }
     
+    #if os(tvOS)
     private func renderPlugins() {
+        plugins.forEach { plugin in
+            addSubview(plugin)
+            plugin.render()
+        }
+    }
+    #endif
+    
+    #if os(iOS)
+    private func renderCoreAndMediaControlPlugins() {
         plugins.forEach { plugin in
             if isNotMediaControlPlugin(plugin) {
                 addSubview(plugin)
                 plugin.render()
             }
 
+            
             if plugin is MediaControl, let mediaControl = plugin as? MediaControl {
                 mediaControl.renderPlugins(plugins)
             }
@@ -122,6 +137,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     private func isNotMediaControlPlugin(_ plugin: UICorePlugin) -> Bool {
         return !(plugin is MediaControlPlugin)
     }
+    #endif
 
     fileprivate func addToContainer() {
         #if os(iOS)

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -101,9 +101,17 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
 
     open override func render() {
         containers.forEach(renderContainer)
-        plugins.filter { !($0 is MediaControlPlugin) }.forEach(installPlugin)
+        installPlugins()
+        renderMediaControlPlugins()
 
         addToContainer()
+    }
+    
+    private func renderMediaControlPlugins() {
+        let mediaControlPlugin = plugins.filter { $0 is MediaControl }.first
+        if let mediaControl = mediaControlPlugin as? MediaControl {
+            mediaControl.renderPlugins(plugins)
+        }
     }
 
     fileprivate func addToContainer() {
@@ -118,9 +126,11 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
         #endif
     }
 
-    fileprivate func installPlugin(_ plugin: UICorePlugin) {
-        addSubview(plugin)
-        plugin.render()
+    private func installPlugins() {
+        plugins.filter { !($0 is MediaControlPlugin) }.forEach { plugin in
+            addSubview(plugin)
+            plugin.render()
+        }
     }
 
     fileprivate func renderContainer(_ container: Container) {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -101,7 +101,7 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
 
     open override func render() {
         containers.forEach(renderContainer)
-        plugins.forEach(installPlugin)
+        plugins.filter { !($0 is MediaControlPlugin) }.forEach(installPlugin)
 
         addToContainer()
     }

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -23,8 +23,7 @@ open class Loader {
     }
 
     open func register(plugins: [Plugin.Type]) {
-        self.plugins.append(contentsOf: plugins)
-        self.plugins = self.plugins.uniques
+        self.plugins.appendOrReplace(contentsOf: plugins)
     }
 
     open func loadPlugins(in core: Core) {

--- a/Sources/Clappr/Classes/Base/Loader.swift
+++ b/Sources/Clappr/Classes/Base/Loader.swift
@@ -1,18 +1,18 @@
 open class Loader {
 
     public static let shared = Loader()
-    public var plugins: [String: Plugin.Type] = [:]
+    public var plugins: [Plugin.Type] = []
 
     var playbacks: [Plugin.Type] {
-        return plugins.filter { $0.value.type == .playback }.map { return $0.value }
+        return plugins.filter { $0.type == .playback }.map { return $0 }
     }
 
     var containerPlugins: [Plugin.Type] {
-        return plugins.filter { $0.value.type == .container }.map { return $0.value }
+        return plugins.filter { $0.type == .container }.map { return $0 }
     }
 
     var corePlugins: [Plugin.Type] {
-        return plugins.filter { $0.value.type == .core }.map { return $0.value }
+        return plugins.filter { $0.type == .core }.map { return $0 }
     }
 
     private init() {
@@ -23,9 +23,8 @@ open class Loader {
     }
 
     open func register(plugins: [Plugin.Type]) {
-        plugins.forEach { plugin in
-            self.plugins[plugin.name] = plugin
-        }
+        self.plugins.append(contentsOf: plugins)
+        self.plugins = self.plugins.uniques
     }
 
     open func loadPlugins(in core: Core) {

--- a/Sources/Clappr/Classes/Extension/Array+UniquePlugins.swift
+++ b/Sources/Clappr/Classes/Extension/Array+UniquePlugins.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension Array where Element == Plugin.Type {
+    var uniques: [Element] {
+        var result = [Plugin.Type]()
+        
+        for plugin in self.reversed() {
+            if !result.contains(where: { $0.name == plugin.name }) {
+                result.append(plugin)
+            }
+        }
+        
+        return result.reversed()
+    }
+}

--- a/Sources/Clappr/Classes/Extension/Array+appendOrReplace.swift
+++ b/Sources/Clappr/Classes/Extension/Array+appendOrReplace.swift
@@ -1,15 +1,18 @@
 import Foundation
 
 extension Array where Element == Plugin.Type {
-    var uniques: [Element] {
-        var result = [Plugin.Type]()
+    mutating func appendOrReplace(contentsOf plugins: [Plugin.Type]) {
+        self.append(contentsOf: plugins)
         
+        var result = [Plugin.Type]()
         for plugin in self.reversed() {
             if !result.contains(where: { $0.name == plugin.name }) {
                 result.append(plugin)
             }
         }
+        result = result.reversed()
         
-        return result.reversed()
+        self.removeAll()
+        self.append(contentsOf: result)
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -168,7 +168,7 @@ open class Player: BaseObject {
             var builtInPlugins: [Plugin.Type] = [AVFoundationPlayback.self]
 
             #if os (iOS)
-            builtInPlugins.append(contentsOf: [MediaControl.self, PosterPlugin.self, SpinnerPlugin.self])
+            builtInPlugins.append(contentsOf: [MediaControl.self, PosterPlugin.self, SpinnerPlugin.self, PlayButton.self, TimeIndicator.self, FullscreenButton.self])
             #endif
 
             Loader.shared.register(plugins: builtInPlugins)

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -33,9 +33,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         return core?.activePlayback
     }
 
-    public var plugins: [MediaControlPlugin] = []
-    var defaultPlugins: [MediaControlPlugin.Type] = [PlayButton.self, TimeIndicator.self, FullscreenButton.self]
-
     override open var pluginName: String {
         return "MediaControl"
     }
@@ -196,37 +193,12 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         view = UIView()
         view.backgroundColor = UIColor.clapprBlack60Color()
 
-        loadPlugins()
-        loadDefaultPlugins()
-        renderPlugins()
         showIfAlwaysVisible()
 
         self.bindFrameToSuperviewBounds()
     }
 
-    private func loadPlugins() {
-        guard let mediaControlPlugins = options?[kMediaControlPlugins] as? [MediaControlPlugin.Type] else {
-            return
-        }
-
-        mediaControlPlugins.forEach { plugin in
-            plugins.append(plugin.init(context: core!))
-        }
-    }
-
-    private func loadDefaultPlugins() {
-        defaultPlugins.forEach { defaultPlugin in
-            addPlugin(defaultPlugin)
-        }
-    }
-
-    private func addPlugin(_ plugin: MediaControlPlugin.Type) {
-        if !plugins.contains(where: { $0.pluginName == plugin.name}) {
-            plugins.append(plugin.init(context: core!))
-        }
-    }
-
-    private func renderPlugins() {
+    func renderPlugins(_ plugins: [MediaControlPlugin]) {
         plugins.forEach { plugin in
             container.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -198,11 +198,13 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         self.bindFrameToSuperviewBounds()
     }
 
-    func renderPlugins(_ plugins: [MediaControlPlugin]) {
-        plugins.forEach { plugin in
-            container.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
-
-            plugin.render()
+    func renderPlugins(_ plugins: [UICorePlugin]) {
+        plugins
+            .filter { $0 is MediaControlPlugin }
+            .map { $0 as! MediaControlPlugin }
+            .forEach { plugin in
+                container.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
+                plugin.render()
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -101,6 +101,7 @@ open class TimeIndicator: MediaControlPlugin {
         if let core = self.core {
             listenTo(core, eventName: InternalEvent.didEnterFullscreen.rawValue) { [weak self] _ in self?.updateLayoutConstants() }
             listenTo(core, eventName: InternalEvent.didExitFullscreen.rawValue) { [weak self] _ in self?.updateLayoutConstants() }
+            listenTo(core, eventName: InternalEvent.didChangeActiveContainer.rawValue) { [weak self] (_: EventUserInfo) in self?.bindEvents() }
         }
     }
 

--- a/Tests/Clappr_Tests/Classes/Extensions/Array+appendOrReplaceTests.swift
+++ b/Tests/Clappr_Tests/Classes/Extensions/Array+appendOrReplaceTests.swift
@@ -1,0 +1,48 @@
+import Quick
+import Nimble
+
+@testable import Clappr
+
+class ArrayAppendOrReplaceTests: QuickSpec {
+    override func spec() {
+        describe("Array") {
+            describe("#appendOrReplace") {
+                it("replaces a plugin that has the same name") {
+                    var array: [Plugin.Type] = [PluginA.self, PluginB.self]
+                    
+                    array.appendOrReplace(contentsOf: [PluginAReplace.self])
+                    
+                    expect(array.first).to(be(PluginB.self))
+                    expect(array[1]).to(be(PluginAReplace.self))
+                }
+                
+                it("just append if there's no equal names") {
+                    var array: [Plugin.Type] = [PluginA.self]
+                    
+                    array.appendOrReplace(contentsOf: [PluginB.self])
+                    
+                    expect(array.first).to(be(PluginA.self))
+                    expect(array[1]).to(be(PluginB.self))
+                }
+            }
+        }
+    }
+}
+
+class PluginA: UIContainerPlugin {
+    override static var name: String {
+        return "pluginA"
+    }
+}
+
+class PluginB: UIContainerPlugin {
+    override static var name: String {
+        return "pluginB"
+    }
+}
+
+class PluginAReplace: UIContainerPlugin {
+    override static var name: String {
+        return "pluginA"
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -132,33 +132,6 @@ class MediaControlTests: QuickSpec {
                 }
             }
 
-            describe("plugins") {
-                it("has the list of plugins that comes from options") {
-                    let options: Options = [kMediaControlPlugins: [MediaControlPluginMock.self]]
-                    let core = Core(options: options)
-
-                    let mediaControl = MediaControl(context: core)
-                    mediaControl.defaultPlugins = []
-                    mediaControl.render()
-
-                    expect(mediaControl.plugins.count).to(equal(1))
-                    expect(mediaControl.plugins[0]).to(beAKindOf(MediaControlPluginMock.self))
-                }
-
-                it("has the list of plugins that comes from options without default") {
-                    let options: Options = [kMediaControlPlugins: [MediaControlPluginMock.self]]
-
-                    let core = Core(options: options)
-
-                    let mediaControl = MediaControl(context: core)
-                    mediaControl.defaultPlugins = []
-                    mediaControl.render()
-
-                    expect(mediaControl.plugins.count).to(equal(1))
-                    expect(mediaControl.plugins[0]).to(beAKindOf(MediaControlPluginMock.self))
-                }
-            }
-
             describe("Events") {
                 var coreStub: CoreStub!
                 var mediaControl: MediaControl!
@@ -317,73 +290,6 @@ class MediaControlTests: QuickSpec {
 
                 func mediaControlVisible() {
                     coreStub.trigger(Event.willShowMediaControl.rawValue)
-                }
-            }
-
-            describe("renderPlugins") {
-                var options: Options!
-                var core: Core!
-                var mediaControlViewMock: MediaControlViewMock!
-
-                beforeEach {
-                    options = [kMediaControlPlugins: [MediaControlPluginMock.self]]
-
-                    core = Core(options: options)
-                    mediaControlViewMock = MediaControlViewMock()
-                    MediaControlPluginMock.reset()
-                }
-
-                context("for any plugin configuration") {
-                    it("always calls the MediaControlView to position the view") {
-                        let mediaControl = MediaControl(context: core)
-                        mediaControl.container = mediaControlViewMock
-                        mediaControl.defaultPlugins = []
-                        mediaControl.render()
-
-                        expect(mediaControlViewMock.didCallAddSubview).to(beTrue())
-                    }
-
-                    it("always calls the MediaControlView passing the plugin's view") {
-                        let mediaControl = MediaControl(context: core)
-                        mediaControl.container = mediaControlViewMock
-                        mediaControl.defaultPlugins = []
-                        mediaControl.render()
-
-                        if let plugin = mediaControl.plugins.first(where: {$0.pluginName == "MediaControlPluginMock" }) {
-                            expect(mediaControlViewMock.didCallAddSubviewWithView).to(equal(plugin.view))
-                        } else {
-                            fail("Could not find MediaControlPluginMock in mediaControl.plugins")
-                        }
-                    }
-
-                    it("always calls the MediaControlView passing the plugin's panel") {
-                        MediaControlPluginMock._panel = .center
-                        let mediaControl = MediaControl(context: core)
-                        mediaControl.container = mediaControlViewMock
-                        mediaControl.defaultPlugins = []
-                        mediaControl.render()
-
-                        expect(mediaControlViewMock.didCallAddSubviewWithPanel).to(equal(MediaControlPanel.center))
-                    }
-
-                    it("always calls the MediaControlView passing the plugin's position") {
-                        MediaControlPluginMock._position = .left
-                        let mediaControl = MediaControl(context: core)
-                        mediaControl.container = mediaControlViewMock
-                        mediaControl.defaultPlugins = []
-                        mediaControl.render()
-
-                        expect(mediaControlViewMock.didCallAddSubviewWithPosition).to(equal(MediaControlPosition.left))
-                    }
-
-                    it("always calls the method render") {
-                        MediaControlPluginMock._panel = .top
-                        let mediaControl = MediaControl(context: core)
-
-                        mediaControl.render()
-
-                        expect(MediaControlPluginMock.didCallRender).to(beTrue())
-                    }
                 }
             }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -293,6 +293,89 @@ class MediaControlTests: QuickSpec {
                 }
             }
 
+            describe("renderPlugins") {
+                var plugins: [MediaControlPlugin]!
+                var core: Core!
+                var mediaControlViewMock: MediaControlViewMock!
+
+                beforeEach {
+                    plugins = [MediaControlPluginMock()]
+
+                    core = Core(options: [:])
+                    mediaControlViewMock = MediaControlViewMock()
+                    MediaControlPluginMock.reset()
+                }
+
+                context("for any plugin configuration") {
+                    it("always calls the MediaControlView to position the view") {
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.container = mediaControlViewMock
+                        mediaControl.render()
+                        
+                        mediaControl.renderPlugins(plugins)
+
+                        expect(mediaControlViewMock.didCallAddSubview).to(beTrue())
+                    }
+
+                    it("always calls the MediaControlView passing the plugin's view") {
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.container = mediaControlViewMock
+                        mediaControl.render()
+                        
+                        mediaControl.renderPlugins(plugins)
+
+                        expect(mediaControlViewMock.didCallAddSubviewWithView).to(equal(plugins.first?.view))
+                    }
+
+                    it("always calls the MediaControlView passing the plugin's panel") {
+                        MediaControlPluginMock._panel = .center
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.container = mediaControlViewMock
+                        mediaControl.render()
+                        
+                        mediaControl.renderPlugins(plugins)
+
+                        expect(mediaControlViewMock.didCallAddSubviewWithPanel).to(equal(MediaControlPanel.center))
+                    }
+
+                    it("always calls the MediaControlView passing the plugin's position") {
+                        MediaControlPluginMock._position = .left
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.container = mediaControlViewMock
+                        mediaControl.render()
+
+                        mediaControl.renderPlugins(plugins)
+                        
+                        expect(mediaControlViewMock.didCallAddSubviewWithPosition).to(equal(MediaControlPosition.left))
+                    }
+
+                    it("always calls the method render") {
+                        MediaControlPluginMock._panel = .top
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.render()
+                        
+                        mediaControl.renderPlugins(plugins)
+
+                        expect(MediaControlPluginMock.didCallRender).to(beTrue())
+                    }
+                }
+                
+                context("when passing a plugin that is not MediaControlPlugin") {
+                    it("does not add it to the view") {
+                        let plugins = [MediaControlPluginMock(), UICorePlugin()]
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.container = mediaControlViewMock
+                        mediaControl.render()
+
+                        
+                        mediaControl.renderPlugins(plugins)
+                        
+                        expect(mediaControlViewMock.didCallAddSubviewWithView).to(equal(plugins.first?.view))
+
+                    }
+                }
+            }
+
             class MediaControlPluginMock: MediaControlPlugin {
                 static var _panel: MediaControlPanel = .top
                 static var _position: MediaControlPosition = .left

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -376,32 +376,6 @@ class MediaControlTests: QuickSpec {
                 }
             }
 
-            class MediaControlPluginMock: MediaControlPlugin {
-                static var _panel: MediaControlPanel = .top
-                static var _position: MediaControlPosition = .left
-                static var didCallRender = false
-
-                override var pluginName: String {
-                    return "MediaControlPluginMock"
-                }
-
-                open override var panel: MediaControlPanel {
-                    return MediaControlPluginMock._panel
-                }
-
-                open override var position: MediaControlPosition {
-                    return MediaControlPluginMock._position
-                }
-
-                override func render() {
-                    MediaControlPluginMock.didCallRender = true
-                }
-
-                static func reset() {
-                    MediaControlPluginMock.didCallRender = false
-                }
-            }
-
             class MediaControlViewMock: MediaControlView {
                 var didCallAddSubview = false
                 var didCallAddSubviewWithView: UIView?
@@ -416,5 +390,31 @@ class MediaControlTests: QuickSpec {
                 }
             }
         }
+    }
+}
+
+class MediaControlPluginMock: MediaControlPlugin {
+    static var _panel: MediaControlPanel = .top
+    static var _position: MediaControlPosition = .left
+    static var didCallRender = false
+    
+    override var pluginName: String {
+        return "MediaControlPluginMock"
+    }
+    
+    open override var panel: MediaControlPanel {
+        return MediaControlPluginMock._panel
+    }
+    
+    open override var position: MediaControlPosition {
+        return MediaControlPluginMock._position
+    }
+    
+    override func render() {
+        MediaControlPluginMock.didCallRender = true
+    }
+    
+    static func reset() {
+        MediaControlPluginMock.didCallRender = false
     }
 }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
@@ -160,6 +160,7 @@ class TimeIndicatorTests: QuickSpec {
                 var timeIndicator: TimeIndicator!
 
                 beforeEach {
+                    Loader.shared.resetPlugins()
                     coreStub = CoreStub()
                     timeIndicator = TimeIndicator(context: coreStub)
 

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -627,7 +627,7 @@ class CoreTests: QuickSpec {
                 }
             }
 
-            context("when a plugin is added") {
+            describe("#render") {
                 it("add plugin as subview after rendered") {
                     let core = Core()
                     let plugin = FakeCorePlugin()
@@ -646,6 +646,18 @@ class CoreTests: QuickSpec {
                     core.render()
                     
                     expect(plugin.superview).to(beNil())
+                }
+                
+                it("calls the mediacontrol to add the plugins into the panels") {
+                    let core = Core()
+                    let mediaControlMock = MediaControlMock()
+                    let mediaControlPluginMock = MediaControlPluginMock()
+                    
+                    core.addPlugin(mediaControlMock)
+                    core.addPlugin(mediaControlPluginMock)
+                    core.render()
+                    
+                    expect(mediaControlMock.didCallRenderPlugins).to(beTrue())
                 }
             }
 
@@ -673,5 +685,13 @@ class CoreTests: QuickSpec {
         controller.view.addSubview(player.view)
         player.didMove(toParentViewController: controller)
         #endif
+    }
+}
+
+class MediaControlMock: MediaControl {
+    var didCallRenderPlugins = false
+    
+    override func renderPlugins(_ plugins: [UICorePlugin]) {
+        didCallRenderPlugins = true
     }
 }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -628,19 +628,24 @@ class CoreTests: QuickSpec {
             }
 
             context("when a plugin is added") {
-
-                var plugin: FakeCorePlugin!
-
-                beforeEach {
-                    core = Core()
-                    plugin = FakeCorePlugin()
-                    core.addPlugin(plugin)
-                }
-
                 it("add plugin as subview after rendered") {
+                    let core = Core()
+                    let plugin = FakeCorePlugin()
+                    
+                    core.addPlugin(plugin)
                     core.render()
 
-                    expect(plugin.superview) == core
+                    expect(plugin.superview).to(equal(core))
+                }
+                
+                it("doesnt add plugin as subview if it is a MediaControlPlugin") {
+                    let core = Core()
+                    let plugin = MediaControlPluginMock()
+                    
+                    core.addPlugin(plugin)
+                    core.render()
+                    
+                    expect(plugin.superview).to(beNil())
                 }
             }
 

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -638,6 +638,7 @@ class CoreTests: QuickSpec {
                     expect(plugin.superview).to(equal(core))
                 }
                 
+                #if os(iOS)
                 it("doesnt add plugin as subview if it is a MediaControlPlugin") {
                     let core = Core()
                     let plugin = MediaControlPluginMock()
@@ -659,6 +660,7 @@ class CoreTests: QuickSpec {
                     
                     expect(mediaControlMock.didCallRenderPlugins).to(beTrue())
                 }
+                #endif
             }
 
             context("core position") {
@@ -688,6 +690,7 @@ class CoreTests: QuickSpec {
     }
 }
 
+#if os(iOS)
 class MediaControlMock: MediaControl {
     var didCallRenderPlugins = false
     
@@ -695,3 +698,4 @@ class MediaControlMock: MediaControl {
         didCallRenderPlugins = true
     }
 }
+#endif

--- a/Tests/Extensions/Loader+Plugins.swift
+++ b/Tests/Extensions/Loader+Plugins.swift
@@ -3,7 +3,7 @@
 extension Loader {
 
     func resetPlugins() {
-        Loader.shared.plugins = [:]
+        Loader.shared.plugins = []
         #if os(iOS)
             Player.hasAlreadyRegisteredPlugins = false
         #endif


### PR DESCRIPTION
# Goal

To load `MediaControl` plugins through the `Loader`.

# How to test

1. Open the example
2. Play the video
3. You should see fullscreen, time indicator and play/pause button plugins
4. Interact with them and make sure that their behavior is ok