### PR TITLE
Add tests for the state of the Playback state machine

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -29,7 +29,7 @@ open class AVFoundationPlayback: Playback {
     
     fileprivate var playerLayer: AVPlayerLayer?
     fileprivate var playerStatus: AVPlayerItemStatus = .unknown
-    fileprivate var currentState = PlaybackState.idle {
+    internal var currentState = PlaybackState.idle {
         didSet {
             switch currentState {
             case .buffering:

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -29,7 +29,7 @@ open class AVFoundationPlayback: Playback {
     
     fileprivate var playerLayer: AVPlayerLayer?
     fileprivate var playerStatus: AVPlayerItemStatus = .unknown
-    internal var currentState = PlaybackState.idle {
+    var currentState = PlaybackState.idle {
         didSet {
             switch currentState {
             case .buffering:

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -945,11 +945,13 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     context("when play is called") {
                         it("changes isPlaying to true") {
-                            let playback = AVFoundationPlayback()
-                            playback.player = AVPlayerStub()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
+
                             playback.play()
 
                             expect(playback.isPlaying).to(beTrue())
+                            expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
                         }
                     }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -933,6 +933,170 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
             }
             
+            describe("#AVFoundationPlayback states") {
+                describe("#idle") {
+                    context("when ready to play") {
+                        it("current state must be idle") {
+                            let playback = AVFoundationPlayback()
+                            
+                            expect(playback.currentState).to(equal(.idle))
+                        }
+                    }
+
+                    context("when play is called") {
+                        it("changes current state to playing") {
+                            let playback = AVFoundationPlayback()
+
+                            playback.play()
+
+                            expect(playback.isPlaying).to(beTrue())
+                            expect(playback.currentState).to(equal(.playing))
+                        }
+                    }
+
+                    context("when pause is called") {
+                        it("changes current state to paused") {
+                            let playback = AVFoundationPlayback()
+
+                            playback.pause()
+                            
+                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.currentState).to(equal(.paused))
+                        }
+                    }
+                }
+
+                describe("#playing") {
+                    context("when paused is called") {
+                        it("changes current state to paused") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.pause()
+
+                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.currentState).to(equal(.paused))
+                        }
+                    }
+
+                    context("when seek is called") {
+                        it("keeps state in playing") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.seek(10)
+                            
+                            expect(playback.isPlaying).to(beTrue())
+                            expect(playback.currentState).to(equal(.playing))
+                        }
+                    }
+
+                    context("when stop is called") {
+                        it("changes state to idle") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.stop()
+                            
+                            expect(playback.currentState).to(equal(.idle))
+                        }
+                    }
+                    
+                    context("when video is over") {
+                        it("changes state to idle") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.seek(Double.infinity)
+                            
+                            expect(playback.currentState).to(equal(.idle))
+                        }
+                    }
+                    
+                    context("when is not likely to keep up") {
+                        it("changes state to buffering") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            
+                            expect(playback.isBuffering).to(beTrue())
+                            expect(playback.currentState).to(equal(.buffering))
+                        }
+                    }
+                }
+
+                describe("#paused") {
+                    context("when playing is called") {
+                        it("changes state to play") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.pause()
+                            playback.play()
+
+                            expect(playback.isPlaying).to(beTrue())
+                            expect(playback.currentState).to(equal(.playing))
+                        }
+                    }
+
+                    context("when seek is called") {
+                        it("keeps state in paused") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.pause()
+                            playback.seek(10)
+                            
+                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.currentState).to(equal(.paused))
+                        }
+                    }
+
+                    context("when stop is called") {
+                        it("changes state to idle") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.pause()
+                            playback.stop()
+
+                            expect(playback.currentState).to(equal(.idle))
+                        }
+                    }
+
+                    context("when is not likely to keep up") {
+                        it("changes state to buffering") {
+                            let playback = AVFoundationPlayback()
+
+                            playback.play()
+                            playback.pause()
+                            playback.play()
+
+                            expect(playback.isBuffering).to(beTrue())
+                            expect(playback.currentState).to(equal(.buffering))
+                        }
+                    }
+                }
+
+                describe("#stalled") {
+                    context("when seek is called") {
+                        it("keeps buffering state") {}
+                    }
+
+                    context("when paused is called") {
+                        it("changes state to paused") {}
+                    }
+
+                    context("when stop is called") {
+                        it("changes state to idle") {}
+                    }
+
+                    context("when is likely to keep up") {
+                        it("changes state to ready") {}
+                    }
+                }
+            }
+            
             #if os(tvOS)
             describe("#loadMetadata") {
                 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -954,7 +954,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
 
                     context("when pause is called") {
-                        fit("changes current state to paused") {
+                        it("changes current state to paused") {
                             let playback = AVFoundationPlayback()
 
                             playback.pause()
@@ -1081,19 +1081,50 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                 describe("#stalled") {
                     context("when seek is called") {
-                        it("keeps buffering state") {}
-                    }
+                        it("keeps buffering state") {
+                            let playback = AVFoundationPlayback()
+                            playback.player = AVPlayerStub()
 
+                            playback.play()
+                            playback.seek(10)
+                            
+                            expect(playback.isBuffering).to(beTrue())
+                            expect(playback.currentState).to(equal(.buffering))
+                        }
+                    }
+                    
                     context("when paused is called") {
-                        it("changes state to paused") {}
+                        it("changes state to paused") {
+                            let playback = AVFoundationPlayback()
+                            
+                            playback.play()
+                            playback.pause()
+                            
+                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.currentState).to(equal(.paused))
+                        }
                     }
-
+                    
                     context("when stop is called") {
-                        it("changes state to idle") {}
-                    }
+                        it("changes state to idle") {
+                            let playback = AVFoundationPlayback()
 
+                            playback.play()
+                            playback.stop()
+                            
+                            expect(playback.currentState).to(equal(.idle))
+                        }
+                    }
+                    
                     context("when is likely to keep up") {
-                        it("changes state to ready") {}
+                        it("has isPlaying as true") {
+                            let playback = AVFoundationPlayback()
+                            playback.player = AVPlayerStub()
+
+                            playback.play()
+                            
+                            expect(playback.isPlaying).to(beTrue())
+                        }
                     }
                 }
             }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -982,13 +982,14 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     context("when seek is called") {
                         it("keeps playing") {
-                            let playback = AVFoundationPlayback()
-                            playback.player = AVPlayerStub()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             playback.seek(10)
 
                             expect(playback.isPlaying).to(beTrue())
+                            expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
                         }
                     }
 
@@ -1030,14 +1031,15 @@ class AVFoundationPlaybackTests: QuickSpec {
                 describe("#paused") {
                     context("when playing is called") {
                         it("changes isPlaying to true") {
-                            let playback = AVFoundationPlayback()
-                            playback.player = AVPlayerStub()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             playback.pause()
                             playback.play()
 
                             expect(playback.isPlaying).to(beTrue())
+                            expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
                         }
                     }
 
@@ -1120,12 +1122,13 @@ class AVFoundationPlaybackTests: QuickSpec {
                     
                     context("when is likely to keep up") {
                         it("has isPlaying as true") {
-                            let playback = AVFoundationPlayback()
-                            playback.player = AVPlayerStub()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             
                             expect(playback.isPlaying).to(beTrue())
+                            expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
                         }
                     }
                 }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -949,9 +949,11 @@ class AVFoundationPlaybackTests: QuickSpec {
                             let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
-
-                            expect(playback.isPlaying).to(beTrue())
+                            
+                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
+                            expect(playback.isPaused).toEventually(beFalse(), timeout: 3)
                             expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
+                            expect(playback.isPlaying).to(beTrue())
                         }
                     }
 
@@ -961,6 +963,8 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                             playback.pause()
                             
+                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
+                            expect(playback.isPlaying).toEventually(beFalse(), timeout: 3)
                             expect(playback.isPaused).to(beTrue())
                             expect(playback.currentState).to(equal(.paused))
                         }
@@ -975,6 +979,8 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.play()
                             playback.pause()
 
+                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
+                            expect(playback.isPlaying).toEventually(beFalse(), timeout: 3)
                             expect(playback.isPaused).to(beTrue())
                             expect(playback.currentState).to(equal(.paused))
                         }
@@ -987,9 +993,11 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                             playback.play()
                             playback.seek(10)
-
-                            expect(playback.isPlaying).to(beTrue())
+                            
+                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
+                            expect(playback.isPaused).toEventually(beFalse(), timeout: 3)
                             expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
+                            expect(playback.isPlaying).to(beTrue())
                         }
                     }
 
@@ -999,7 +1007,10 @@ class AVFoundationPlaybackTests: QuickSpec {
                             
                             playback.play()
                             playback.stop()
-                            
+
+                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
+                            expect(playback.isPlaying).toEventually(beFalse(), timeout: 3)
+                            expect(playback.isPaused).toEventually(beFalse(), timeout: 3)
                             expect(playback.currentState).to(equal(.idle))
                         }
                     }
@@ -1037,9 +1048,9 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.play()
                             playback.pause()
                             playback.play()
-
-                            expect(playback.isPlaying).to(beTrue())
+                            
                             expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
+                            expect(playback.isPlaying).to(beTrue())
                         }
                     }
 
@@ -1070,8 +1081,7 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     context("when is not likely to keep up") {
                         it("changes state to buffering") {
-                            let playback = AVFoundationPlayback()
-                            playback.player = AVPlayerStub()
+                            let playback = AVFoundationPlayback(options: [kSourceUrl: "http://localhost:8080/sample.m3u8"])
 
                             playback.play()
                             playback.pause()
@@ -1086,8 +1096,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 describe("#stalled") {
                     context("when seek is called") {
                         it("keeps buffering state") {
-                            let playback = AVFoundationPlayback()
-                            playback.player = AVPlayerStub()
+                            let playback = AVFoundationPlayback(options: [kSourceUrl: "http://localhost:8080/sample.m3u8"])
 
                             playback.play()
                             playback.seek(10)
@@ -1117,18 +1126,6 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.stop()
                             
                             expect(playback.currentState).to(equal(.idle))
-                        }
-                    }
-                    
-                    context("when is likely to keep up") {
-                        it("has isPlaying as true") {
-                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
-                            let playback = AVFoundationPlayback(options: options)
-
-                            playback.play()
-                            
-                            expect(playback.isPlaying).to(beTrue())
-                            expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
                         }
                     }
                 }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -944,7 +944,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
 
                     context("when play is called") {
-                        it("changes current state to playing") {
+                        it("changes isPlaying to true") {
                             let playback = AVFoundationPlayback()
                             playback.player = AVPlayerStub()
                             playback.play()
@@ -979,7 +979,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
 
                     context("when seek is called") {
-                        it("keeps state in playing") {
+                        it("keeps playing") {
                             let playback = AVFoundationPlayback()
                             playback.player = AVPlayerStub()
 
@@ -1027,7 +1027,7 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                 describe("#paused") {
                     context("when playing is called") {
-                        it("changes state to play") {
+                        it("changes isPlaying to true") {
                             let playback = AVFoundationPlayback()
                             playback.player = AVPlayerStub()
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -937,7 +937,8 @@ class AVFoundationPlaybackTests: QuickSpec {
                 describe("#idle") {
                     context("when ready to play") {
                         it("current state must be idle") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
                             
                             expect(playback.currentState).to(equal(.idle))
                         }
@@ -959,13 +960,14 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     context("when pause is called") {
                         it("changes current state to paused") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.pause()
                             
-                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
-                            expect(playback.isPlaying).toEventually(beFalse(), timeout: 3)
-                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.isPaused).toEventually(beTrue(), timeout: 3)
+                            expect(playback.isBuffering).to(beFalse())
+                            expect(playback.isPlaying).to(beFalse())
                             expect(playback.currentState).to(equal(.paused))
                         }
                     }
@@ -974,14 +976,15 @@ class AVFoundationPlaybackTests: QuickSpec {
                 describe("#playing") {
                     context("when paused is called") {
                         it("changes current state to paused") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
                             
                             playback.play()
                             playback.pause()
 
-                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
-                            expect(playback.isPlaying).toEventually(beFalse(), timeout: 3)
-                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.isPaused).toEventually(beTrue(), timeout: 3)
+                            expect(playback.isBuffering).to(beFalse())
+                            expect(playback.isPlaying).to(beFalse())
                             expect(playback.currentState).to(equal(.paused))
                         }
                     }
@@ -995,34 +998,36 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.seek(10)
                             
                             expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
-                            expect(playback.isPaused).toEventually(beFalse(), timeout: 3)
-                            expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
+                            expect(playback.isPaused).to(beFalse())
+                            expect(playback.currentState).to(equal(.playing))
                             expect(playback.isPlaying).to(beTrue())
                         }
                     }
 
                     context("when stop is called") {
                         it("changes state to idle") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
                             
                             playback.play()
                             playback.stop()
 
-                            expect(playback.isBuffering).toEventually(beFalse(), timeout: 3)
-                            expect(playback.isPlaying).toEventually(beFalse(), timeout: 3)
-                            expect(playback.isPaused).toEventually(beFalse(), timeout: 3)
-                            expect(playback.currentState).to(equal(.idle))
+                            expect(playback.currentState).toEventually(equal(.idle), timeout: 3)
+                            expect(playback.isBuffering).to(beFalse())
+                            expect(playback.isPlaying).to(beFalse())
+                            expect(playback.isPaused).to(beFalse())
                         }
                     }
                     
                     context("when video is over") {
                         it("changes state to idle") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
                             
                             playback.play()
-                            playback.seek(Double.infinity)
+                            playback.seek(playback.duration)
                             
-                            expect(playback.currentState).to(equal(.idle))
+                            expect(playback.currentState).toEventually(equal(.idle), timeout: 6)
                             expect(playback.isBuffering).to(beFalse())
                             expect(playback.isPlaying).to(beFalse())
                             expect(playback.isPaused).to(beFalse())
@@ -1052,10 +1057,11 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.pause()
                             playback.play()
                             
+                            
                             expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
-                            expect(playback.isBuffering).toEventually(beFalse())
-                            expect(playback.isPaused).toEventually(beFalse())
                             expect(playback.isPlaying).to(beTrue())
+                            expect(playback.isBuffering).to(beFalse())
+                            expect(playback.isPaused).to(beFalse())
                         }
                     }
 
@@ -1077,7 +1083,8 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     context("when stop is called") {
                         it("changes state to idle") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             playback.pause()
@@ -1098,11 +1105,11 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.play()
                             playback.pause()
                             playback.play()
-
                             
                             expect(playback.currentState).toEventually(equal(.buffering), timeout: 3)
                             expect(playback.isBuffering).to(beTrue())
                             expect(playback.isPaused).to(beFalse())
+                            expect(playback.isPlaying).to(beTrue())
                         }
                     }
                 }
@@ -1119,12 +1126,14 @@ class AVFoundationPlaybackTests: QuickSpec {
                             expect(playback.currentState).to(equal(.buffering))
                             expect(playback.isBuffering).to(beTrue())
                             expect(playback.isPaused).to(beFalse())
+                            expect(playback.isPlaying).to(beTrue())
                         }
                     }
                     
                     context("when paused is called") {
                         it("changes state to paused") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
                             
                             playback.play()
                             playback.pause()
@@ -1138,7 +1147,8 @@ class AVFoundationPlaybackTests: QuickSpec {
                     
                     context("when stop is called") {
                         it("changes state to idle") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             playback.stop()

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -946,16 +946,15 @@ class AVFoundationPlaybackTests: QuickSpec {
                     context("when play is called") {
                         it("changes current state to playing") {
                             let playback = AVFoundationPlayback()
-
+                            playback.player = AVPlayerStub()
                             playback.play()
 
                             expect(playback.isPlaying).to(beTrue())
-                            expect(playback.currentState).to(equal(.playing))
                         }
                     }
 
                     context("when pause is called") {
-                        it("changes current state to paused") {
+                        fit("changes current state to paused") {
                             let playback = AVFoundationPlayback()
 
                             playback.pause()
@@ -982,12 +981,12 @@ class AVFoundationPlaybackTests: QuickSpec {
                     context("when seek is called") {
                         it("keeps state in playing") {
                             let playback = AVFoundationPlayback()
-                            
+                            playback.player = AVPlayerStub()
+
                             playback.play()
                             playback.seek(10)
-                            
+
                             expect(playback.isPlaying).to(beTrue())
-                            expect(playback.currentState).to(equal(.playing))
                         }
                     }
 
@@ -1016,7 +1015,8 @@ class AVFoundationPlaybackTests: QuickSpec {
                     context("when is not likely to keep up") {
                         it("changes state to buffering") {
                             let playback = AVFoundationPlayback()
-                            
+                            playback.player = AVPlayerStub()
+
                             playback.play()
                             
                             expect(playback.isBuffering).to(beTrue())
@@ -1029,24 +1029,24 @@ class AVFoundationPlaybackTests: QuickSpec {
                     context("when playing is called") {
                         it("changes state to play") {
                             let playback = AVFoundationPlayback()
-                            
+                            playback.player = AVPlayerStub()
+
                             playback.play()
                             playback.pause()
                             playback.play()
 
                             expect(playback.isPlaying).to(beTrue())
-                            expect(playback.currentState).to(equal(.playing))
                         }
                     }
 
                     context("when seek is called") {
                         it("keeps state in paused") {
                             let playback = AVFoundationPlayback()
-                            
+
                             playback.play()
                             playback.pause()
                             playback.seek(10)
-                            
+
                             expect(playback.isPaused).to(beTrue())
                             expect(playback.currentState).to(equal(.paused))
                         }
@@ -1055,7 +1055,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     context("when stop is called") {
                         it("changes state to idle") {
                             let playback = AVFoundationPlayback()
-                            
+
                             playback.play()
                             playback.pause()
                             playback.stop()
@@ -1067,6 +1067,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     context("when is not likely to keep up") {
                         it("changes state to buffering") {
                             let playback = AVFoundationPlayback()
+                            playback.player = AVPlayerStub()
 
                             playback.play()
                             playback.pause()

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1023,13 +1023,16 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.seek(Double.infinity)
                             
                             expect(playback.currentState).to(equal(.idle))
+                            expect(playback.isBuffering).to(beFalse())
+                            expect(playback.isPlaying).to(beFalse())
+                            expect(playback.isPaused).to(beFalse())
                         }
                     }
                     
                     context("when is not likely to keep up") {
                         it("changes state to buffering") {
-                            let playback = AVFoundationPlayback()
-                            playback.player = AVPlayerStub()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             
@@ -1050,20 +1053,25 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.play()
                             
                             expect(playback.currentState).toEventually(equal(.playing), timeout: 3)
+                            expect(playback.isBuffering).toEventually(beFalse())
+                            expect(playback.isPaused).toEventually(beFalse())
                             expect(playback.isPlaying).to(beTrue())
                         }
                     }
 
                     context("when seek is called") {
                         it("keeps state in paused") {
-                            let playback = AVFoundationPlayback()
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             playback.pause()
                             playback.seek(10)
 
-                            expect(playback.isPaused).to(beTrue())
                             expect(playback.currentState).to(equal(.paused))
+                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.isBuffering).to(beFalse())
+                            expect(playback.isPlaying).to(beFalse())
                         }
                     }
 
@@ -1076,19 +1084,25 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.stop()
 
                             expect(playback.currentState).to(equal(.idle))
+                            expect(playback.isPaused).to(beFalse())
+                            expect(playback.isBuffering).to(beFalse())
+                            expect(playback.isPlaying).to(beFalse())
                         }
                     }
 
                     context("when is not likely to keep up") {
                         it("changes state to buffering") {
-                            let playback = AVFoundationPlayback(options: [kSourceUrl: "http://localhost:8080/sample.m3u8"])
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             playback.pause()
                             playback.play()
 
+                            
+                            expect(playback.currentState).toEventually(equal(.buffering), timeout: 3)
                             expect(playback.isBuffering).to(beTrue())
-                            expect(playback.currentState).to(equal(.buffering))
+                            expect(playback.isPaused).to(beFalse())
                         }
                     }
                 }
@@ -1096,13 +1110,15 @@ class AVFoundationPlaybackTests: QuickSpec {
                 describe("#stalled") {
                     context("when seek is called") {
                         it("keeps buffering state") {
-                            let playback = AVFoundationPlayback(options: [kSourceUrl: "http://localhost:8080/sample.m3u8"])
+                            let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
 
                             playback.play()
                             playback.seek(10)
                             
-                            expect(playback.isBuffering).to(beTrue())
                             expect(playback.currentState).to(equal(.buffering))
+                            expect(playback.isBuffering).to(beTrue())
+                            expect(playback.isPaused).to(beFalse())
                         }
                     }
                     
@@ -1113,8 +1129,10 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.play()
                             playback.pause()
                             
-                            expect(playback.isPaused).to(beTrue())
                             expect(playback.currentState).to(equal(.paused))
+                            expect(playback.isPaused).to(beTrue())
+                            expect(playback.isPlaying).to(beFalse())
+                            expect(playback.isBuffering).to(beFalse())
                         }
                     }
                     
@@ -1126,6 +1144,9 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.stop()
                             
                             expect(playback.currentState).to(equal(.idle))
+                            expect(playback.isPaused).to(beFalse())
+                            expect(playback.isPlaying).to(beFalse())
+                            expect(playback.isBuffering).to(beFalse())
                         }
                     }
                 }

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -288,7 +288,7 @@ class PlayerTests: QuickSpec {
                 }
             }
             
-            fdescribe("#player states") {
+            describe("#player states") {
                 describe("when player is initialised") {
                     it("starts player with idle state") {
                         let player = Player(options: [:])
@@ -299,25 +299,36 @@ class PlayerTests: QuickSpec {
                 }
                 
                 describe("when play is called") {
-                    it("change state to buffering") {
+                    it("change state to playing") {
                         let player = Player(options: [kSourceUrl: "http://clappr.io/highline.mp4"])
-                        
-                        expect(player.isPlaying).to(beFalse())
-                        expect(player.isPaused).to(beFalse())
-                        expect(player.isBuffering).to(beFalse())
-                        
-                        it("starts player with idle state") {
-                            
-                        }
+
+                        player.play()
+
+                        expect(player.isPlaying).toEventually(beTrue())
                     }
                 }
-                
+
                 describe("when pause is called") {
-                    it("change state to paused then playing") {}
+                    it("change state to paused") {
+                        let player = Player(options: [kSourceUrl: "http://clappr.io/highline.mp4"])
+
+                        player.play()
+                        player.pause()
+
+                        expect(player.isPlaying).to(beFalse())
+                        expect(player.isPaused).to(beTrue())
+                        expect(player.isBuffering).to(beFalse())
+                    }
                 }
-                
+
                 describe("when video is buffering") {
-                    it("change state to stalled") {}
+                    it("change state to stalled") {
+                        let player = Player(options: [kSourceUrl: "http://invalid.clappr.io/highline.mp4"])
+
+                        player.play()
+
+                        expect(player.isBuffering).to(beTrue())
+                    }
                 }
             }
             

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -287,6 +287,40 @@ class PlayerTests: QuickSpec {
                     expect(playerOptionValue).to(equal("bar"))
                 }
             }
+            
+            fdescribe("#player states") {
+                describe("when player is initialised") {
+                    it("starts player with idle state") {
+                        let player = Player(options: [:])
+                        expect(player.isPlaying).to(beFalse())
+                        expect(player.isPaused).to(beFalse())
+                        expect(player.isBuffering).to(beFalse())
+                    }
+                }
+                
+                describe("when play is called") {
+                    it("change state to buffering") {
+                        let player = Player(options: [kSourceUrl: "http://clappr.io/highline.mp4"])
+                        
+                        expect(player.isPlaying).to(beFalse())
+                        expect(player.isPaused).to(beFalse())
+                        expect(player.isBuffering).to(beFalse())
+                        
+                        it("starts player with idle state") {
+                            
+                        }
+                    }
+                }
+                
+                describe("when pause is called") {
+                    it("change state to paused then playing") {}
+                }
+                
+                describe("when video is buffering") {
+                    it("change state to stalled") {}
+                }
+            }
+            
         }
     }
 

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -222,7 +222,7 @@ class PlayerTests: QuickSpec {
                     it("sets external playback as active") {
                         Loader.shared.resetPlugins()
                         Player.register(plugins: [StubPlayback.self])
-                        player = Player(options: options)
+                        player = Player(options: [kSourceUrl: "video"])
                         playback = player.activePlayback
 
                         expect(player.activePlayback).to(beAKindOf(StubPlayback.self))

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -287,51 +287,6 @@ class PlayerTests: QuickSpec {
                     expect(playerOptionValue).to(equal("bar"))
                 }
             }
-            
-            describe("#player states") {
-                describe("when player is initialised") {
-                    it("starts player with idle state") {
-                        let player = Player(options: [:])
-                        expect(player.isPlaying).to(beFalse())
-                        expect(player.isPaused).to(beFalse())
-                        expect(player.isBuffering).to(beFalse())
-                    }
-                }
-                
-                describe("when play is called") {
-                    it("change state to playing") {
-                        let player = Player(options: [kSourceUrl: "http://clappr.io/highline.mp4"])
-
-                        player.play()
-
-                        expect(player.isPlaying).toEventually(beTrue())
-                    }
-                }
-
-                describe("when pause is called") {
-                    it("change state to paused") {
-                        let player = Player(options: [kSourceUrl: "http://clappr.io/highline.mp4"])
-
-                        player.play()
-                        player.pause()
-
-                        expect(player.isPlaying).to(beFalse())
-                        expect(player.isPaused).to(beTrue())
-                        expect(player.isBuffering).to(beFalse())
-                    }
-                }
-
-                describe("when video is buffering") {
-                    it("change state to stalled") {
-                        let player = Player(options: [kSourceUrl: "http://invalid.clappr.io/highline.mp4"])
-
-                        player.play()
-
-                        expect(player.isBuffering).to(beTrue())
-                    }
-                }
-            }
-            
         }
     }
 


### PR DESCRIPTION
## Goal

According to the following picture from [Clappr-docs](https://github.com/clappr/clappr-docs/wiki/Architecture), the player should follow some states when interacting with the playback:

![](https://github.com/clappr/clappr-docs/wiki/clappr_playback_states.png)

With this PR we want to cover some scenarios of the state, our tests are:

#### idle
- when player is ready to play ->  `currentState` must be `idle`
- when play is called -> changes `isPlaying` to *true*
- when pause is called -> changes `currentState` to paused, and `isPaused` to *true*

#### playing
- when pause is called -> it changes `currentState` to paused, and `isPaused` to *true*
- when seek is called -> it changes `currentState` to playing, and `isPlaying` to *true*
- when stop is called -> it changes `currentState` to idle 
- when video is over -> it changes `currentState` to idle
- when is not likely to keep up -> it changes `currentState` to buffering, and `isBuffering` to *true*

##### paused
-  when play is called -> it changes `currentState` to playing, and `isPlaying` to *true*
-  when seek is called -> it keeps `currentState` paused, and `isPaused` *true*
-  when stop is called -> it changes `currentState` to idle
- when is not likely to keep up

#### stalled
- when seek is called -> it keeps `currentState` buffering, and `isBuffering` *true*
- when paused is called ->  it changes `currentState` to paused, and `isPaused` to *true*
- when stop is called -> it changes `currentState` to idle


The next step is to cover the events triggered during the interactions with tests.