### PR TITLE
Remove pause event when trigger stop

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -126,6 +126,8 @@ open class AVFoundationPlayback: Playback {
         return currentState == .buffering
     }
 
+    private var isStopped = false
+
     open override var duration: Double {
         guard let item = player?.currentItem else {
             return 0
@@ -311,6 +313,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override func stop() {
+        isStopped = true
         trigger(.willStop)
         player?.pause()
         updateState(.idle)
@@ -422,7 +425,12 @@ open class AVFoundationPlayback: Playback {
         case .buffering:
             trigger(.stalled)
         case .paused:
-            trigger(.didPause)
+            if isStopped {
+                isStopped = false
+            } else {
+                trigger(.didPause)
+            }
+
             triggerDvrStatusIfNeeded()
         case .playing:
             trigger(.playing)

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -32,7 +32,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         let expectedEvents: [Event] = [
                             .ready, .willPlay, .stalled, .willPlay, .playing,
                             .willPause, .didPause, .willSeek, .didSeek,
-                            .willPlay, .playing, .willStop, .didPause, .didStop
+                            .willPlay, .playing, .willStop, .didStop
                         ]
                         var triggeredEvents: [Event] = []
                         for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {


### PR DESCRIPTION
# Goal 

There is no `stop` method on `AVPlayer`, to get around this we call `pause` and destroy the `player`. This PR allow us to continue using this approach without trigger `pause` event along the ecosystem.

# How to test

- We adjust the `AVFoundationPlaybackStateMachineEventsTests` to contemplate this change.
- We don't have an explicit stop call in our sample. Insert this code above in `ViewController.swift` on line 21 and check that we don't trigger pause event before `didStop`. 

```swift
DispatchQueue.main.asyncAfter(deadline: .now()+10) { [weak self] in
    self?.player.stop()
}
```