### PR TITLE
Trigger events when MediaControl is show/hidden

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -208,6 +208,6 @@ open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     }
 
     @objc func didTappedView() {
-        trigger(Event.willShowMediaControl.rawValue)
+        trigger(InternalEvent.didTappedCore.rawValue)
     }
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -31,4 +31,5 @@ public enum Event: String {
     case didChangeDvrAvailability
     case didUpdateOptions
     case willShowMediaControl
+    case didShowMediaControl
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -32,4 +32,6 @@ public enum Event: String {
     case didUpdateOptions
     case willShowMediaControl
     case didShowMediaControl
+    case willHideMediaControl
+    case didHideMediaControl
 }

--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -16,4 +16,5 @@ public enum InternalEvent: String {
     case didDestroy
     case userRequestEnterInFullscreen
     case userRequestExitFullscreen
+    case didTappedCore
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -135,6 +135,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     func show(animated: Bool = false, completion: (() -> Void)? = nil) {
         let duration = animated ? animationDuration : 0
+        
+        trigger(Event.willShowMediaControl.rawValue)
 
         if self.alpha == 0 {
             self.isHidden = false
@@ -145,8 +147,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
             animations: {
                 self.alpha = 1
         },
-            completion: { _ in
-                self.isHidden = false
+            completion: { [weak self] _ in
+                self?.isHidden = false
+                self?.trigger(Event.didShowMediaControl.rawValue)
                 completion?()
         }
         )

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -134,8 +134,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     func show(animated: Bool = false, completion: (() -> Void)? = nil) {
-        if !isHidden { return }
-        
         let duration = animated ? animationDuration : 0
         
         core?.trigger(Event.willShowMediaControl.rawValue)
@@ -158,8 +156,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     func hide(animated: Bool = false, completion: (() -> Void)? = nil) {
-        if isHidden { return }
-        
         if !alwaysVisible {
             core?.trigger(Event.willHideMediaControl.rawValue)
             

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -138,7 +138,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         
         let duration = animated ? animationDuration : 0
         
-        trigger(Event.willShowMediaControl.rawValue)
+        core?.trigger(Event.willShowMediaControl.rawValue)
 
         if self.alpha == 0 {
             self.isHidden = false
@@ -151,7 +151,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         },
             completion: { [weak self] _ in
                 self?.isHidden = false
-                self?.trigger(Event.didShowMediaControl.rawValue)
+                self?.core?.trigger(Event.didShowMediaControl.rawValue)
                 completion?()
         }
         )
@@ -161,7 +161,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         if isHidden { return }
         
         if !alwaysVisible {
-            trigger(Event.willHideMediaControl.rawValue)
+            core?.trigger(Event.willHideMediaControl.rawValue)
             
             let duration = animated ? animationDuration : 0
 
@@ -172,7 +172,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
             },
                 completion: { [weak self] _ in
                     self?.isHidden = true
-                    self?.trigger(Event.didHideMediaControl.rawValue)
+                    self?.core?.trigger(Event.didHideMediaControl.rawValue)
                     completion?()
             }
             )

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -157,6 +157,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     func hide(animated: Bool = false, completion: (() -> Void)? = nil) {
         if !alwaysVisible {
+            trigger(Event.willHideMediaControl.rawValue)
+            
             let duration = animated ? animationDuration : 0
 
             UIView.animate(
@@ -164,8 +166,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
                 animations: {
                     self.alpha = 0
             },
-                completion: { _ in
-                    self.isHidden = true
+                completion: { [weak self] _ in
+                    self?.isHidden = true
+                    self?.trigger(Event.didHideMediaControl.rawValue)
                     completion?()
             }
             )

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -87,7 +87,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
                 }
             }
 
-            listenTo(core, eventName: Event.willShowMediaControl.rawValue) { [weak self] _ in
+            listenTo(core, eventName: InternalEvent.didTappedCore.rawValue) { [weak self] _ in
                 self?.toggleVisibility()
             }
         }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -134,6 +134,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     func show(animated: Bool = false, completion: (() -> Void)? = nil) {
+        if !isHidden { return }
+        
         let duration = animated ? animationDuration : 0
         
         trigger(Event.willShowMediaControl.rawValue)
@@ -156,6 +158,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     func hide(animated: Bool = false, completion: (() -> Void)? = nil) {
+        if isHidden { return }
+        
         if !alwaysVisible {
             trigger(Event.willHideMediaControl.rawValue)
             

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -56,10 +56,6 @@ open class PlayButton: MediaControlPlugin {
     open func bindCoreEvents() {
         if let core = core {
             listenTo(core, eventName: InternalEvent.didChangeActiveContainer.rawValue) { [weak self] _ in self?.bindEvents() }
-            listenTo(core, eventName: Event.didShowMediaControl.rawValue) { _ in print("didShowMediaControl") }
-            listenTo(core, eventName: Event.didHideMediaControl.rawValue) { _ in print("didHideMediaControl") }
-            listenTo(core, eventName: Event.willHideMediaControl.rawValue) { _ in print("willHideMediaControl") }
-            listenTo(core, eventName: Event.willShowMediaControl.rawValue) { _ in print("willShowMediaControl") }
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -56,6 +56,10 @@ open class PlayButton: MediaControlPlugin {
     open func bindCoreEvents() {
         if let core = core {
             listenTo(core, eventName: InternalEvent.didChangeActiveContainer.rawValue) { [weak self] _ in self?.bindEvents() }
+            listenTo(core, eventName: Event.didShowMediaControl.rawValue) { _ in print("didShowMediaControl") }
+            listenTo(core, eventName: Event.didHideMediaControl.rawValue) { _ in print("didHideMediaControl") }
+            listenTo(core, eventName: Event.willHideMediaControl.rawValue) { _ in print("willHideMediaControl") }
+            listenTo(core, eventName: Event.willShowMediaControl.rawValue) { _ in print("willShowMediaControl") }
         }
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -295,13 +295,15 @@ class MediaControlTests: QuickSpec {
             
             describe("show") {
                 it("triggers willShowMediaControl before showing the view") {
-                    let mediaControl = MediaControl()
+                    let core = CoreStub()
+                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     
+                    mediaControl.render()
                     mediaControl.on(Event.willShowMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = mediaControl.isHidden
+                        viewIsVisible = !mediaControl.isHidden
                     }
                     mediaControl.show()
                     
@@ -316,9 +318,41 @@ class MediaControlTests: QuickSpec {
                     
                     mediaControl.on(Event.didShowMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = mediaControl.isHidden
+                        viewIsVisible = !mediaControl.isHidden
                     }
                     mediaControl.show()
+                    
+                    expect(eventTriggered).toEventually(beTrue())
+                    expect(viewIsVisible).to(beTrue())
+                }
+            }
+            
+            describe("hide") {
+                it("triggers willHideMediaControl before hiding the view") {
+                    let mediaControl = MediaControl()
+                    var eventTriggered = false
+                    var viewIsVisible: Bool?
+                    
+                    mediaControl.on(Event.willHideMediaControl.rawValue) { _ in
+                        eventTriggered = true
+                        viewIsVisible = !mediaControl.isHidden
+                    }
+                    mediaControl.hide()
+                    
+                    expect(eventTriggered).toEventually(beTrue())
+                    expect(viewIsVisible).to(beTrue())
+                }
+                
+                it("triggers didHideMediaControl after showing the view") {
+                    let mediaControl = MediaControl()
+                    var eventTriggered = false
+                    var viewIsVisible: Bool?
+                    
+                    mediaControl.on(Event.didHideMediaControl.rawValue) { _ in
+                        eventTriggered = true
+                        viewIsVisible = !mediaControl.isHidden
+                    }
+                    mediaControl.hide()
                     
                     expect(eventTriggered).toEventually(beTrue())
                     expect(viewIsVisible).to(beFalse())

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -191,7 +191,7 @@ class MediaControlTests: QuickSpec {
                     it("shows itself when hidden") {
                         mediaControlHidden()
 
-                        coreStub.trigger(Event.willShowMediaControl.rawValue)
+                        coreStub.trigger(InternalEvent.didTappedCore.rawValue)
 
                         expect(mediaControl.isHidden).to(beFalse())
                         expect(mediaControl.alpha).to(equal(1))
@@ -201,7 +201,7 @@ class MediaControlTests: QuickSpec {
                         mediaControlHidden()
 
                         coreStub.activePlayback?.trigger(Event.error.rawValue)
-                        coreStub.trigger(Event.willShowMediaControl.rawValue)
+                        coreStub.trigger(InternalEvent.didTappedCore.rawValue)
 
                         expect(mediaControl.isHidden).to(beTrue())
                         expect(mediaControl.alpha).to(equal(0))
@@ -289,7 +289,7 @@ class MediaControlTests: QuickSpec {
                 }
 
                 func mediaControlVisible() {
-                    coreStub.trigger(Event.willShowMediaControl.rawValue)
+                    coreStub.trigger(InternalEvent.didTappedCore.rawValue)
                 }
             }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -292,6 +292,38 @@ class MediaControlTests: QuickSpec {
                     coreStub.trigger(InternalEvent.didTappedCore.rawValue)
                 }
             }
+            
+            describe("show") {
+                it("triggers willShowMediaControl before showing the view") {
+                    let mediaControl = MediaControl()
+                    var eventTriggered = false
+                    var viewIsVisible: Bool?
+                    
+                    mediaControl.on(Event.willShowMediaControl.rawValue) { _ in
+                        eventTriggered = true
+                        viewIsVisible = mediaControl.isHidden
+                    }
+                    mediaControl.show()
+                    
+                    expect(eventTriggered).toEventually(beTrue())
+                    expect(viewIsVisible).to(beFalse())
+                }
+                
+                it("triggers didShowMediaControl after showing the view") {
+                    let mediaControl = MediaControl()
+                    var eventTriggered = false
+                    var viewIsVisible: Bool?
+                    
+                    mediaControl.on(Event.didShowMediaControl.rawValue) { _ in
+                        eventTriggered = true
+                        viewIsVisible = mediaControl.isHidden
+                    }
+                    mediaControl.show()
+                    
+                    expect(eventTriggered).toEventually(beTrue())
+                    expect(viewIsVisible).to(beFalse())
+                }
+            }
 
             describe("renderPlugins") {
                 var plugins: [MediaControlPlugin]!

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -193,18 +193,19 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.trigger(InternalEvent.didTappedCore.rawValue)
 
-                        expect(mediaControl.isHidden).to(beFalse())
-                        expect(mediaControl.alpha).to(equal(1))
+                        expect(mediaControl.isHidden).toEventually(beFalse())
+                        expect(mediaControl.alpha).toEventually(equal(1))
                     }
 
                     it("doesn't show itself if an error occurred") {
+                        mediaControlVisible()
                         mediaControlHidden()
 
                         coreStub.activePlayback?.trigger(Event.error.rawValue)
                         coreStub.trigger(InternalEvent.didTappedCore.rawValue)
 
-                        expect(mediaControl.isHidden).to(beTrue())
-                        expect(mediaControl.alpha).to(equal(0))
+                        expect(mediaControl.isHidden).toEventually(beTrue())
+                        expect(mediaControl.alpha).toEventually(equal(0))
                     }
                 }
 
@@ -315,6 +316,7 @@ class MediaControlTests: QuickSpec {
                     let mediaControl = MediaControl()
                     var eventTriggered = false
                     var viewIsVisible: Bool?
+                    mediaControl.isHidden = true
                     
                     mediaControl.on(Event.didShowMediaControl.rawValue) { _ in
                         eventTriggered = true

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -302,7 +302,7 @@ class MediaControlTests: QuickSpec {
                     var viewIsVisible: Bool?
                     
                     mediaControl.render()
-                    mediaControl.on(Event.willShowMediaControl.rawValue) { _ in
+                    core.on(Event.willShowMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.isHidden
                     }
@@ -313,12 +313,13 @@ class MediaControlTests: QuickSpec {
                 }
                 
                 it("triggers didShowMediaControl after showing the view") {
-                    let mediaControl = MediaControl()
+                    let core = CoreStub()
+                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     mediaControl.isHidden = true
                     
-                    mediaControl.on(Event.didShowMediaControl.rawValue) { _ in
+                    core.on(Event.didShowMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.isHidden
                     }
@@ -331,11 +332,12 @@ class MediaControlTests: QuickSpec {
             
             describe("hide") {
                 it("triggers willHideMediaControl before hiding the view") {
-                    let mediaControl = MediaControl()
+                    let core = CoreStub()
+                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     
-                    mediaControl.on(Event.willHideMediaControl.rawValue) { _ in
+                    core.on(Event.willHideMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.isHidden
                     }
@@ -346,11 +348,12 @@ class MediaControlTests: QuickSpec {
                 }
                 
                 it("triggers didHideMediaControl after showing the view") {
-                    let mediaControl = MediaControl()
+                    let core = CoreStub()
+                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     
-                    mediaControl.on(Event.didHideMediaControl.rawValue) { _ in
+                    core.on(Event.didHideMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.isHidden
                     }


### PR DESCRIPTION
# Goal

To trigger core events telling if the `MediaControl` will show or hide.

# How to test

In any `CorePlugin` (like `PlayButton`) add the following code:

```swift
listenTo(core, eventName: Event.didShowMediaControl.rawValue) { _ in print("didShowMediaControl") }
listenTo(core, eventName: Event.didHideMediaControl.rawValue) { _ in print("didHideMediaControl") }
listenTo(core, eventName: Event.willHideMediaControl.rawValue) { _ in print("willHideMediaControl") }
listenTo(core, eventName: Event.willShowMediaControl.rawValue) { _ in print("willShowMediaControl") }
```

Then, play the video and manipulate `MediaControl` looking at the log output.