### PR TITLE
startAt accepting Integers

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -101,6 +101,10 @@
 		571B7B2D21750173005C0942 /* AVPlayerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EED97052088E48700D1C84A /* AVPlayerStub.swift */; };
 		571B7B2E21750204005C0942 /* AVFoundationPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9684B6C81D186E2D00D012C2 /* AVFoundationPlaybackTests.swift */; };
 		571B7B32217503BB005C0942 /* NowPlayingServiceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571B7B30217503BB005C0942 /* NowPlayingServiceStub.swift */; };
+		5733D1BC21BAA3C8002107D2 /* Dictionary+startAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D1BB21BAA3C8002107D2 /* Dictionary+startAt.swift */; };
+		5733D1BE21BAA6E4002107D2 /* Dictionary+startAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D1BD21BAA6E4002107D2 /* Dictionary+startAtTests.swift */; };
+		5733D1BF21BAA6E4002107D2 /* Dictionary+startAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D1BD21BAA6E4002107D2 /* Dictionary+startAtTests.swift */; };
+		5733D1C021BAA6EE002107D2 /* Dictionary+startAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733D1BB21BAA3C8002107D2 /* Dictionary+startAt.swift */; };
 		57351C6820248D78007DEBBE /* video.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 57351C6720248D78007DEBBE /* video.mp4 */; };
 		57351C6A20248F08007DEBBE /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 57351C6920248F08007DEBBE /* OHHTTPStubs.framework */; };
 		5753591C2187486900A88BE2 /* Array+appendOrReplaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */; };
@@ -366,6 +370,8 @@
 		32E4021C1FF43533001C2096 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
 		32E4021D1FF43534001C2096 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		571B7B30217503BB005C0942 /* NowPlayingServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingServiceStub.swift; sourceTree = "<group>"; };
+		5733D1BB21BAA3C8002107D2 /* Dictionary+startAt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+startAt.swift"; sourceTree = "<group>"; };
+		5733D1BD21BAA6E4002107D2 /* Dictionary+startAtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+startAtTests.swift"; sourceTree = "<group>"; };
 		57351C6720248D78007DEBBE /* video.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = video.mp4; sourceTree = "<group>"; };
 		57351C6920248F08007DEBBE /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+appendOrReplaceTests.swift"; sourceTree = "<group>"; };
@@ -862,6 +868,7 @@
 				C9EDF8572163A9A900789E2F /* UIColor+ClapprAdditions.swift */,
 				C9177B2D21664D1C001D0292 /* UIImage+Ext.swift */,
 				57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */,
+				5733D1BB21BAA3C8002107D2 /* Dictionary+startAt.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1079,6 +1086,7 @@
 			children = (
 				C92F1C99216F8F000059D860 /* UIViewExtensionTests.swift */,
 				57535919218747C300A88BE2 /* Array+appendOrReplaceTests.swift */,
+				5733D1BD21BAA6E4002107D2 /* Dictionary+startAtTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1727,6 +1735,7 @@
 				FC7785A62005233D00EC879F /* BaseObject.swift in Sources */,
 				32E401C81FF42351001C2096 /* UIContainerPlugin.swift in Sources */,
 				571B7B252174DBDD005C0942 /* AVFoundationPlayback.swift in Sources */,
+				5733D1C021BAA6EE002107D2 /* Dictionary+startAt.swift in Sources */,
 				32E401C11FF42321001C2096 /* PluginType.swift in Sources */,
 				32E401C91FF42359001C2096 /* UICorePlugin.swift in Sources */,
 				32E401CB1FF42379001C2096 /* Plugin.swift in Sources */,
@@ -1770,6 +1779,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5733D1BF21BAA6E4002107D2 /* Dictionary+startAtTests.swift in Sources */,
 				FC7785C2200526D900EC879F /* AVFoundationPlaybackNowPlayingServiceTests.swift in Sources */,
 				32E402191FF433FB001C2096 /* EventDispatcherTests.swift in Sources */,
 				571B7B2B2175015F005C0942 /* AVURLAssetStub.swift in Sources */,
@@ -1816,6 +1826,7 @@
 				C9EDF84D2162CEF500789E2F /* UIViewControllerMock.swift in Sources */,
 				EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */,
 				C9EDF8482162C98D00789E2F /* MediaControlPluginTests.swift in Sources */,
+				5733D1BE21BAA6E4002107D2 /* Dictionary+startAtTests.swift in Sources */,
 				96912C3E1C21A1AF003A4AFD /* PosterPluginTests.swift in Sources */,
 				FBE6A3E42163EEAE0083C9CC /* Loader+Plugins.swift in Sources */,
 				322EA4CA20F941300018973A /* AVURLAssetStub.swift in Sources */,
@@ -1886,6 +1897,7 @@
 				96D362D81D41339400CCB866 /* PluginType.swift in Sources */,
 				96D362C91D41339400CCB866 /* Loader.swift in Sources */,
 				968E5BD91D6CBFA50092F372 /* Logger.swift in Sources */,
+				5733D1BC21BAA3C8002107D2 /* Dictionary+startAt.swift in Sources */,
 				96D362EA1D41339400CCB866 /* GradientView.swift in Sources */,
 				96D362E51D41339400CCB866 /* UIPlugin.swift in Sources */,
 				ABAFEBA62152C25B007BA497 /* AvailableMediaOptions.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -28,7 +28,7 @@ open class Playback: UIObject, Plugin {
     }
 
     @objc open var startAt: TimeInterval {
-        return options[kStartAt] as? TimeInterval ?? 0.0
+        return options.startAt ?? 0.0
     }
 
     @objc open var isPlaying: Bool {

--- a/Sources/Clappr/Classes/Extension/Dictionary+startAt.swift
+++ b/Sources/Clappr/Classes/Extension/Dictionary+startAt.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Dictionary where Key == String, Value == Any {
+    var startAt: Double? {
+        switch self[kStartAt] {
+        case is Double:
+            return self[kStartAt] as? Double
+        case is Int:
+            return Double(self[kStartAt] as! Int)
+        case is String:
+            return Double(self[kStartAt] as! String)
+        default:
+            return nil
+        }
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Extensions/Dictionary+startAtTests.swift
+++ b/Tests/Clappr_Tests/Classes/Extensions/Dictionary+startAtTests.swift
@@ -1,0 +1,39 @@
+import Quick
+import Nimble
+
+@testable import Clappr
+
+class DictionaryStartAtTests: QuickSpec {
+    override func spec() {
+        describe("Dictionary+startAt") {
+            describe("#startAt") {
+                it("returns a Double value if it's a Double") {
+                    let dict: Options = [kStartAt: Double(10)]
+
+                    expect(dict.startAt).to(beAKindOf(Double.self))
+                    expect(dict.startAt).to(equal(10.0))
+                }
+
+                it("returns a Double value if it's a Int") {
+                    let dict: Options = [kStartAt: Int(10)]
+
+                    expect(dict.startAt).to(beAKindOf(Double.self))
+                    expect(dict.startAt).to(equal(10.0))
+                }
+
+                it("returns a Double value if it's a String") {
+                    let dict: Options = [kStartAt: String(10)]
+
+                    expect(dict.startAt).to(beAKindOf(Double.self))
+                    expect(dict.startAt).to(equal(10.0))
+                }
+
+                it("returns nil if it's not a String, Int or Double") {
+                    let dict: Options = [kStartAt: []]
+
+                    expect(dict.startAt).to(beNil())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Goal

To make the option `kStartAt` able to receive the type `Int`.

# How to test

In `ViewController.swift` line `19` add this code:

```swift
        DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
            self?.player.configure(options: [kSourceUrl: "http://clappr.io/highline.mp4", kStartAt: 10])
            self?.player.play()
        }
```

Play a vídeo, wait until the video is reloaded and check if it started in 10s.