### PR TITLE
UI objects with a view property

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -78,7 +78,6 @@
 		32E401C41FF42335001C2096 /* UIView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362A31D41339400CCB866 /* UIView+Ext.swift */; };
 		32E401C51FF42343001C2096 /* MediaOptionFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362A71D41339400CCB866 /* MediaOptionFactory.swift */; };
 		32E401C61FF42343001C2096 /* PlaybackFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362A81D41339400CCB866 /* PlaybackFactory.swift */; };
-		32E401C71FF42351001C2096 /* SpinnerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362AD1D41339400CCB866 /* SpinnerPlugin.swift */; };
 		32E401C81FF42351001C2096 /* UIContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362AF1D41339400CCB866 /* UIContainerPlugin.swift */; };
 		32E401C91FF42359001C2096 /* UICorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362B11D41339400CCB866 /* UICorePlugin.swift */; };
 		32E401CA1FF42372001C2096 /* UIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362B51D41339400CCB866 /* UIPlugin.swift */; };
@@ -1693,7 +1692,6 @@
 				FC7785A82005233D00EC879F /* EventDispatcher.swift in Sources */,
 				FC7785A92005233D00EC879F /* EventHandler.swift in Sources */,
 				ABE7D3EF212C36200049773A /* SharedData.swift in Sources */,
-				32E401C71FF42351001C2096 /* SpinnerPlugin.swift in Sources */,
 				576786C02188A4B40046508C /* Array+appendOrReplace.swift in Sources */,
 				32DA34191FFBCFC400484C90 /* Container.swift in Sources */,
 				571B7B262174E324005C0942 /* AVFoundationPlayback+tvOS.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -108,13 +108,12 @@
 		576786C12188A4C60046508C /* Array+appendOrReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */; };
 		57937C571FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */; };
 		57937C5A1FB0DD2C000A239E /* AVURLAssetWithCookiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */; };
-		57B0A1DF1FF40C3600891037 /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B0A1DE1FF40C3600891037 /* UIObject.swift */; };
 		57B2F823212AEFC600913EC1 /* Kingfisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96D362F01D41345E00CCB866 /* Kingfisher.framework */; };
 		57F1354921836EE000111BC6 /* Array+appendOrReplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */; };
 		96036D671CBD89500022CCCA /* PlaybackFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */; };
 		9603A06C1C05E6D100B55D8F /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9603A06B1C05E6D100B55D8F /* PlayerTests.swift */; };
 		963B19981E4B827700A0A6BA /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963B19971E4B827700A0A6BA /* Event.swift */; };
-		96664E571BF0CBD400095E6E /* UIBaseObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96664E551BF0CBD100095E6E /* UIBaseObjectTests.swift */; };
+		96664E571BF0CBD400095E6E /* UIObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96664E551BF0CBD100095E6E /* UIObjectTests.swift */; };
 		96664E5E1BF0D5FB00095E6E /* PlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96664E581BF0D58400095E6E /* PlaybackTests.swift */; };
 		96664E6D1BF209CF00095E6E /* ContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96664E6B1BF209CB00095E6E /* ContainerTests.swift */; };
 		968E5BD91D6CBFA50092F372 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968E5BD81D6CBFA50092F372 /* Logger.swift */; };
@@ -142,7 +141,7 @@
 		96D362CC1D41339400CCB866 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362941D41339400CCB866 /* Options.swift */; };
 		96D362CD1D41339400CCB866 /* Playback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362951D41339400CCB866 /* Playback.swift */; };
 		96D362CE1D41339400CCB866 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362961D41339400CCB866 /* Player.swift */; };
-		96D362CF1D41339400CCB866 /* UIBaseObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362971D41339400CCB866 /* UIBaseObject.swift */; };
+		96D362CF1D41339400CCB866 /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D362971D41339400CCB866 /* UIObject.swift */; };
 		96D362D31D41339400CCB866 /* MediaControlState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D3629C1D41339400CCB866 /* MediaControlState.swift */; };
 		96D362D41D41339400CCB866 /* MediaOptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D3629D1D41339400CCB866 /* MediaOptionType.swift */; };
 		96D362D61D41339400CCB866 /* PlaybackType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96D3629F1D41339400CCB866 /* PlaybackType.swift */; };
@@ -232,7 +231,7 @@
 		FC7785A82005233D00EC879F /* EventDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7785982005233D00EC879F /* EventDispatcher.swift */; };
 		FC7785A92005233D00EC879F /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7785992005233D00EC879F /* EventHandler.swift */; };
 		FC7785AE2005233D00EC879F /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC77859E2005233D00EC879F /* Player.swift */; };
-		FC7785AF2005233D00EC879F /* UIBaseObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC77859F2005233D00EC879F /* UIBaseObject.swift */; };
+		FC7785AF2005233D00EC879F /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC77859F2005233D00EC879F /* UIObject.swift */; };
 		FC7785B22005233D00EC879F /* EventProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7785A52005233D00EC879F /* EventProtocol.swift */; };
 		FC7785B7200523E400EC879F /* AVFoundationNowPlayingBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7785B4200523E400EC879F /* AVFoundationNowPlayingBuilder.swift */; };
 		FC7785B8200523E400EC879F /* AVFoundationNowPlayingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7785B5200523E400EC879F /* AVFoundationNowPlayingService.swift */; };
@@ -244,7 +243,6 @@
 		FC7785E820052CB800EC879F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FC7785E720052CB800EC879F /* Assets.xcassets */; };
 		FC7785ED20052EB300EC879F /* Clappr.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 321781A81FED90CC00EDD678 /* Clappr.framework */; };
 		FC7785EE20052EB300EC879F /* Clappr.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 321781A81FED90CC00EDD678 /* Clappr.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		FCF11C3E2007E86F008DC4D6 /* UIObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B0A1DE1FF40C3600891037 /* UIObject.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -362,7 +360,6 @@
 		57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+appendOrReplaceTests.swift"; sourceTree = "<group>"; };
 		57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesBuilder.swift; sourceTree = "<group>"; };
 		57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesTests.swift; sourceTree = "<group>"; };
-		57B0A1DE1FF40C3600891037 /* UIObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIObject.swift; sourceTree = "<group>"; };
 		57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+appendOrReplace.swift"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* Clappr_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clappr_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACE51AFB9204008FA782 /* Clappr_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Clappr_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -371,7 +368,7 @@
 		96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaybackFactoryTests.swift; sourceTree = "<group>"; };
 		9603A06B1C05E6D100B55D8F /* PlayerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerTests.swift; sourceTree = "<group>"; };
 		963B19971E4B827700A0A6BA /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
-		96664E551BF0CBD100095E6E /* UIBaseObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBaseObjectTests.swift; sourceTree = "<group>"; };
+		96664E551BF0CBD100095E6E /* UIObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIObjectTests.swift; sourceTree = "<group>"; };
 		96664E581BF0D58400095E6E /* PlaybackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaybackTests.swift; sourceTree = "<group>"; };
 		96664E6B1BF209CB00095E6E /* ContainerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerTests.swift; sourceTree = "<group>"; };
 		9684B6C81D186E2D00D012C2 /* AVFoundationPlaybackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackTests.swift; sourceTree = "<group>"; };
@@ -400,7 +397,7 @@
 		96D362941D41339400CCB866 /* Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		96D362951D41339400CCB866 /* Playback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Playback.swift; sourceTree = "<group>"; };
 		96D362961D41339400CCB866 /* Player.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
-		96D362971D41339400CCB866 /* UIBaseObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBaseObject.swift; sourceTree = "<group>"; };
+		96D362971D41339400CCB866 /* UIObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIObject.swift; sourceTree = "<group>"; };
 		96D3629C1D41339400CCB866 /* MediaControlState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaControlState.swift; sourceTree = "<group>"; };
 		96D3629D1D41339400CCB866 /* MediaOptionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaOptionType.swift; sourceTree = "<group>"; };
 		96D3629F1D41339400CCB866 /* PlaybackType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaybackType.swift; sourceTree = "<group>"; };
@@ -483,7 +480,7 @@
 		FC7785982005233D00EC879F /* EventDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDispatcher.swift; sourceTree = "<group>"; };
 		FC7785992005233D00EC879F /* EventHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventHandler.swift; sourceTree = "<group>"; };
 		FC77859E2005233D00EC879F /* Player.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
-		FC77859F2005233D00EC879F /* UIBaseObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBaseObject.swift; sourceTree = "<group>"; };
+		FC77859F2005233D00EC879F /* UIObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIObject.swift; sourceTree = "<group>"; };
 		FC7785A52005233D00EC879F /* EventProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventProtocol.swift; sourceTree = "<group>"; };
 		FC7785B4200523E400EC879F /* AVFoundationNowPlayingBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVFoundationNowPlayingBuilder.swift; sourceTree = "<group>"; };
 		FC7785B5200523E400EC879F /* AVFoundationNowPlayingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVFoundationNowPlayingService.swift; sourceTree = "<group>"; };
@@ -727,7 +724,7 @@
 				9603A06B1C05E6D100B55D8F /* PlayerTests.swift */,
 				96912C3C1C219F25003A4AFD /* PosterPluginTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
-				96664E551BF0CBD100095E6E /* UIBaseObjectTests.swift */,
+				96664E551BF0CBD100095E6E /* UIObjectTests.swift */,
 				96B465691BF6027F0025975A /* UIPluginTests.swift */,
 				EDF652211D467CCA00627C48 /* UICorePluginTests.swift */,
 				EDF652231D46829100627C48 /* UIContainerPluginTests.swift */,
@@ -816,7 +813,6 @@
 				96D3628D1D41339400CCB866 /* Container.swift */,
 				96D362911D41339400CCB866 /* Loader.swift */,
 				96D362931D41339400CCB866 /* MediaOption.swift */,
-				57B0A1DE1FF40C3600891037 /* UIObject.swift */,
 				ABE7D3ED212C36200049773A /* SharedData.swift */,
 				ABAFEBA52152C25B007BA497 /* AvailableMediaOptions.swift */,
 				96D362951D41339400CCB866 /* Playback.swift */,
@@ -962,7 +958,7 @@
 				96D3628C1D41339400CCB866 /* BaseObject.swift */,
 				96D3628F1D41339400CCB866 /* EventHandler.swift */,
 				96D362961D41339400CCB866 /* Player.swift */,
-				96D362971D41339400CCB866 /* UIBaseObject.swift */,
+				96D362971D41339400CCB866 /* UIObject.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1170,7 +1166,7 @@
 				FC7785982005233D00EC879F /* EventDispatcher.swift */,
 				FC7785992005233D00EC879F /* EventHandler.swift */,
 				FC77859E2005233D00EC879F /* Player.swift */,
-				FC77859F2005233D00EC879F /* UIBaseObject.swift */,
+				FC77859F2005233D00EC879F /* UIObject.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1672,7 +1668,6 @@
 				32E401C61FF42343001C2096 /* PlaybackFactory.swift in Sources */,
 				32E401C51FF42343001C2096 /* MediaOptionFactory.swift in Sources */,
 				32A7A297215EA27F00296DE3 /* NoOpPlayback.swift in Sources */,
-				FCF11C3E2007E86F008DC4D6 /* UIObject.swift in Sources */,
 				32E401C21FF42321001C2096 /* Event.swift in Sources */,
 				32E401CA1FF42372001C2096 /* UIPlugin.swift in Sources */,
 				32E401CE1FF42386001C2096 /* GradientView.swift in Sources */,
@@ -1681,7 +1676,7 @@
 				FC7785B8200523E400EC879F /* AVFoundationNowPlayingService.swift in Sources */,
 				FC7785AE2005233D00EC879F /* Player.swift in Sources */,
 				FC7785B22005233D00EC879F /* EventProtocol.swift in Sources */,
-				FC7785AF2005233D00EC879F /* UIBaseObject.swift in Sources */,
+				FC7785AF2005233D00EC879F /* UIObject.swift in Sources */,
 				32DA341A1FFBD02A00484C90 /* Loader.swift in Sources */,
 				AB24DCD62152ED0E002D4660 /* AvailableMediaOptions.swift in Sources */,
 				32E401BC1FF422E0001C2096 /* Logger.swift in Sources */,
@@ -1763,7 +1758,7 @@
 				96664E6D1BF209CF00095E6E /* ContainerTests.swift in Sources */,
 				571B7B2E21750204005C0942 /* AVFoundationPlaybackTests.swift in Sources */,
 				EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */,
-				96664E571BF0CBD400095E6E /* UIBaseObjectTests.swift in Sources */,
+				96664E571BF0CBD400095E6E /* UIObjectTests.swift in Sources */,
 				E7BEEB5C21751EE600B8F7FA /* TimeIndicatorTests.swift in Sources */,
 				C9EDF84F2162CF1600789E2F /* UINavigationControllerMock.swift in Sources */,
 				96A979881BFF964F00E5EA01 /* CoreTests.swift in Sources */,
@@ -1822,7 +1817,6 @@
 				96D362E91D41339400CCB866 /* DragDetectorView.swift in Sources */,
 				96D362D41D41339400CCB866 /* MediaOptionType.swift in Sources */,
 				FC6418DE2007DB9100E81B7C /* ClapprDateFormatter.swift in Sources */,
-				57B0A1DF1FF40C3600891037 /* UIObject.swift in Sources */,
 				9E26CFF32016149600AE92B7 /* FullScreenStateHandler.swift in Sources */,
 				96D362CC1D41339400CCB866 /* Options.swift in Sources */,
 				9EED97012088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift in Sources */,
@@ -1831,7 +1825,7 @@
 				C9EDF8582163A9A900789E2F /* UIColor+ClapprAdditions.swift in Sources */,
 				ABE7D3EE212C36200049773A /* SharedData.swift in Sources */,
 				96E7D2741E786FEE0056F358 /* InternalEvent.swift in Sources */,
-				96D362CF1D41339400CCB866 /* UIBaseObject.swift in Sources */,
+				96D362CF1D41339400CCB866 /* UIObject.swift in Sources */,
 				96D362C51D41339400CCB866 /* Container.swift in Sources */,
 				963B19981E4B827700A0A6BA /* Event.swift in Sources */,
 				96D362DF1D41339400CCB866 /* SpinnerPlugin.swift in Sources */,

--- a/Example/Clappr/ViewController.swift
+++ b/Example/Clappr/ViewController.swift
@@ -59,7 +59,7 @@ class ViewController: UIViewController {
         present(fullscreenController, animated: false) {
             self.player.setFullscreen(true)
         }
-        fullscreenController.view.addSubviewMatchingConstraints(player.core!)
+        fullscreenController.view.addSubviewMatchingConstraints(player.core!.view)
     }
 
     @objc func onExitFullscreen() {
@@ -67,7 +67,7 @@ class ViewController: UIViewController {
         fullscreenController.dismiss(animated: false) {
             self.player.setFullscreen(false)
         }
-        core.parentView?.addSubviewMatchingConstraints(core)
+        core.parentView?.addSubviewMatchingConstraints(core.view)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -24,7 +24,7 @@ open class Container: UIBaseObject {
         }
         didSet {
             if self.playback != oldValue {
-                self.playback?.removeFromSuperview()
+                self.playback?.view.removeFromSuperview()
                 self.playback?.once(Event.playing.rawValue) { [weak self] _ in self?.options[kStartAt] = 0.0 }
                 trigger(InternalEvent.didChangePlayback.rawValue)
             }
@@ -34,18 +34,16 @@ open class Container: UIBaseObject {
     public init(options: Options = [:]) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
         self.options = options
-        super.init(frame: CGRect.zero)
+
+        super.init()
+
         self.sharedData.container = self
-        backgroundColor = UIColor.clear
+        view.backgroundColor = UIColor.clear
         Loader.shared.loadPlugins(in: self)
-        accessibilityIdentifier = "Container"
+        view.accessibilityIdentifier = "Container"
         if let source = options[kSourceUrl] as? String {
             load(source, mimeType: options[kMimeType] as? String)
         }
-    }
-
-    public required init?(coder _: NSCoder) {
-        fatalError("Use init(playback: Playback) instead")
     }
 
     @objc open func load(_ source: String, mimeType: String? = nil) {
@@ -79,13 +77,13 @@ open class Container: UIBaseObject {
             return
         }
 
-        addSubviewMatchingConstraints(playback)
+        view.addSubviewMatchingConstraints(playback.view)
         playback.render()
-        sendSubview(toBack: playback)
+        view.sendSubview(toBack: playback.view)
     }
 
     fileprivate func renderPlugin(_ plugin: UIContainerPlugin) {
-        addSubview(plugin)
+        view.addSubview(plugin.view)
         plugin.render()
     }
 
@@ -109,7 +107,7 @@ open class Container: UIBaseObject {
         plugins.forEach { plugin in plugin.destroy() }
         plugins.removeAll()
 
-        removeFromSuperview()
+        view.removeFromSuperview()
 
         trigger(InternalEvent.didDestroy.rawValue)
         Logger.logDebug("destroying listeners", scope: "Container")

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class Container: UIBaseObject {
+open class Container: UIObject {
     @objc internal(set) open var plugins: [UIContainerPlugin] = []
     @objc open var sharedData = SharedData()
     @objc open var options: Options {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -1,4 +1,4 @@
-open class Core: UIBaseObject {
+open class Core: UIBaseObject, UIGestureRecognizerDelegate {
     @objc open var options: Options {
         didSet {
             containers.forEach { $0.options = options }
@@ -77,8 +77,8 @@ open class Core: UIBaseObject {
 
     fileprivate func addTapRecognizer() {
         #if os(iOS)
-        view.isUserInteractionEnabled = true
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTappedView))
+        tapRecognizer.delegate = self
         view.addGestureRecognizer(tapRecognizer)
         #endif
     }
@@ -105,7 +105,7 @@ open class Core: UIBaseObject {
 
         addToContainer()
     }
-    
+
     #if os(tvOS)
     private func renderPlugins() {
         plugins.forEach { plugin in
@@ -114,7 +114,7 @@ open class Core: UIBaseObject {
         }
     }
     #endif
-    
+
     #if os(iOS)
     private func renderCoreAndMediaControlPlugins() {
         plugins.forEach { plugin in
@@ -123,7 +123,7 @@ open class Core: UIBaseObject {
                 plugin.render()
             }
 
-            
+
             if plugin is MediaControl, let mediaControl = plugin as? MediaControl {
                 mediaControl.renderPlugins(plugins)
             }
@@ -164,6 +164,10 @@ open class Core: UIBaseObject {
 
     @objc open func hasPlugin(_ pluginClass: AnyClass) -> Bool {
         return plugins.filter({ $0.isKind(of: pluginClass) }).count > 0
+    }
+
+    open func gestureRecognizer(_: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        return touch.view!.accessibilityIdentifier == "Container"
     }
 
     @objc open func setFullscreen(_ fullscreen: Bool) {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -1,4 +1,4 @@
-open class Core: UIBaseObject, UIGestureRecognizerDelegate {
+open class Core: UIObject, UIGestureRecognizerDelegate {
     @objc open var options: Options {
         didSet {
             containers.forEach { $0.options = options }

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 
-open class Playback: UIBaseObject, Plugin {
+open class Playback: UIObject, Plugin {
     open class var type: PluginType { return .playback }
 
     @objc open class var name: String {
@@ -76,7 +76,7 @@ open class Playback: UIBaseObject, Plugin {
         view.isUserInteractionEnabled = false
     }
 
-    @objc public required init(context _: UIBaseObject) {
+    @objc public required init(context _: UIObject) {
         fatalError("Use init(url: NSURL) instead")
     }
 

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -63,21 +63,17 @@ open class Playback: UIBaseObject, Plugin {
         return false
     }
 
-    public required init() {
+    public required override init() {
         options = [:]
-        super.init(frame: CGRect.zero)
-        backgroundColor = UIColor.clear
+        super.init()
+        view.backgroundColor = UIColor.clear
     }
 
     @objc public required init(options: Options) {
         Logger.logDebug("loading with \(options)", scope: "\(Swift.type(of: self))")
         self.options = options
-        super.init(frame: CGRect.zero)
-        isUserInteractionEnabled = false
-    }
-
-    public required init?(coder _: NSCoder) {
-        fatalError("Use init(url: NSURL) instead")
+        super.init()
+        view.isUserInteractionEnabled = false
     }
 
     @objc public required init(context _: UIBaseObject) {
@@ -112,7 +108,7 @@ open class Playback: UIBaseObject, Plugin {
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Playback")
         Logger.logDebug("destroying ui elements", scope: "Playback")
-        removeFromSuperview()
+        view.removeFromSuperview()
         Logger.logDebug("destroying listeners", scope: "Playback")
         stopListening()
         Logger.logDebug("destroyed", scope: "Playback")

--- a/Sources/Clappr/Classes/Base/UIObject.swift
+++ b/Sources/Clappr/Classes/Base/UIObject.swift
@@ -1,3 +1,0 @@
-protocol UIObject {
-    func render()
-}

--- a/Sources/Clappr/Classes/Base/UIObject.swift
+++ b/Sources/Clappr/Classes/Base/UIObject.swift
@@ -1,5 +1,3 @@
 protocol UIObject {
-    var view: UIView { get }
-
     func render()
 }

--- a/Sources/Clappr/Classes/Extension/AVFoundationPlayback+ViewPort.swift
+++ b/Sources/Clappr/Classes/Extension/AVFoundationPlayback+ViewPort.swift
@@ -3,10 +3,12 @@ import AVFoundation
 extension AVFoundationPlayback {
 
     func setupMaxResolution(for size: CGSize) {
-        if #available(tvOS 11.0, iOS 11.0, *) {
+        #if os(iOS)
+        if #available(iOS 11.0, *) {
             let screenScale = UIScreen.main.scale
             let screenSize = CGSize(width: size.width * screenScale, height: size.height * screenScale)
             player?.currentItem?.preferredMaximumResolution = screenSize
         }
+        #endif
     }
 }

--- a/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
+++ b/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
@@ -18,7 +18,7 @@ open class NoOpPlayback: Playback {
         super.init()
     }
 
-    public required init(context _: UIBaseObject) {
+    public required init(context _: UIObject) {
         fatalError("init(context:) has not been implemented")
     }
 

--- a/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
+++ b/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
@@ -27,7 +27,7 @@ open class NoOpPlayback: Playback {
     }
 
     open override func render() {
-        addSubviewMatchingConstraints(errorLabel)
+        view.addSubviewMatchingConstraints(errorLabel)
     }
 
     fileprivate func setupLabel() {

--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -14,17 +14,13 @@ open class SpinnerPlugin: UIContainerPlugin {
         return "spinner"
     }
 
-    public required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     public required init(context: UIBaseObject) {
         super.init(context: context)
         spinningWheel = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
-        addSubview(spinningWheel)
-        isUserInteractionEnabled = false
+        view.addSubview(spinningWheel)
+        view.isUserInteractionEnabled = false
         bindDidChangePlayback()
-        accessibilityIdentifier = "SpinnerPlugin"
+        view.accessibilityIdentifier = "SpinnerPlugin"
     }
 
     private func bindDidChangePlayback() {
@@ -44,23 +40,23 @@ open class SpinnerPlugin: UIContainerPlugin {
     }
 
     fileprivate func addCenteringConstraints() {
-        translatesAutoresizingMaskIntoConstraints = false
+        view.translatesAutoresizingMaskIntoConstraints = false
 
-        let widthConstraint = NSLayoutConstraint(item: self, attribute: .width, relatedBy: .equal,
+        let widthConstraint = NSLayoutConstraint(item: view, attribute: .width, relatedBy: .equal,
                                                  toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: spinningWheel.frame.width)
-        addConstraint(widthConstraint)
+        view.addConstraint(widthConstraint)
 
-        let heightConstraint = NSLayoutConstraint(item: self, attribute: .height, relatedBy: .equal,
+        let heightConstraint = NSLayoutConstraint(item: view, attribute: .height, relatedBy: .equal,
                                                   toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: spinningWheel.frame.height)
-        addConstraint(heightConstraint)
+        view.addConstraint(heightConstraint)
 
-        let xCenterConstraint = NSLayoutConstraint(item: self, attribute: .centerX,
-                                                   relatedBy: .equal, toItem: container, attribute: .centerX, multiplier: 1, constant: 0)
-        container?.addConstraint(xCenterConstraint)
+        let xCenterConstraint = NSLayoutConstraint(item: view, attribute: .centerX,
+                                                   relatedBy: .equal, toItem: container?.view, attribute: .centerX, multiplier: 1, constant: 0)
+        container?.view.addConstraint(xCenterConstraint)
 
-        let yCenterConstraint = NSLayoutConstraint(item: self, attribute: .centerY,
-                                                   relatedBy: .equal, toItem: container, attribute: .centerY, multiplier: 1, constant: 0)
-        container?.addConstraint(yCenterConstraint)
+        let yCenterConstraint = NSLayoutConstraint(item: view, attribute: .centerY,
+                                                   relatedBy: .equal, toItem: container?.view, attribute: .centerY, multiplier: 1, constant: 0)
+        container?.view.addConstraint(yCenterConstraint)
     }
 
     private func bindPlaybackEvents() {
@@ -73,13 +69,13 @@ open class SpinnerPlugin: UIContainerPlugin {
     }
 
     fileprivate func startAnimating(_: EventUserInfo) {
-        isHidden = false
+        view.isHidden = false
         spinningWheel.startAnimating()
         Logger.logDebug("started animating spinning wheel", scope: pluginName)
     }
 
     fileprivate func stopAnimating(_: EventUserInfo) {
-        isHidden = true
+        view.isHidden = true
         spinningWheel.stopAnimating()
         Logger.logDebug("stoped animating spinning wheel", scope: pluginName)
     }
@@ -88,7 +84,7 @@ open class SpinnerPlugin: UIContainerPlugin {
         super.destroy()
         Logger.logDebug("destroying", scope: "SpinnerPlugin")
         Logger.logDebug("destroying ui elements", scope: "SpinnerPlugin")
-        removeFromSuperview()
+        view.removeFromSuperview()
         Logger.logDebug("destroyed", scope: "SpinnerPlugin")
     }
 }

--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -14,7 +14,7 @@ open class SpinnerPlugin: UIContainerPlugin {
         return "spinner"
     }
 
-    public required init(context: UIBaseObject) {
+    public required init(context: UIObject) {
         super.init(context: context)
         spinningWheel = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
         view.addSubview(spinningWheel)

--- a/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
@@ -12,21 +12,17 @@ open class UIContainerPlugin: UIPlugin, Plugin {
         return ""
     }
 
-    public required init() {
-        super.init(frame: CGRect.zero)
+    public required override init() {
+        super.init()
     }
 
     @objc public required init(context: UIBaseObject) {
-        super.init(frame: CGRect.zero)
+        super.init()
         if let container = context as? Container {
             self.container = container
         } else {
             NSException(name: NSExceptionName(rawValue: "WrongContextType"), reason: "Container Plugins should always be initialized with a Container context", userInfo: nil).raise()
         }
-    }
-
-    public required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
 
     @objc open func destroy() {

--- a/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
@@ -16,7 +16,7 @@ open class UIContainerPlugin: UIPlugin, Plugin {
         super.init()
     }
 
-    @objc public required init(context: UIBaseObject) {
+    @objc public required init(context: UIObject) {
         super.init()
         if let container = context as? Container {
             self.container = container

--- a/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
@@ -25,10 +25,6 @@ open class UICorePlugin: UIPlugin, Plugin {
         }
     }
 
-    public required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "UICorePlugin")
         Logger.logDebug("destroying listeners", scope: "UICorePlugin")

--- a/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
@@ -12,12 +12,12 @@ open class UICorePlugin: UIPlugin, Plugin {
         return ""
     }
 
-    public required init() {
-        super.init(frame: CGRect.zero)
+    public required override init() {
+        super.init()
     }
 
     @objc public required init(context: UIBaseObject) {
-        super.init(frame: CGRect.zero)
+        super.init()
         if let core = context as? Core {
             self.core = core
         } else {

--- a/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
@@ -16,7 +16,7 @@ open class UICorePlugin: UIPlugin, Plugin {
         super.init()
     }
 
-    @objc public required init(context: UIBaseObject) {
+    @objc public required init(context: UIObject) {
         super.init()
         if let core = context as? Core {
             self.core = core

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -216,10 +216,7 @@ open class AVFoundationPlayback: Playback {
             return
         }
         playerLayer.frame = view.bounds
-
-        #if os(iOS)
         setupMaxResolution(for: playerLayer.frame.size)
-        #endif
     }
 
     open override func play() {
@@ -250,9 +247,7 @@ open class AVFoundationPlayback: Playback {
             playerLayer = AVPlayerLayer(player: player)
             view.layer.addSublayer(playerLayer!)
             playerLayer?.frame = view.bounds
-            #if os(iOS)
             setupMaxResolution(for: playerLayer!.frame.size)
-            #endif
 
             addObservers()
             trigger(.ready)

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -207,7 +207,7 @@ open class AVFoundationPlayback: Playback {
         super.init()
     }
 
-    public required init(context _: UIBaseObject) {
+    public required init(context _: UIObject) {
         fatalError("init(context:) has not been implemented")
     }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -216,7 +216,10 @@ open class AVFoundationPlayback: Playback {
             return
         }
         playerLayer.frame = view.bounds
+
+        #if os(iOS)
         setupMaxResolution(for: playerLayer.frame.size)
+        #endif
     }
 
     open override func play() {
@@ -247,6 +250,9 @@ open class AVFoundationPlayback: Playback {
             playerLayer = AVPlayerLayer(player: player)
             view.layer.addSublayer(playerLayer!)
             playerLayer?.frame = view.bounds
+            #if os(iOS)
+            setupMaxResolution(for: playerLayer!.frame.size)
+            #endif
 
             addObservers()
             trigger(.ready)

--- a/Sources/Clappr/Classes/Plugin/UIPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/UIPlugin.swift
@@ -1,3 +1,3 @@
-open class UIPlugin: UIBaseObject, UIObject {
+open class UIPlugin: UIObject {
 
 }

--- a/Sources/Clappr/Classes/Plugin/UIPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/UIPlugin.swift
@@ -1,12 +1,3 @@
 open class UIPlugin: UIBaseObject, UIObject {
-    @objc open var view: UIView
-    
-    public override init(frame: CGRect) {
-        self.view = UIView()
-        super.init(frame: frame)
-    }
-    
-    required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+
 }

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -3,6 +3,6 @@ public protocol Plugin {
     static var name: String { get }
     var pluginName: String { get }
     init()
-    init(context: UIBaseObject)
+    init(context: UIObject)
     func destroy()
 }

--- a/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
+++ b/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
@@ -47,7 +47,7 @@ struct FullscreenByPlayer: FullscreenStateHandler {
         fullscreenController.view.backgroundColor = UIColor.black
         fullscreenController.modalPresentationStyle = .overFullScreen
         core.parentController?.present(fullscreenController, animated: false, completion: nil)
-        fullscreenController.view.addSubviewMatchingConstraints(core)
+        fullscreenController.view.addSubviewMatchingConstraints(core.view)
         core.trigger(InternalEvent.didEnterFullscreen.rawValue)
         core.trigger(InternalEvent.userRequestEnterInFullscreen.rawValue)
     }
@@ -62,7 +62,7 @@ struct FullscreenByPlayer: FullscreenStateHandler {
     }
 
     private func handleExit() {
-        core.parentView?.addSubviewMatchingConstraints(core)
+        core.parentView?.addSubviewMatchingConstraints(core.view)
         core.fullscreenController?.dismiss(animated: false, completion: nil)
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/UIBaseObject.swift
+++ b/Sources/Clappr_iOS/Classes/Base/UIBaseObject.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-open class UIBaseObject: UIView, EventProtocol {
+open class UIBaseObject: NSObject, EventProtocol {
     fileprivate let baseObject = BaseObject()
+    @objc open var view: UIView = UIView()
 
     @objc @discardableResult
     open func on(_ eventName: String, callback: @escaping EventCallback) -> String {

--- a/Sources/Clappr_iOS/Classes/Base/UIObject.swift
+++ b/Sources/Clappr_iOS/Classes/Base/UIObject.swift
@@ -1,54 +1,53 @@
 import Foundation
 
-@objcMembers
-open class UIBaseObject: NSObject, EventProtocol {
-    fileprivate let dispatcher = EventDispatcher()
+open class UIObject: NSObject, EventProtocol {
+    fileprivate let baseObject = BaseObject()
     @objc open var view: UIView = UIView()
 
-    @discardableResult
+    @objc @discardableResult
     open func on(_ eventName: String, callback: @escaping EventCallback) -> String {
-        return dispatcher.on(eventName, callback: callback)
+        return baseObject.on(eventName, callback: callback)
     }
 
-    @discardableResult
+    @objc @discardableResult
     open func once(_ eventName: String, callback: @escaping EventCallback) -> String {
-        return dispatcher.once(eventName, callback: callback)
+        return baseObject.once(eventName, callback: callback)
     }
 
-    open func off(_ listenId: String) {
-        dispatcher.off(listenId)
+    @objc open func off(_ listenId: String) {
+        baseObject.off(listenId)
     }
 
-    open func trigger(_ eventName: String) {
-        dispatcher.trigger(eventName)
+    @objc open func trigger(_ eventName: String) {
+        baseObject.trigger(eventName)
         Logger.logDebug("[\(eventName)] triggered", scope: logIdentifier())
     }
 
-    open func trigger(_ eventName: String, userInfo: EventUserInfo) {
-        dispatcher.trigger(eventName, userInfo: userInfo)
+    @objc open func trigger(_ eventName: String, userInfo: EventUserInfo) {
+        baseObject.trigger(eventName, userInfo: userInfo)
         Logger.logDebug("[\(eventName)] triggered with \(String(describing: userInfo))", scope: logIdentifier())
     }
 
     @discardableResult
     open func listenTo<T: EventProtocol>(_ contextObject: T, eventName: String, callback: @escaping EventCallback) -> String {
-        return dispatcher.listenTo(contextObject, eventName: eventName, callback: callback)
+        return baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
     }
 
     @discardableResult
     open func listenToOnce<T: EventProtocol>(_ contextObject: T, eventName: String, callback: @escaping EventCallback) -> String {
-        return dispatcher.listenToOnce(contextObject, eventName: eventName, callback: callback)
+        return baseObject.listenToOnce(contextObject, eventName: eventName, callback: callback)
     }
 
-    open func stopListening() {
-        dispatcher.stopListening()
+    @objc open func stopListening() {
+        baseObject.stopListening()
     }
 
-    open func stopListening(_ listenId: String) {
-        dispatcher.stopListening(listenId)
+    @objc open func stopListening(_ listenId: String) {
+        baseObject.stopListening(listenId)
     }
 
-    open func getEventDispatcher() -> EventDispatcher {
-        return dispatcher
+    @objc open func getEventContextObject() -> BaseObject {
+        return baseObject
     }
 
     fileprivate func logIdentifier() -> String {
@@ -58,14 +57,15 @@ open class UIBaseObject: NSObject, EventProtocol {
         return "\(type(of: self))"
     }
 
-    open func render() {}
+    @objc open func render() {}
+    
 
     deinit {
         Logger.logDebug("deinit", scope: NSStringFromClass(type(of: self)))
     }
 }
 
-public extension UIBaseObject {
+public extension UIObject {
     public func trigger(_ event: Event) {
         trigger(event.rawValue)
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -12,7 +12,7 @@ open class PosterPlugin: UIContainerPlugin {
         super.init()
     }
 
-    public required init(context: UIBaseObject) {
+    public required init(context: UIObject) {
         super.init(context: context)
         view.translatesAutoresizingMaskIntoConstraints = false
         poster.contentMode = .scaleAspectFit

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -4,10 +4,6 @@ open class PosterPlugin: UIContainerPlugin {
     internal(set) var poster = UIImageView(frame: CGRect.zero)
     fileprivate var playButton = UIButton(frame: CGRect.zero)
 
-    public required init?(coder _: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     open override var pluginName: String {
         return "poster"
     }
@@ -18,7 +14,7 @@ open class PosterPlugin: UIContainerPlugin {
 
     public required init(context: UIBaseObject) {
         super.init(context: context)
-        translatesAutoresizingMaskIntoConstraints = false
+        view.translatesAutoresizingMaskIntoConstraints = false
         poster.contentMode = .scaleAspectFit
         bindContainerEvents()
     }
@@ -28,7 +24,7 @@ open class PosterPlugin: UIContainerPlugin {
         if let urlString = container.options[kPosterUrl] as? String {
             setPosterImage(with: urlString)
         } else {
-            isHidden = true
+            view.isHidden = true
             container.mediaControlEnabled = false
         }
 
@@ -59,18 +55,18 @@ open class PosterPlugin: UIContainerPlugin {
     }
 
     fileprivate func configureViews() {
-        container?.addMatchingConstraints(self)
-        addSubviewMatchingConstraints(poster)
+        container?.view.addMatchingConstraints(view)
+        view.addSubviewMatchingConstraints(poster)
 
-        addSubview(playButton)
+        view.addSubview(playButton)
 
         let xCenterConstraint = NSLayoutConstraint(item: playButton, attribute: .centerX,
-                                                   relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1, constant: 0)
-        addConstraint(xCenterConstraint)
+                                                   relatedBy: .equal, toItem: view, attribute: .centerX, multiplier: 1, constant: 0)
+        view.addConstraint(xCenterConstraint)
 
         let yCenterConstraint = NSLayoutConstraint(item: playButton, attribute: .centerY,
-                                                   relatedBy: .equal, toItem: self, attribute: .centerY, multiplier: 1, constant: 0)
-        addConstraint(yCenterConstraint)
+                                                   relatedBy: .equal, toItem: view, attribute: .centerY, multiplier: 1, constant: 0)
+        view.addConstraint(yCenterConstraint)
     }
 
     private func bindPlaybackEvents() {
@@ -97,7 +93,7 @@ open class PosterPlugin: UIContainerPlugin {
         bindPlaybackEvents()
         bindContainerEvents()
         if isNoOpPlayback {
-            isHidden = true
+            view.isHidden = true
         }
     }
 
@@ -106,14 +102,14 @@ open class PosterPlugin: UIContainerPlugin {
     }
 
     fileprivate func playbackStarted() {
-        isHidden = true
+        view.isHidden = true
         container?.mediaControlEnabled = true
     }
 
     fileprivate func playbackEnded() {
         container?.mediaControlEnabled = false
         playButton.isHidden = false
-        isHidden = false
+        view.isHidden = false
     }
 
     fileprivate func updatePoster(_ info: EventUserInfo) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
@@ -45,10 +45,6 @@ open class FullscreenButton: MediaControlPlugin {
         super.init()
     }
     
-    required public init?(coder argument: NSCoder) {
-        super.init(coder: argument)
-    }
-    
     private func bindEvents() {
         stopListening()
         bindCoreEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
@@ -36,7 +36,7 @@ open class FullscreenButton: MediaControlPlugin {
         return .right
     }
     
-    required public init(context: UIBaseObject) {
+    required public init(context: UIObject) {
         super.init(context: context)
         bindEvents()
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -1,21 +1,6 @@
 import Foundation
 
 open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
-
-    override open var view: UIView {
-        didSet {
-            view.addSubview(container)
-
-            view.bindFrameToSuperviewBounds()
-            container.bindFrameToSuperviewBounds()
-
-            let gesture = UITapGestureRecognizer(target: self, action: #selector(tapped))
-            gesture.delegate = self
-            self.view.addGestureRecognizer(gesture)
-            self.gesture = gesture
-        }
-    }
-
     public var gesture: UITapGestureRecognizer?
 
     var container: MediaControlView = .fromNib()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -46,7 +46,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     private var currentlyShowing = false
     private var currentlyHiding = false
 
-    required public init(context: UIBaseObject) {
+    required public init(context: UIObject) {
         super.init(context: context)
         alwaysVisible = (core?.options[kMediaControlAlwaysVisible] as? Bool) ?? false
         bindEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -56,10 +56,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         super.init()
     }
 
-    required public init?(coder argument: NSCoder) {
-        super.init(coder: argument)
-    }
-
     private func bindEvents() {
         stopListening()
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -4,7 +4,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     override open var view: UIView {
         didSet {
-            addSubview(view)
             view.addSubview(container)
 
             view.bindFrameToSuperviewBounds()
@@ -147,17 +146,17 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         
         core?.trigger(Event.willShowMediaControl.rawValue)
 
-        if self.alpha == 0 {
-            self.isHidden = false
+        if self.view.alpha == 0 {
+            self.view.isHidden = false
         }
 
         UIView.animate(
             withDuration: duration,
             animations: {
-                self.alpha = 1
+                self.view.alpha = 1
         },
             completion: { [weak self] _ in
-                self?.isHidden = false
+                self?.view.isHidden = false
                 self?.currentlyShowing = false
                 self?.core?.trigger(Event.didShowMediaControl.rawValue)
                 completion?()
@@ -182,11 +181,11 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
             UIView.animate(
                 withDuration: duration,
                 animations: {
-                    self.alpha = 0
+                    self.view.alpha = 0
             },
                 completion: { [weak self] _ in
                     self?.currentlyHiding = false
-                    self?.isHidden = true
+                    self?.view.isHidden = true
                     self?.core?.trigger(Event.didHideMediaControl.rawValue)
                     completion?()
             }
@@ -214,13 +213,20 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     override open func render() {
-        self.isHidden = true
-        view = UIView()
+        view.addSubview(container)
+        container.bindFrameToSuperviewBounds()
+
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(tapped))
+        gesture.delegate = self
+        self.view.addGestureRecognizer(gesture)
+        self.gesture = gesture
+        
+        view.isHidden = true
         view.backgroundColor = UIColor.clapprBlack60Color()
 
         showIfAlwaysVisible()
 
-        self.bindFrameToSuperviewBounds()
+        self.view.bindFrameToSuperviewBounds()
     }
 
     func renderPlugins(_ plugins: [UICorePlugin]) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -32,7 +32,7 @@ open class PlayButton: MediaControlPlugin {
         }
     }
 
-    required public init(context: UIBaseObject) {
+    required public init(context: UIObject) {
         super.init(context: context)
         bindEvents()
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -41,10 +41,6 @@ open class PlayButton: MediaControlPlugin {
         super.init()
     }
 
-    required public init?(coder argument: NSCoder) {
-        super.init(coder: argument)
-    }
-
     private func bindEvents() {
         stopListening()
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -74,10 +74,6 @@ open class TimeIndicator: MediaControlPlugin {
         super.init()
     }
 
-    required public init?(coder argument: NSCoder) {
-        super.init(coder: argument)
-    }
-
     private func bindEvents() {
         bindContainerEvents()
         bindPlaybackEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -64,7 +64,7 @@ open class TimeIndicator: MediaControlPlugin {
         return core?.activePlayback
     }
 
-    required public init(context: UIBaseObject) {
+    required public init(context: UIObject) {
         super.init(context: context)
         stopListening()
         bindEvents()

--- a/Sources/Clappr_tvOS/Classes/Base/UIBaseObject.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/UIBaseObject.swift
@@ -1,8 +1,9 @@
 import Foundation
 
 @objcMembers
-open class UIBaseObject: UIView, EventProtocol {
+open class UIBaseObject: NSObject, EventProtocol {
     fileprivate let dispatcher = EventDispatcher()
+    @objc open var view: UIView = UIView()
 
     @discardableResult
     open func on(_ eventName: String, callback: @escaping EventCallback) -> String {

--- a/Sources/Clappr_tvOS/Classes/Base/UIObject.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/UIObject.swift
@@ -1,53 +1,54 @@
 import Foundation
 
-open class UIBaseObject: NSObject, EventProtocol {
-    fileprivate let baseObject = BaseObject()
+@objcMembers
+open class UIObject: NSObject, EventProtocol {
+    fileprivate let dispatcher = EventDispatcher()
     @objc open var view: UIView = UIView()
 
-    @objc @discardableResult
+    @discardableResult
     open func on(_ eventName: String, callback: @escaping EventCallback) -> String {
-        return baseObject.on(eventName, callback: callback)
+        return dispatcher.on(eventName, callback: callback)
     }
 
-    @objc @discardableResult
+    @discardableResult
     open func once(_ eventName: String, callback: @escaping EventCallback) -> String {
-        return baseObject.once(eventName, callback: callback)
+        return dispatcher.once(eventName, callback: callback)
     }
 
-    @objc open func off(_ listenId: String) {
-        baseObject.off(listenId)
+    open func off(_ listenId: String) {
+        dispatcher.off(listenId)
     }
 
-    @objc open func trigger(_ eventName: String) {
-        baseObject.trigger(eventName)
+    open func trigger(_ eventName: String) {
+        dispatcher.trigger(eventName)
         Logger.logDebug("[\(eventName)] triggered", scope: logIdentifier())
     }
 
-    @objc open func trigger(_ eventName: String, userInfo: EventUserInfo) {
-        baseObject.trigger(eventName, userInfo: userInfo)
+    open func trigger(_ eventName: String, userInfo: EventUserInfo) {
+        dispatcher.trigger(eventName, userInfo: userInfo)
         Logger.logDebug("[\(eventName)] triggered with \(String(describing: userInfo))", scope: logIdentifier())
     }
 
     @discardableResult
     open func listenTo<T: EventProtocol>(_ contextObject: T, eventName: String, callback: @escaping EventCallback) -> String {
-        return baseObject.listenTo(contextObject, eventName: eventName, callback: callback)
+        return dispatcher.listenTo(contextObject, eventName: eventName, callback: callback)
     }
 
     @discardableResult
     open func listenToOnce<T: EventProtocol>(_ contextObject: T, eventName: String, callback: @escaping EventCallback) -> String {
-        return baseObject.listenToOnce(contextObject, eventName: eventName, callback: callback)
+        return dispatcher.listenToOnce(contextObject, eventName: eventName, callback: callback)
     }
 
-    @objc open func stopListening() {
-        baseObject.stopListening()
+    open func stopListening() {
+        dispatcher.stopListening()
     }
 
-    @objc open func stopListening(_ listenId: String) {
-        baseObject.stopListening(listenId)
+    open func stopListening(_ listenId: String) {
+        dispatcher.stopListening(listenId)
     }
 
-    @objc open func getEventContextObject() -> BaseObject {
-        return baseObject
+    open func getEventDispatcher() -> EventDispatcher {
+        return dispatcher
     }
 
     fileprivate func logIdentifier() -> String {
@@ -57,14 +58,14 @@ open class UIBaseObject: NSObject, EventProtocol {
         return "\(type(of: self))"
     }
 
-    @objc open func render() {}
+    open func render() {}
 
     deinit {
         Logger.logDebug("deinit", scope: NSStringFromClass(type(of: self)))
     }
 }
 
-public extension UIBaseObject {
+public extension UIObject {
     public func trigger(_ event: Event) {
         trigger(event.rawValue)
     }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -468,6 +468,7 @@ class AVFoundationPlaybackTests: QuickSpec {
             }
 
             if #available(iOS 11.0, *) {
+                #if os(iOS)
                 context("when did change bounds") {
                     it("sets preferredMaximumResolution according to playback bounds size") {
                         let playback = AVFoundationPlayback(options: [kSourceUrl: "http://clappr.io/slack.mp4"])
@@ -481,6 +482,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                         expect(playback.player?.currentItem?.preferredMaximumResolution).to(equal(screenSize))
                     }
                 }
+                #endif
 
                 context("when setups avplayer") {
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -470,11 +470,11 @@ class AVFoundationPlaybackTests: QuickSpec {
             if #available(iOS 11.0, *) {
                 context("when did change bounds") {
                     it("sets preferredMaximumResolution according to playback bounds size") {
-                        let playback = AVFoundationPlayback()
-                        playback.player = AVPlayerStub()
+                        let playback = AVFoundationPlayback(options: [kSourceUrl: "http://clappr.io/slack.mp4"])
 
-                        playback.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
-                        let playerSize = playback.bounds.size
+                        playback.play()
+                        playback.view.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+                        let playerSize = playback.view.bounds.size
                         let mainScale = UIScreen.main.scale
                         let screenSize = CGSize(width: playerSize.width * mainScale, height: playerSize.height * mainScale)
 
@@ -494,8 +494,8 @@ class AVFoundationPlaybackTests: QuickSpec {
                     #if os(iOS)
                     it("sets preferredMaximumResolution according to playback bounds size") {
                         let playback = AVFoundationPlayback(options: [kSourceUrl: "http://clappr.io/slack.mp4"])
-                        playback.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
-                        let playerSize = playback.bounds.size
+                        playback.view.bounds = CGRect(x: 0, y: 0, width: 200, height: 200)
+                        let playerSize = playback.view.bounds.size
                         let mainScale = UIScreen.main.scale
                         let screenSize = CGSize(width: playerSize.width * mainScale, height: playerSize.height * mainScale)
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -58,7 +58,7 @@ class MediaControlTests: QuickSpec {
                     mediaControl.tapped()
 
                     expect(mediaControl.hideControlsTimer?.isValid).to(beNil())
-                    expect(mediaControl.isHidden).to(beTrue())
+                    expect(mediaControl.view.isHidden).to(beTrue())
                 }
 
                 context("when a option to keep media control always visible is given") {
@@ -71,7 +71,7 @@ class MediaControlTests: QuickSpec {
                         mediaControl.tapped()
 
                         expect(mediaControl.hideControlsTimer?.isValid).to(beNil())
-                        expect(mediaControl.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
                     }
                 }
             }
@@ -88,7 +88,7 @@ class MediaControlTests: QuickSpec {
 
                     mediaControl.render()
 
-                    expect(mediaControl.isHidden).to(beTrue())
+                    expect(mediaControl.view.isHidden).to(beTrue())
                 }
 
                 it("has black background with 60% of opacity") {
@@ -104,7 +104,7 @@ class MediaControlTests: QuickSpec {
                     let superview = UIView(frame: frame)
                     let mediaControl = MediaControl(context: coreStub)
 
-                    superview.addSubview(mediaControl)
+                    superview.addSubview(mediaControl.view)
                     mediaControl.render()
 
                     expect(superview.constraints.count).to(equal(4))
@@ -152,8 +152,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activePlayback?.trigger(Event.ready)
 
-                        expect(mediaControl.isHidden).toEventually(beFalse())
-                        expect(mediaControl.alpha).toEventually(equal(1))
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
                     }
                 }
 
@@ -163,8 +163,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activePlayback?.trigger(Event.playing)
 
-                        expect(mediaControl.isHidden).toEventually(beFalse())
-                        expect(mediaControl.alpha).toEventually(equal(1))
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
                     }
 
                     it("starts the timer to hide itself") {
@@ -182,8 +182,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activePlayback?.trigger(Event.didComplete)
 
-                        expect(mediaControl.isHidden).to(beTrue())
-                        expect(mediaControl.alpha).toEventually(equal(0))
+                        expect(mediaControl.view.isHidden).to(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
                     }
                 }
 
@@ -193,8 +193,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.trigger(InternalEvent.didTappedCore.rawValue)
 
-                        expect(mediaControl.isHidden).toEventually(beFalse())
-                        expect(mediaControl.alpha).toEventually(equal(1))
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
                     }
 
                     it("doesn't show itself if an error occurred") {
@@ -204,8 +204,8 @@ class MediaControlTests: QuickSpec {
                         coreStub.activePlayback?.trigger(Event.error.rawValue)
                         coreStub.trigger(InternalEvent.didTappedCore.rawValue)
 
-                        expect(mediaControl.isHidden).toEventually(beTrue())
-                        expect(mediaControl.alpha).toEventually(equal(0))
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
                     }
                 }
 
@@ -215,8 +215,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activePlayback?.trigger(Event.didPause)
 
-                        expect(mediaControl.isHidden).toEventually(beFalse())
-                        expect(mediaControl.alpha).toEventually(equal(1))
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
                         expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
                     }
                 }
@@ -228,8 +228,8 @@ class MediaControlTests: QuickSpec {
                         coreStub.trigger(InternalEvent.didEnterFullscreen.rawValue)
 
                         expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
-                        expect(mediaControl.isHidden).toEventually(beTrue())
-                        expect(mediaControl.alpha).toEventually(equal(0))
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
                     }
 
                     it("doesn't hide the media control after some time if the video is paused") {
@@ -249,8 +249,8 @@ class MediaControlTests: QuickSpec {
                         coreStub.trigger(InternalEvent.didExitFullscreen.rawValue)
 
                         expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
-                        expect(mediaControl.isHidden).toEventually(beTrue())
-                        expect(mediaControl.alpha).toEventually(equal(0))
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
                     }
 
                     it("doesn't hide the media control after some time if the video is paused") {
@@ -269,8 +269,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activeContainer?.trigger(Event.disableMediaControl.rawValue)
 
-                        expect(mediaControl.isHidden).toEventually(beTrue())
-                        expect(mediaControl.alpha).toEventually(equal(0))
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
                     }
                 }
 
@@ -280,8 +280,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activeContainer?.trigger(Event.enableMediaControl.rawValue)
 
-                        expect(mediaControl.isHidden).toEventually(beFalse())
-                        expect(mediaControl.alpha).toEventually(equal(1))
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
                     }
                 }
 
@@ -304,7 +304,7 @@ class MediaControlTests: QuickSpec {
                     mediaControl.render()
                     core.on(Event.willShowMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.isHidden
+                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.show()
                     
@@ -317,11 +317,11 @@ class MediaControlTests: QuickSpec {
                     let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
-                    mediaControl.isHidden = true
+                    mediaControl.view.isHidden = true
                     
                     core.on(Event.didShowMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.isHidden
+                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.show()
                     
@@ -339,7 +339,7 @@ class MediaControlTests: QuickSpec {
                     
                     core.on(Event.willHideMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.isHidden
+                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.hide()
                     
@@ -355,7 +355,7 @@ class MediaControlTests: QuickSpec {
                     
                     core.on(Event.didHideMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.isHidden
+                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.hide()
                     

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
@@ -169,7 +169,7 @@ class TimeIndicatorTests: QuickSpec {
 
                 context("when user enters in fullscreen") {
                     it("update layout constants for medium screen") {
-                        coreStub.activeContainer?.frame = CGRect(x: 0, y: 0, width: 500, height: 0)
+                        coreStub.activeContainer?.view.frame = CGRect(x: 0, y: 0, width: 500, height: 0)
 
                         coreStub.trigger(InternalEvent.didEnterFullscreen.rawValue)
 
@@ -180,7 +180,7 @@ class TimeIndicatorTests: QuickSpec {
 
                 context("when user leaves fullscreen") {
                     it("update layout constants for small screen") {
-                        coreStub.activeContainer?.frame = CGRect(x: 0, y: 0, width: 200, height: 0)
+                        coreStub.activeContainer?.view.frame = CGRect(x: 0, y: 0, width: 200, height: 0)
 
                         coreStub.trigger(InternalEvent.didExitFullscreen.rawValue)
 

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -61,23 +61,23 @@ class ContainerTests: QuickSpec {
                     }
 
                     it("set playback as subview") {
-                        expect(container.playback?.superview) == container
+                        expect(container.playback?.view.superview) == container.view
                     }
 
                     it("set playback to front of container") {
-                        expect(container.subviews.first) == container.playback
+                        expect(container.view.subviews.first) == container.playback?.view
                     }
 
                     it("set background color to `clear`") {
-                        expect(container.backgroundColor) == .clear
+                        expect(container.view.backgroundColor) == .clear
                     }
 
                     it("set the frame of container as CGRect.zero") {
-                        expect(container.frame) == CGRect.zero
+                        expect(container.view.frame) == CGRect.zero
                     }
 
                     it("set acessibility indentifier to 'Container'") {
-                        expect(container.accessibilityIdentifier) == "Container"
+                        expect(container.view.accessibilityIdentifier) == "Container"
                     }
 
                     it("save options without mutating") {
@@ -106,11 +106,11 @@ class ContainerTests: QuickSpec {
                     }
 
                     it("set playback as subview") {
-                        expect(container.playback?.superview).to(beNil())
+                        expect(container.playback?.view.superview).to(beNil())
                     }
 
                     it("set playback to front of container") {
-                        expect(container.subviews.first).to(beNil())
+                        expect(container.view.subviews.first).to(beNil())
                     }
                 }
             }
@@ -124,16 +124,16 @@ class ContainerTests: QuickSpec {
 
                 it("remove container from superview") {
                     let wrapperView = UIView()
-                    wrapperView.addSubview(container)
+                    wrapperView.addSubview(container.view)
 
                     container.destroy()
 
-                    expect(container.superview).to(beNil())
+                    expect(container.view.superview).to(beNil())
                 }
 
                 it("destroy playback") {
                     container.destroy()
-                    expect(container.playback?.superview).to(beNil())
+                    expect(container.playback?.view.superview).to(beNil())
                 }
 
                 it("stop listening events") {
@@ -203,14 +203,14 @@ class ContainerTests: QuickSpec {
                         container.load(source)
 
                         expect(container.playback?.pluginName) == "AVPlayback"
-                        expect(container.playback?.superview) == container
+                        expect(container.playback?.view.superview) == container.view
                     }
 
                     it("load a source with mime type") {
                         container.load(source, mimeType: "video/mp4")
 
                         expect(container.playback?.pluginName) == "AVPlayback"
-                        expect(container.playback?.superview) == container
+                        expect(container.playback?.view.superview) == container.view
                     }
                 }
 
@@ -226,24 +226,24 @@ class ContainerTests: QuickSpec {
                         container.load(source)
 
                         expect(container.playback?.pluginName) == NoOpPlayback.name
-                        expect(container.playback?.superview) == container
+                        expect(container.playback?.view.superview) == container.view
                     }
 
                     it("set playback as a 'noop' playback with mimetype") {
                         container.load(source, mimeType: "video/mp4")
 
                         expect(container.playback?.pluginName) == "AVPlayback"
-                        expect(container.playback?.superview) == container
+                        expect(container.playback?.view.superview) == container.view
                     }
                 }
 
                 it("keep just one playback as subview at time") {
                     let container = Container()
                     container.load("anyVideo")
-                    expect(container.subviews.filter({ $0 is Playback }).count).to(equal(1))
+                    expect(container.view.subviews.count).to(equal(1))
 
                     container.load("anyOtherVideo")
-                    expect(container.subviews.filter({ $0 is Playback }).count).to(equal(1))
+                    expect(container.view.subviews.count).to(equal(1))
                 }
             }
 

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -238,6 +238,7 @@ class ContainerTests: QuickSpec {
                 }
 
                 it("keep just one playback as subview at time") {
+                    Loader.shared.resetPlugins()
                     let container = Container()
                     container.load("anyVideo")
                     expect(container.view.subviews.count).to(equal(1))

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -35,11 +35,11 @@ class CoreTests: QuickSpec {
                 }
                 
                 it("set backgroundColor to black") {
-                    expect(core.backgroundColor) == .black
+                    expect(core.view.backgroundColor) == .black
                 }
 
                 it("set frame Rect to zero") {
-                    expect(core.frame) == CGRect.zero
+                    expect(core.view.frame) == CGRect.zero
                 }
 
                 it("save options passed on parameter") {
@@ -60,7 +60,7 @@ class CoreTests: QuickSpec {
                 #if os(iOS)
 
                 it("add gesture recognizer") {
-                    expect(core.gestureRecognizers?.count) > 0
+                    expect(core.view.gestureRecognizers?.count) > 0
                 }
 
                 #endif
@@ -81,7 +81,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(core.parentView?.subviews.contains(core)).to(beTrue())
+                        expect(core.parentView?.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beFalse())
                     }
 
@@ -92,7 +92,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(core.parentView?.subviews.contains(core)).to(beTrue())
+                        expect(core.parentView?.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beFalse())
                     }
 
@@ -109,7 +109,7 @@ class CoreTests: QuickSpec {
                         player.setFullscreen(true)
 
                         expect(callbackWasCalled).toEventually(beTrue())
-                        expect(player.core!.parentView?.subviews.contains(core)).to(beFalse())
+                        expect(player.core!.parentView?.subviews.contains(core.view)).to(beFalse())
                         expect(player.core!.isFullscreen).to(beTrue())
                     }
                 }
@@ -128,8 +128,8 @@ class CoreTests: QuickSpec {
                         core.render()
 
                         expect(callbackWasCall).toEventually(beTrue())
-                        expect(core.parentView?.subviews.contains(core)).to(beFalse())
-                        expect(core.fullscreenController?.view.subviews.contains(core)).to(beTrue())
+                        expect(core.parentView?.subviews.contains(core.view)).to(beFalse())
+                        expect(core.fullscreenController?.view.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beTrue())
                     }
 
@@ -140,7 +140,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(core.parentView?.subviews.contains(core)).to(beTrue())
+                        expect(core.parentView?.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beFalse())
                     }
 
@@ -151,7 +151,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(core.parentView?.subviews.contains(core)).to(beTrue())
+                        expect(core.parentView?.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beFalse())
                     }
                 }
@@ -173,13 +173,13 @@ class CoreTests: QuickSpec {
                         it("removes core from parentView") {
                             core.setFullscreen(true)
 
-                            expect(core.parentView?.subviews.contains(core)).to(beFalse())
+                            expect(core.parentView?.subviews.contains(core.view)).to(beFalse())
                         }
 
                         it("sets core as subview of fullscreenController") {
                             core.setFullscreen(true)
 
-                            expect(core.fullscreenController?.view.subviews.contains(core)).to(beTrue())
+                            expect(core.fullscreenController?.view.subviews.contains(core.view)).to(beTrue())
                         }
 
                         it("set isFullscreen to true") {
@@ -227,7 +227,7 @@ class CoreTests: QuickSpec {
                             core.setFullscreen(true)
                             core.setFullscreen(true)
 
-                            expect(core.fullscreenController?.view.subviews.filter { $0 == core }.count).to(equal(1))
+                            expect(core.fullscreenController?.view.subviews.filter { $0 == core.view }.count).to(equal(1))
                         }
                     }
 
@@ -268,7 +268,7 @@ class CoreTests: QuickSpec {
                         it("sets core as subview of core.parentView") {
                             core.setFullscreen(false)
 
-                            expect(core.parentView?.subviews).to(contain(core))
+                            expect(core.parentView?.subviews).to(contain(core.view))
                         }
 
                         it("removes core as subview of fullscreenController") {
@@ -281,7 +281,7 @@ class CoreTests: QuickSpec {
                             core.setFullscreen(false)
                             core.setFullscreen(false)
 
-                            expect(core.parentView?.subviews.filter { $0 == core }.count).to(equal(1))
+                            expect(core.parentView?.subviews.filter { $0 == core.view }.count).to(equal(1))
                         }
                     }
                 }
@@ -409,7 +409,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(core.parentView?.subviews.contains(core)).to(beTrue())
+                        expect(core.parentView?.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beFalse())
                     }
                 }
@@ -423,7 +423,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(core.parentView?.subviews.contains(core)).to(beTrue())
+                        expect(core.parentView?.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beFalse())
                     }
 
@@ -439,7 +439,7 @@ class CoreTests: QuickSpec {
                         player.setFullscreen(true)
 
                         expect(callbackWasCalled).toEventually(beTrue())
-                        expect(player.core!.parentView?.subviews.contains(core)).to(beFalse())
+                        expect(player.core!.parentView?.subviews.contains(core.view)).to(beFalse())
                         expect(player.core!.isFullscreen).to(beTrue())
                     }
                 }
@@ -458,7 +458,7 @@ class CoreTests: QuickSpec {
                         player.setFullscreen(true)
 
                         expect(callbackWasCalled).toEventually(beTrue())
-                        expect(player.core!.parentView?.subviews.contains(core)).to(beFalse())
+                        expect(player.core!.parentView?.subviews.contains(core.view)).to(beFalse())
                         expect(player.core!.isFullscreen).to(beTrue())
                     }
                 }
@@ -635,7 +635,7 @@ class CoreTests: QuickSpec {
                     core.addPlugin(plugin)
                     core.render()
 
-                    expect(plugin.superview).to(equal(core))
+                    expect(plugin.view.superview).to(equal(core.view))
                 }
                 
                 #if os(iOS)
@@ -646,7 +646,7 @@ class CoreTests: QuickSpec {
                     core.addPlugin(plugin)
                     core.render()
                     
-                    expect(plugin.superview).to(beNil())
+                    expect(plugin.view.superview).to(beNil())
                 }
                 
                 it("calls the mediacontrol to add the plugins into the panels") {
@@ -670,8 +670,9 @@ class CoreTests: QuickSpec {
 
                     core.render()
 
-                    expect(core.subviews.first).to(beAKindOf(Container.self))
-                    expect(core.subviews[1]).to(beAKindOf(FakeCorePlugin.self))
+                    expect(core.view.subviews.count).to(equal(2))
+                    expect(core.view.subviews.first?.accessibilityIdentifier).to(equal("Container"))
+                    expect(core.view.subviews[1].accessibilityIdentifier).to(beNil())
                 }
             }
         }

--- a/Tests/Clappr_Tests/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/PlaybackTests.swift
@@ -14,15 +14,15 @@ class PlaybackTests: QuickSpec {
             }
 
             it("set frame of Playback to CGRect.zero") {
-                expect(playback.frame) == CGRect.zero
+                expect(playback.view.frame) == CGRect.zero
             }
 
             it("set backgroundColor to clear") {
-                expect(playback.backgroundColor).to(beNil())
+                expect(playback.view.backgroundColor).to(beNil())
             }
 
             it("set isUserInteractionEnabled to false") {
-                expect(playback.isUserInteractionEnabled) == false
+                expect(playback.view.isUserInteractionEnabled) == false
             }
 
             it("have a play method") {
@@ -63,11 +63,11 @@ class PlaybackTests: QuickSpec {
 
             it("removed from superview when destroy is called") {
                 let container = UIView()
-                container.addSubview(playback)
+                container.addSubview(playback.view)
 
-                expect(playback.superview).toNot(beNil())
+                expect(playback.view.superview).toNot(beNil())
                 playback.destroy()
-                expect(playback.superview).to(beNil())
+                expect(playback.view.superview).to(beNil())
             }
 
             it("stop listening events after destroy has been called") {

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -322,10 +322,6 @@ class PlayerTests: QuickSpec {
             super.init()
         }
 
-        required init?(coder argument: NSCoder) {
-            super.init(coder: argument)
-        }
-
         private func bindEvents() {
             stopListening()
             bindPlaybackEvents()

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -313,7 +313,7 @@ class PlayerTests: QuickSpec {
     class LoggerPlugin: UICorePlugin {
         override var pluginName: String { return "Logger" }
 
-        required init(context: UIBaseObject) {
+        required init(context: UIObject) {
             super.init(context: context)
             bindEvents()
         }

--- a/Tests/Clappr_Tests/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/PosterPluginTests.swift
@@ -20,7 +20,7 @@ class PosterPluginTests: QuickSpec {
 
                     let posterPlugin = self.getPosterPlugin(container)
 
-                    expect(posterPlugin.isHidden).to(beTrue())
+                    expect(posterPlugin.view.isHidden).to(beTrue())
                 }
             }
 
@@ -31,7 +31,7 @@ class PosterPluginTests: QuickSpec {
 
                     let posterPlugin = self.getPosterPlugin(container)
 
-                    expect(posterPlugin.isHidden).to(beTrue())
+                    expect(posterPlugin.view.isHidden).to(beTrue())
                 }
             }
 
@@ -42,7 +42,7 @@ class PosterPluginTests: QuickSpec {
 
                     let posterPlugin = self.getPosterPlugin(container)
 
-                    expect(posterPlugin.superview) == container
+                    expect(posterPlugin.view.superview) == container.view
                 }
             }
 
@@ -62,7 +62,7 @@ class PosterPluginTests: QuickSpec {
                     }
 
                     it("hides itself") {
-                        expect(posterPlugin.isHidden).toEventually(beTrue())
+                        expect(posterPlugin.view.isHidden).toEventually(beTrue())
                     }
 
                     it("isNoOpPlayback is true") {
@@ -77,7 +77,7 @@ class PosterPluginTests: QuickSpec {
                         }
 
                         it("hides itself") {
-                            expect(posterPlugin.isHidden).toEventually(beTrue())
+                            expect(posterPlugin.view.isHidden).toEventually(beTrue())
                         }
                     }
                 }
@@ -90,7 +90,7 @@ class PosterPluginTests: QuickSpec {
                     }
 
                     it("reveal itself") {
-                        expect(posterPlugin.isHidden).toEventually(beFalse())
+                        expect(posterPlugin.view.isHidden).toEventually(beFalse())
                     }
 
                     it("isNoOpPlayback is true") {
@@ -110,9 +110,9 @@ class PosterPluginTests: QuickSpec {
 
                 context("when playback trigger a play event") {
                     it("hides itself") {
-                        expect(posterPlugin.isHidden).to(beFalse())
+                        expect(posterPlugin.view.isHidden).to(beFalse())
                         container.playback?.trigger(Event.playing.rawValue)
-                        expect(posterPlugin.isHidden).to(beTrue())
+                        expect(posterPlugin.view.isHidden).to(beTrue())
                     }
                 }
 
@@ -121,7 +121,7 @@ class PosterPluginTests: QuickSpec {
                         container.playback?.trigger(Event.playing.rawValue)
                         container.playback?.trigger(Event.didComplete.rawValue)
 
-                        expect(posterPlugin.isHidden).to(beFalse())
+                        expect(posterPlugin.view.isHidden).to(beFalse())
                     }
                 }
             }

--- a/Tests/Clappr_Tests/SpinnerPluginTests.swift
+++ b/Tests/Clappr_Tests/SpinnerPluginTests.swift
@@ -23,7 +23,7 @@ class SpinnerPluginTests: QuickSpec {
             describe("#init") {
 
                 it("sets the accessibilityIdentifier") {
-                    expect(spinnerPlugin.accessibilityIdentifier).to(equal("SpinnerPlugin"))
+                    expect(spinnerPlugin.view.accessibilityIdentifier).to(equal("SpinnerPlugin"))
                 }
 
                 it("sets the pluginName as spinner") {
@@ -35,11 +35,11 @@ class SpinnerPluginTests: QuickSpec {
                 }
 
                 it("sets isUserInteractionEnabled to false") {
-                    expect(spinnerPlugin.isUserInteractionEnabled).to(beFalse())
+                    expect(spinnerPlugin.view.isUserInteractionEnabled).to(beFalse())
                 }
 
                 it("has a UIActivityIndicatorView as subview") {
-                    expect(spinnerPlugin.subviews.contains(where: { $0 is UIActivityIndicatorView})).to(beTrue())
+                    expect(spinnerPlugin.view.subviews.contains(where: { $0 is UIActivityIndicatorView})).to(beTrue())
                 }
             }
 
@@ -47,7 +47,7 @@ class SpinnerPluginTests: QuickSpec {
                 it("removes from itself from superview") {
                     spinnerPlugin.destroy()
 
-                    expect(spinnerPlugin.superview).to(beNil())
+                    expect(spinnerPlugin.view.superview).to(beNil())
                 }
             }
 
@@ -58,7 +58,7 @@ class SpinnerPluginTests: QuickSpec {
                 }
 
                 it("hides the spinner") {
-                    expect(spinnerPlugin.isHidden).toEventually(beTrue())
+                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
                 }
 
                 it("sets the isAnimating to false") {
@@ -73,7 +73,7 @@ class SpinnerPluginTests: QuickSpec {
                 }
 
                 it("hides the spinner") {
-                    expect(spinnerPlugin.isHidden).toEventually(beTrue())
+                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
                 }
 
                 it("sets the isAnimating to false") {
@@ -88,7 +88,7 @@ class SpinnerPluginTests: QuickSpec {
                 }
 
                 it("hides the spinner") {
-                    expect(spinnerPlugin.isHidden).toEventually(beTrue())
+                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
                 }
 
                 it("sets the isAnimating to false") {
@@ -103,7 +103,7 @@ class SpinnerPluginTests: QuickSpec {
                 }
 
                 it("hides the spinner") {
-                    expect(spinnerPlugin.isHidden).toEventually(beFalse())
+                    expect(spinnerPlugin.view.isHidden).toEventually(beFalse())
                 }
 
                 it("sets the isAnimating to false") {

--- a/Tests/Clappr_Tests/UIContainerPluginTests.swift
+++ b/Tests/Clappr_Tests/UIContainerPluginTests.swift
@@ -19,7 +19,7 @@ class UIContainerPluginTests: QuickSpec {
             }
 
             it("Should not be initializaed with wrong context") {
-                let context = UIBaseObject()
+                let context = UIObject()
                 expect(StubContainerPlugin(context: context)).to(raiseException(named: "WrongContextType"))
 
                 let core = Core()

--- a/Tests/Clappr_Tests/UICorePluginTests.swift
+++ b/Tests/Clappr_Tests/UICorePluginTests.swift
@@ -19,7 +19,7 @@ class UICorePluginTests: QuickSpec {
             }
 
             it("Should not be initializaed with wrong context") {
-                let context = UIBaseObject()
+                let context = UIObject()
                 expect(StubCorePlugin(context: context)).to(raiseException(named: "WrongContextType"))
 
                 let container = Container()

--- a/Tests/Clappr_Tests/UIObjectTests.swift
+++ b/Tests/Clappr_Tests/UIObjectTests.swift
@@ -2,12 +2,12 @@ import Quick
 import Nimble
 @testable import Clappr
 
-class UIBaseObjectTests: QuickSpec {
+class UIObjectTests: QuickSpec {
 
     override func spec() {
-        describe("UIBaseObject") {
+        describe("UIObject") {
             it("Should handle EventListeners callbacks when triggered") {
-                let uiObject = UIBaseObject()
+                let uiObject = UIObject()
                 var callbackWasCalled = false
 
                 uiObject.on("some-event") { _ in


### PR DESCRIPTION
### Goal
- UI objects shouldn't extend from `UIView`, they should contain a view property;
- `UIBaseObject` was renamed to `UIObject`;

### How to test
Run Clappr example and check if the video and media control are displayed properly.

