### PR TITLE
Add tests for the triggered events of the Playback state machine

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -224,6 +224,8 @@
 		E7BEEB5C21751EE600B8F7FA /* TimeIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEEB5A21751D9600B8F7FA /* TimeIndicatorTests.swift */; };
 		E7C6E891219225B900A74149 /* SeekbarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C6E88F2192239500A74149 /* SeekbarViewTests.swift */; };
 		E7D0BD17218A389B00F5FDF2 /* SeekbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D0BD16218A389B00F5FDF2 /* SeekbarTests.swift */; };
+		C990DAA52194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
+		C990DAA62194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
 		EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652211D467CCA00627C48 /* UICorePluginTests.swift */; };
 		EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652231D46829100627C48 /* UIContainerPluginTests.swift */; };
 		FB0A223C2175492E00D2180F /* Loader+Plugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */; };
@@ -473,6 +475,7 @@
 		C9F6D7B42182650A0055A599 /* SeekbarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeekbarView.swift; sourceTree = "<group>"; };
 		C9F6D7B52182650A0055A599 /* SeekbarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SeekbarView.xib; sourceTree = "<group>"; };
 		C9F6D7B8218265140055A599 /* Seekbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Seekbar.swift; sourceTree = "<group>"; };
+		C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackStateMachineEventsTests.swift; sourceTree = "<group>"; };
 		D105480873032552EC2B57ED /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		D8810057D2C05E1F7A2759D7 /* Clappr.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = Clappr.podspec; sourceTree = "<group>"; };
 		E7BEEB58217506C100B8F7FA /* TimeIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIndicator.swift; sourceTree = "<group>"; };
@@ -724,6 +727,7 @@
 				C9EDF8432162C8DF00789E2F /* Classes */,
 				FC6418DB2007DA6200E81B7C /* ClapprDateFormatterTests.swift */,
 				9684B6C81D186E2D00D012C2 /* AVFoundationPlaybackTests.swift */,
+				C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */,
 				969703A51BEA8C7500B7F282 /* BaseObjectTests.swift */,
 				96664E6B1BF209CB00095E6E /* ContainerTests.swift */,
 				96A979861BFF964C00E5EA01 /* CoreTests.swift */,
@@ -1760,6 +1764,7 @@
 				571B7B2A21750157005C0942 /* HTTPStub.swift in Sources */,
 				32E4021A1FF433FB001C2096 /* BaseObjectTests.swift in Sources */,
 				3251114821359C48001FEEBA /* CoreTests.swift in Sources */,
+				C990DAA62194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */,
 				571B7B2D21750173005C0942 /* AVPlayerStub.swift in Sources */,
 				571B7B32217503BB005C0942 /* NowPlayingServiceStub.swift in Sources */,
 				32A7A298215EA49700296DE3 /* NoOpPlaybackTests.swift in Sources */,
@@ -1782,6 +1787,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C990DAA52194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */,
 				96664E5E1BF0D5FB00095E6E /* PlaybackTests.swift in Sources */,
 				C92F1C9A216F8F000059D860 /* UIViewExtensionTests.swift in Sources */,
 				5753591C2187486900A88BE2 /* Array+appendOrReplaceTests.swift in Sources */,

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -1,4 +1,4 @@
-public enum Event: String {
+public enum Event: String, CaseIterable {
     case bufferUpdate
     case positionUpdate
     case ready

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -84,7 +84,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                 }
 
                 context("when pause, play and stop") {
-                    it("triggers events following the state machine pattern") {
+                    xit("triggers events following the state machine pattern") {
                         let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
@@ -107,7 +107,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                 }
 
                 context("when pause, play, pause and stop") {
-                    it("triggers events following the state machine pattern") {
+                    xit("triggers events following the state machine pattern") {
                         let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -1,0 +1,166 @@
+import Quick
+import Nimble
+import AVFoundation
+import Swifter
+
+@testable import Clappr
+
+class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
+    override func spec() {
+        describe("AVFoundationPlayback Tests") {
+            let server = HTTPStub()
+            let unwantedEvents: [Event] = [
+                .bufferUpdate, .positionUpdate,
+                .seekableUpdate, .audioAvailable,
+                .subtitleAvailable, .didChangeDvrAvailability,
+                .seek
+            ]
+
+            beforeSuite {
+                server.start()
+            }
+
+            afterSuite {
+                server.stop()
+            }
+
+            describe("#state machine events") {
+                context("when play, pause, seek, play and stop") {
+                    it("triggers events following the state machine pattern") {
+                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let playback = AVFoundationPlayback(options: options)
+                        let expectedEvents: [Event] = [
+                            .ready, .willPlay, .stalled, .willPlay, .playing,
+                            .willPause, .didPause, .willSeek, .didSeek,
+                            .willPlay, .playing, .willStop, .didPause, .didStop
+                        ]
+                        var triggeredEvents: [Event] = []
+                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
+                            playback.on(event.rawValue) { _ in
+                                triggeredEvents.append(event)
+                            }
+                        }
+
+                        playback.play()
+                        playback.once(Event.playing.rawValue) { _ in
+                            playback.pause()
+                            playback.seek(2)
+                        }
+                        playback.once(Event.didSeek.rawValue) { _ in
+                            playback.play()
+
+                            playback.once(Event.playing.rawValue) { _ in
+                                playback.stop()
+                            }
+                        }
+
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
+                    }
+                }
+
+                context("when play and seek to end") {
+                    it("triggers events following the state machine pattern") {
+                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let playback = AVFoundationPlayback(options: options)
+                        let expectedEvents: [Event] = [
+                            .ready, .willPlay, .stalled, .willPlay, .playing,
+                            .willSeek, .stalled, .playing, .didSeek, .stalled,
+                            .playing, .didComplete
+                        ]
+                        var triggeredEvents: [Event] = []
+                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
+                            playback.on(event.rawValue) { _ in
+                                triggeredEvents.append(event)
+                            }
+                        }
+
+                        playback.play()
+                        playback.once(Event.playing.rawValue) { _ in
+                            playback.seek(playback.duration)
+                        }
+
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 10)
+                    }
+                }
+
+                context("when pause, play and stop") {
+                    it("triggers events following the state machine pattern") {
+                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let playback = AVFoundationPlayback(options: options)
+                        let expectedEvents: [Event] = [
+                            .ready, .willPause, .didPause,
+                            .willPlay, .stalled, .willStop, .didStop
+                        ]
+                        var triggeredEvents: [Event] = []
+                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
+                            playback.on(event.rawValue) { _ in
+                                triggeredEvents.append(event)
+                            }
+                        }
+
+                        playback.pause()
+                        playback.play()
+                        playback.stop()
+
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
+                    }
+                }
+
+                context("when pause, play, pause and stop") {
+                    it("triggers events following the state machine pattern") {
+                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let playback = AVFoundationPlayback(options: options)
+                        let expectedEvents: [Event] = [
+                            .ready, .willPause, .didPause,
+                            .willPlay, .stalled, .willPause,
+                            .didPause, .willStop, .didStop
+                        ]
+                        var triggeredEvents: [Event] = []
+                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
+                            playback.on(event.rawValue) { _ in
+                                triggeredEvents.append(event)
+                            }
+                        }
+
+                        playback.pause()
+                        playback.play()
+                        playback.pause()
+                        playback.stop()
+
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
+                    }
+                }
+            }
+
+            describe("#state machine error events") {
+                beforeEach {
+                    server.stop()
+                }
+
+                afterEach {
+                    server.start()
+                }
+
+                context("when play and an error occurs") {
+                    it("triggers events following the state machine pattern") {
+                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let playback = AVFoundationPlayback(options: options)
+                        let expectedEvents: [Event] = [
+                            .ready, .willPlay, .stalled, .error, .didPause
+                        ]
+                        var triggeredEvents: [Event] = []
+                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
+                            playback.on(event.rawValue) { _ in
+                                triggeredEvents.append(event)
+                            }
+                        }
+
+                        playback.play()
+
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1164,48 +1164,6 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
             }
 
-            describe("#state machine events") {
-                context("when playback is running") {
-                    it("triggers events following the state machine pattern") {
-                        let expectedEvents: [Event] = [
-                            .ready, .willPlay, .stalled, .willPlay, .playing,
-                            .willPause, .didPause, .willSeek, .didSeek,
-                            .willPlay, .playing, .willStop,.didPause, .didStop
-                        ]
-                        var triggeredEvents = [Event]()
-                        let playback = AVFoundationPlayback(options: [kSourceUrl: "http://localhost:8080/sample.m3u8"])
-                        let unwantedEvents: [Event] = [
-                            .bufferUpdate, .positionUpdate,
-                            .seekableUpdate, .audioAvailable,
-                            .subtitleAvailable, .didChangeDvrAvailability,
-                            .seek
-                        ]
-                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
-                            playback.on(event.rawValue) { _ in
-                                print("passei aqui com o evento -> \(event.rawValue)")
-                                triggeredEvents.append(event)
-                            }
-                        }
-
-                        playback.play()
-
-                        playback.once(Event.playing.rawValue) { _ in
-                            playback.pause()
-                            playback.seek(2)
-                        }
-
-                        playback.once(Event.didSeek.rawValue) { _ in
-                            playback.play()
-                            playback.once(Event.playing.rawValue) { _ in
-                                playback.stop()
-                            }
-                        }
-
-                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
-                    }
-                }
-            }
-
             #if os(tvOS)
             describe("#loadMetadata") {
                 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1167,22 +1167,41 @@ class AVFoundationPlaybackTests: QuickSpec {
             describe("#state machine events") {
                 context("when playback is running") {
                     it("triggers events following the state machine pattern") {
-                        let expectedEvents: [Event] = [.ready, .willPlay,.stalled, .willPlay, .playing, .willPause, .didPause]
+                        let expectedEvents: [Event] = [
+                            .ready, .willPlay, .stalled, .willPlay, .playing,
+                            .willPause, .didPause, .willSeek, .didSeek,
+                            .willPlay, .playing, .willStop,.didPause, .didStop
+                        ]
                         var triggeredEvents = [Event]()
                         let playback = AVFoundationPlayback(options: [kSourceUrl: "http://localhost:8080/sample.m3u8"])
-                        let unwantedEvents: [Event] = [.bufferUpdate, .positionUpdate, .seekableUpdate, .audioAvailable, .subtitleAvailable, .didChangeDvrAvailability]
+                        let unwantedEvents: [Event] = [
+                            .bufferUpdate, .positionUpdate,
+                            .seekableUpdate, .audioAvailable,
+                            .subtitleAvailable, .didChangeDvrAvailability,
+                            .seek
+                        ]
                         for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
                             playback.on(event.rawValue) { _ in
+                                print("passei aqui com o evento -> \(event.rawValue)")
                                 triggeredEvents.append(event)
                             }
                         }
 
                         playback.play()
-                        playback.on(Event.playing.rawValue) { _ in
+
+                        playback.once(Event.playing.rawValue) { _ in
                             playback.pause()
+                            playback.seek(2)
                         }
 
-                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 15)
+                        playback.once(Event.didSeek.rawValue) { _ in
+                            playback.play()
+                            playback.once(Event.playing.rawValue) { _ in
+                                playback.stop()
+                            }
+                        }
+
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
                     }
                 }
             }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -38,6 +38,10 @@ class AVFoundationPlaybackTests: QuickSpec {
                 playback = AVFoundationPlayback()
                 playback.player = player
             }
+            
+            afterEach {
+                playback.stop()
+            }
 
             describe("AVFoundationPlaybackExtension") {
                 describe("#minDvrSize") {

--- a/Tests/Stub/HTTPStub.swift
+++ b/Tests/Stub/HTTPStub.swift
@@ -12,7 +12,11 @@ class HTTPStub {
 
     func start() {
         setupInitialStubs()
-        try! server.start()
+        do {
+            try server.start()
+        } catch {
+            print("Error while starting server: \(error)")
+        }
     }
 
     func stop() {


### PR DESCRIPTION
# Goal

According to the following picture from [Clappr-docs](https://github.com/clappr/clappr-docs/wiki/Architecture), the player should trigger some events when interacting with the playback:

![](https://github.com/clappr/clappr-docs/wiki/clappr_playback_states.png)

With this PR we want to cover some scenarios of the triggered events, our tests are:

#### Scenario 1 - Play -> Pause -> Seek -> Play -> Stop
- Expected triggered events: Ready, WillPlay, Stalled, WillPlay, Playing, WillPause, DidPause, WillSeek, DidSeek, WillPlay, Playing, WillStop, WidPause, DidStop

#### Scenario 2 - Play -> Seek to End
- Expected triggered events: Ready, WillPlay, Stalled, WillPlay, Playing, WillSeek, Stalled, Playing, DidSeek, Stalled, Playing, DidComplete

#### Scenario 3 - Pause ->  Play -> Stop (skipped on tests)
- Expected triggered events: Ready, WillPause, DidPause, WillPlay, Stalled, WillStop, DidStop

#### Scenario 4 - Pause ->  Play -> Pause -> Stop (skipped on tests)
- Expected triggered events: Ready, WillPause, DidPause, WillPlay, Stalled,  WillPause, DidPause, WillStop, DidStop

#### Scenario 5 - Play -> Error
- Expected triggered events: Ready, WillPlay, Stalled, Error, DidPause

## Tech Notes

- Skipped tests: was skipped because there is a setupPlayer method that instantiates `Player` and triggers _ready_ event. This method is calling by play action, so the triggered events don't follow the architecture. 

- There is not stop action on `AVPlayer`, so when stop method is calling in `AVFoundation` it triggers pause event.  