### PR TITLE
Fix ready event

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
 github "Quick/Nimble" "v7.3.1"
 github "Quick/Quick" "v1.3.2"
-github "leandroalonso/swifter" "1.4.3"
+github "httpswift/swifter" "1.4.5"
 github "onevcat/Kingfisher" "4.6.3"

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -85,12 +85,6 @@ open class Playback: UIObject, Plugin {
     }
 
     open override func render() {
-        once(Event.ready.rawValue) { [unowned self] _ in
-            if self.startAt != 0.0 && self.playbackType == .vod {
-                self.seek(self.startAt)
-            }
-        }
-
         #if os(tvOS)
         DispatchQueue.main.asyncAfter(deadline: .now()) { [weak self] in
             self?.play()

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -48,7 +48,8 @@ public enum Event: String {
     case didEnterFullscreen
     case willExitFullscreen
     case didExitFullscreen
-    
+    case didUpdateDuration
+
     @available(*, deprecated, message: "Update to stalling")
     case stalled
     @available(*, deprecated, message: "Update to didUpdatePosition")
@@ -67,6 +68,6 @@ public enum Event: String {
     case audioSelected
     
     public static var allCases: [Event] {
-        return [.didUpdateBuffer, .didUpdatePosition, .ready, .stalling, .didFindAudio, .didFindSubtitle, .didSelectAudio, .didSelectSubtitle, .disableMediaControl, .enableMediaControl, .didComplete, .willPlay, .playing, .willPause, .didPause, .willStop, .didStop, .error, .didUpdateAirPlayStatus, .requestFullscreen, .exitFullscreen, .requestPosterUpdate, .willUpdatePoster, .didUpdatePoster, .willSeek, .didSeek, .didChangeDvrStatus, .seekableUpdate, .didChangeDvrAvailability, .didUpdateOptions, .willShowMediaControl, .didShowMediaControl, .willHideMediaControl, .didHideMediaControl, .willDestroy, .didDestroy, .willLoadSource, .didLoadSource, .didNotLoadSource, .willChangePlayback, .didChangePlayback, .willChangeActivePlayback, .didChangeActivePlayback, .willChangeActiveContainer, .didChangeActiveContainer, .willEnterFullscreen, .didEnterFullscreen, .willExitFullscreen, .didExitFullscreen]
+        return [.didUpdateBuffer, .didUpdatePosition, .ready, .stalling, .didFindAudio, .didFindSubtitle, .didSelectAudio, .didSelectSubtitle, .disableMediaControl, .enableMediaControl, .didComplete, .willPlay, .playing, .willPause, .didPause, .willStop, .didStop, .error, .didUpdateAirPlayStatus, .requestFullscreen, .exitFullscreen, .requestPosterUpdate, .willUpdatePoster, .didUpdatePoster, .willSeek, .didSeek, .didChangeDvrStatus, .seekableUpdate, .didChangeDvrAvailability, .didUpdateOptions, .willShowMediaControl, .didShowMediaControl, .willHideMediaControl, .didHideMediaControl, .willDestroy, .didDestroy, .willLoadSource, .didLoadSource, .didNotLoadSource, .willChangePlayback, .didChangePlayback, .willChangeActivePlayback, .didChangeActivePlayback, .willChangeActiveContainer, .didChangeActiveContainer, .willEnterFullscreen, .didEnterFullscreen, .willExitFullscreen, .didExitFullscreen, .didUpdateDuration]
     }
 }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -135,19 +135,17 @@ open class AVFoundationPlayback: Playback {
             return 0
         }
 
+        var durationTime: Double = 0
+
         if playbackType == .vod {
-            return CMTimeGetSeconds(item.asset.duration)
-        }
-        
-        if playbackType == .live {
-            let liveDuration = seekableTimeRanges.reduce(0.0, { previous, current in
-                return previous + current.timeRangeValue.duration.seconds
+            durationTime = CMTimeGetSeconds(item.asset.duration)
+        } else if playbackType == .live {
+            durationTime = seekableTimeRanges.reduce(0.0, { previous, current in
+                previous + current.timeRangeValue.duration.seconds
             })
-
-            return liveDuration
         }
 
-        return 0
+        return durationTime
     }
 
     open override var position: Double {
@@ -248,13 +246,15 @@ open class AVFoundationPlayback: Playback {
 
             selectDefaultAudioIfNeeded()
 
+            trigger(.didUpdateDuration, userInfo: ["duration": duration])
+
             playerLayer = AVPlayerLayer(player: player)
             view.layer.addSublayer(playerLayer!)
             playerLayer?.frame = view.bounds
             setupMaxResolution(for: playerLayer!.frame.size)
 
-            if self.startAt != 0.0 && self.playbackType == .vod {
-                self.seek(self.startAt)
+            if startAt != 0.0 && playbackType == .vod {
+                seek(startAt)
             }
 
             addObservers()

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -253,6 +253,10 @@ open class AVFoundationPlayback: Playback {
             playerLayer?.frame = view.bounds
             setupMaxResolution(for: playerLayer!.frame.size)
 
+            if self.startAt != 0.0 && self.playbackType == .vod {
+                self.seek(self.startAt)
+            }
+
             addObservers()
         } else {
             trigger(.error)
@@ -646,10 +650,10 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override func render() {
+        super.render()
         if asset != nil {
             trigger(.ready)
         }
-        super.render()
     }
 }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -646,8 +646,10 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override func render() {
+        if asset != nil {
+            trigger(.ready)
+        }
         super.render()
-        trigger(.ready)
     }
 }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -254,7 +254,6 @@ open class AVFoundationPlayback: Playback {
             setupMaxResolution(for: playerLayer!.frame.size)
 
             addObservers()
-            trigger(.ready)
         } else {
             trigger(.error)
             Logger.logError("could not setup player", scope: pluginName)
@@ -644,6 +643,11 @@ open class AVFoundationPlayback: Playback {
         Logger.logDebug("destroying", scope: "AVFoundationPlayback")
         releaseResources()
         Logger.logDebug("destroyed", scope: "AVFoundationPlayback")
+    }
+
+    open override func render() {
+        super.render()
+        trigger(.ready)
     }
 }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -89,7 +89,7 @@ open class TimeIndicator: MediaControlPlugin {
 
     private func bindPlaybackEvents() {
         if let playback = activePlayback {
-            listenTo(playback, eventName: Event.ready.rawValue) { [weak self] _ in self?.displayVideoDuration() }
+            listenTo(playback, eventName: Event.didUpdateDuration.rawValue) { [weak self] (info: EventUserInfo) in self?.displayVideoDuration(info) }
             listenTo(playback, eventName: Event.didUpdatePosition.rawValue) { [weak self] (info: EventUserInfo) in self?.updateElapsedTime(info) }
         }
     }
@@ -102,8 +102,9 @@ open class TimeIndicator: MediaControlPlugin {
         }
     }
 
-    open func displayVideoDuration() {
-        durationTimeLabel?.text = ClapprDateFormatter.formatSeconds(activePlayback?.duration ?? 0.0)
+    open func displayVideoDuration(_ info: EventUserInfo) {
+        guard let duration = info?["duration"] as? Double else { return }
+        durationTimeLabel?.text = ClapprDateFormatter.formatSeconds(duration)
         view.isHidden = false
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -105,6 +105,7 @@ open class Player: UIViewController, BaseObject {
     public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
         super.init(nibName: nil, bundle: nil)
         Player.register(playbacks: [])
+        Player.register(plugins: externalPlugins)
         Logger.logInfo("loading with \(options)", scope: "Clappr")
 
         self.playbackEventsToListen.append(contentsOf:
@@ -221,6 +222,10 @@ open class Player: UIViewController, BaseObject {
             hasAlreadyRegisteredPlaybacks = true
         }
         Loader.shared.register(playbacks: playbacks)
+    }
+
+    open class func register(plugins: [Plugin.Type]) {
+        Loader.shared.register(plugins: plugins)
     }
 
     fileprivate func forward(_ event: Event, userInfo: EventUserInfo) {

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -137,8 +137,6 @@ open class Player: UIViewController, BaseObject {
     }
     
     fileprivate func bindCoreEvents() {
-        self.core?.stopListening()
-
         self.core?.on(Event.willChangeActivePlayback.rawValue) { [weak self] _ in self?.unbindPlaybackEvents() }
         self.core?.on(Event.didChangeActivePlayback.rawValue) { [weak self] _ in self?.bindPlaybackEvents() }
         self.core?.on(Event.didEnterFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.forward(.requestFullscreen, userInfo: info) }

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -104,8 +104,10 @@ open class Player: UIViewController, BaseObject {
 
     public init(options: Options = [:], externalPlugins: [Plugin.Type] = []) {
         super.init(nibName: nil, bundle: nil)
+
         Player.register(playbacks: [])
         Player.register(plugins: externalPlugins)
+
         Logger.logInfo("loading with \(options)", scope: "Clappr")
 
         self.playbackEventsToListen.append(contentsOf:
@@ -121,8 +123,6 @@ open class Player: UIViewController, BaseObject {
              Event.didFindSubtitle.rawValue, Event.didFindAudio.rawValue,
              Event.didSelectSubtitle.rawValue, Event.didSelectAudio.rawValue,])
 
-        Loader.shared.register(plugins: externalPlugins)
-        
         setCore(with: options)
         
         bindPlaybackEvents()
@@ -224,7 +224,7 @@ open class Player: UIViewController, BaseObject {
         Loader.shared.register(playbacks: playbacks)
     }
 
-    open class func register(plugins: [Plugin.Type]) {
+    private class func register(plugins: [Plugin.Type]) {
         Loader.shared.register(plugins: plugins)
     }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -171,7 +171,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         playback.play()
                         #endif
 
-                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 30)
                     }
                 }
             }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -39,6 +39,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                                 triggeredEvents.append(event)
                             }
                         }
+                        playback.render()
 
                         playback.play()
                         playback.once(Event.playing.rawValue) { _ in
@@ -72,6 +73,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                                 triggeredEvents.append(event)
                             }
                         }
+                        playback.render()
 
                         playback.play()
                         playback.once(Event.playing.rawValue) { _ in
@@ -83,7 +85,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                 }
 
                 context("when pause, play and stop") {
-                    xit("triggers events following the state machine pattern") {
+                    it("triggers events following the state machine pattern") {
                         let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
@@ -96,6 +98,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                                 triggeredEvents.append(event)
                             }
                         }
+                        playback.render()
 
                         playback.pause()
                         playback.play()
@@ -106,7 +109,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                 }
 
                 context("when pause, play, pause and stop") {
-                    xit("triggers events following the state machine pattern") {
+                    it("triggers events following the state machine pattern") {
                         let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
@@ -120,6 +123,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                                 triggeredEvents.append(event)
                             }
                         }
+                        playback.render()
 
                         playback.pause()
                         playback.play()
@@ -153,6 +157,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                                 triggeredEvents.append(event)
                             }
                         }
+                        playback.render()
 
                         playback.play()
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -41,7 +41,9 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         }
                         playback.render()
 
+                        #if os(iOS)
                         playback.play()
+                        #endif
                         playback.once(Event.playing.rawValue) { _ in
                             playback.pause()
                             playback.seek(2)
@@ -75,7 +77,9 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         }
                         playback.render()
 
+                        #if os(iOS)
                         playback.play()
+                        #endif
                         playback.once(Event.playing.rawValue) { _ in
                             playback.seek(playback.duration)
                         }
@@ -103,6 +107,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         playback.pause()
                         playback.play()
                         playback.stop()
+                        playback.destroy()
 
                         expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
                     }
@@ -129,6 +134,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         playback.play()
                         playback.pause()
                         playback.stop()
+                        playback.destroy()
 
                         expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
                     }
@@ -157,9 +163,12 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                                 triggeredEvents.append(event)
                             }
                         }
+
                         playback.render()
 
+                        #if os(iOS)
                         playback.play()
+                        #endif
 
                         expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
                     }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -12,7 +12,8 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
             let unwantedEvents: [Event] = [
                 .didUpdateBuffer, .didUpdatePosition,
                 .seekableUpdate, .didFindAudio,
-                .didFindSubtitle, .didChangeDvrAvailability
+                .didFindSubtitle, .didChangeDvrAvailability,
+                .didUpdateDuration
             ]
 
             beforeSuite {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -497,6 +497,10 @@ class AVFoundationPlaybackTests: QuickSpec {
                         }
                     }
 
+                    afterEach {
+                        OHHTTPStubs.removeAllStubs()
+                    }
+
                     #if os(iOS)
                     it("sets preferredMaximumResolution according to playback bounds size") {
                         let playback = AVFoundationPlayback(options: [kSourceUrl: "http://clappr.io/slack.mp4"])
@@ -510,6 +514,20 @@ class AVFoundationPlaybackTests: QuickSpec {
                         expect(playback.player?.currentItem?.preferredMaximumResolution).toEventually(equal(screenSize))
                     }
                     #endif
+
+                    it("trigger didUpdateDuration") {
+                        let playback = AVFoundationPlayback(options: [kSourceUrl: "http://clappr.io/slack.mp4"])
+                        var callDidUpdateDuration = false
+                        playback.render()
+
+                        playback.on(Event.didUpdateDuration.rawValue) { userInfo in
+                            callDidUpdateDuration = true
+                        }
+
+                        playback.play()
+
+                        expect(callDidUpdateDuration).to(beTrue())
+                    }
                 }
             }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
@@ -122,7 +122,7 @@ class TimeIndicatorTests: QuickSpec {
                 }
             }
 
-            describe("when player is ready") {
+            describe("when playback is ready") {
                 var coreStub: CoreStub!
                 var timeIndicator: TimeIndicator!
 
@@ -133,12 +133,23 @@ class TimeIndicatorTests: QuickSpec {
                     timeIndicator.render()
                 }
 
-                it("updates the duration time of the video label") {
-                    coreStub.playbackMock?.videoDuration = 138.505
+                context("duration time of video") {
+                    it("updates the video label when event is triggered") {
+                        coreStub.playbackMock?.videoDuration = 138.505
 
-                    coreStub.activePlayback?.trigger(Event.ready)
+                        coreStub.activePlayback?.trigger(.didUpdateDuration, userInfo: ["duration": 138.505])
 
-                    expect(timeIndicator.durationTimeLabel.text).to(equal("02:18"))
+                        expect(timeIndicator.durationTimeLabel.text).to(equal("02:18"))
+                    }
+
+                    it("doesnt update the video label when there is no userInfo on event") {
+                        coreStub.playbackMock?.videoDuration = 138.505
+
+                        coreStub.activePlayback?.trigger(.didUpdateDuration, userInfo: [:])
+
+                        expect(timeIndicator.durationTimeLabel.text).to(equal("00:00"))
+                        expect(timeIndicator.view.isHidden).to(beTrue())
+                    }
                 }
             }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
@@ -122,7 +122,7 @@ class TimeIndicatorTests: QuickSpec {
                 }
             }
 
-            describe("when playback is ready") {
+            describe("when playback receives didUpdateDuration event") {
                 var coreStub: CoreStub!
                 var timeIndicator: TimeIndicator!
 

--- a/Tests/Clappr_Tests/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/PlaybackTests.swift
@@ -99,16 +99,6 @@ class PlaybackTests: QuickSpec {
                     expect(playback.startAt) == 0.0
                 }
 
-                context("when video is vod") {
-                    it("seek video when rendering if startAt is set") {
-                        let playback = StubPlayback(options: [kStartAt: 15.0])
-                        playback.type = .vod
-                        playback.render()
-                        playback.play()
-                        expect(playback.seekWasCalledWithValue) == 15.0
-                    }
-                }
-
                 context("when video is live") {
                     it("doesn't seek video when rendering if startAt is set") {
                         let playback = StubPlayback(options: [kStartAt: 15.0])


### PR DESCRIPTION
### Goal
Adjust the moment when ready event is triggered to be after AVFoundationPlayback is rendered. 

### How to test
1 - Comment the line 597 at file AVFoundationPlayback.swift (with this the video will **not** play).
2 - Run Clappr example app;
3 - Check if ready event appears at log.