### PR TITLE
Do not display media control when video starts

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,4 @@
 github "Quick/Quick" == 1.3.2
 github "Quick/Nimble" == 7.3.1
 github "AliSoftware/OHHTTPStubs" == 6.1.0
-github "leandroalonso/swifter" == 1.4.3
+github "httpswift/swifter" == 1.4.5

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -103,7 +103,6 @@ open class PosterPlugin: UIContainerPlugin {
 
     fileprivate func playbackStarted() {
         view.isHidden = true
-        container?.mediaControlEnabled = true
     }
 
     fileprivate func playbackEnded() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -98,19 +98,10 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         if let playback = activePlayback {
             listenTo(playback, eventName: Event.ready.rawValue) { [weak self] _ in
                 self?.showControls = true
-                self?.show { [weak self] in
-                    self?.disappearAfterSomeTime()
-                }
             }
 
             listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in
                 self?.hide()
-            }
-
-            listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in
-                self?.show { [weak self] in
-                    self?.disappearAfterSomeTime()
-                }
             }
 
             listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -106,6 +106,11 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
             listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in
                 self?.keepVisible()
+                self?.listenToOnce(playback, eventName: Event.playing.rawValue) { [weak self] _ in
+                    self?.show { [weak self] in
+                        self?.disappearAfterSomeTime()
+                    }
+                }
             }
 
             listenTo(playback, eventName: Event.error.rawValue) { [weak self] _ in

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -152,8 +152,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activePlayback?.trigger(Event.ready)
 
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                        expect(mediaControl.view.alpha).toEventually(equal(1))
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
                     }
                 }
 
@@ -163,8 +163,8 @@ class MediaControlTests: QuickSpec {
 
                         coreStub.activePlayback?.trigger(Event.playing)
 
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                        expect(mediaControl.view.alpha).toEventually(equal(1))
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
                     }
 
                     it("starts the timer to hide itself") {

--- a/Tests/Clappr_Tests/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/PlaybackTests.swift
@@ -141,7 +141,7 @@ class PlaybackTests: QuickSpec {
 
                     playback.options = [:]
 
-                    expect(didUpdateOptionsTriggered).to(beTrue())
+                    expect(didUpdateOptionsTriggered).toEventually(beTrue())
                 }
             }
         }


### PR DESCRIPTION
### Goal
Do not display media control when video starts.

### How to test
- Run sample and check if media control is not displayed when video starts;
- Check if media control still working as before when the user touches the screen;