### PR TITLE
Fix didUpdatePosition trigger moment

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -368,15 +368,14 @@ open class AVFoundationPlayback: Playback {
 
         player?.currentItem?.seek(to: time, toleranceBefore: tolerance, toleranceAfter: tolerance) { [weak self] success in
             if success {
+                self?.trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
+                self?.trigger(.didUpdatePosition, userInfo: ["position": CMTimeGetSeconds(time)])
                 self?.trigger(.didSeek)
                 if let triggerEvent = triggerEvent {
                     triggerEvent()
                 }
             }
         }
-
-        trigger(.positionUpdate, userInfo: ["position": CMTimeGetSeconds(time)])
-        trigger(.didUpdatePosition, userInfo: ["position": CMTimeGetSeconds(time)])
     }
 
     open override func seekToLivePosition() {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -727,6 +727,31 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     expect(updatedPosition).to(equal(5))
                 }
+                
+                it("triggers didUpdatePosition before didSeek event") {
+                    let playback = AVFoundationPlayback()
+                    let player = AVPlayerStub()
+                    playback.player = player
+                    player.setStatus(to: .readyToPlay)
+                    var updatedPosition: Float64? = nil
+                    var didSeek = false
+                    var didTriggerDidSeekBefore = false
+                    
+                    playback.on(Event.didSeek.rawValue) { _ in
+                        didSeek = true
+                    }
+                    playback.on(Event.didUpdatePosition.rawValue) { (userInfo: EventUserInfo) in
+                        updatedPosition = userInfo!["position"] as? Float64
+                        if didSeek {
+                            didTriggerDidSeekBefore = true
+                        }
+                    }
+                    
+                    playback.seek(5)
+                    
+                    expect(updatedPosition).to(equal(5))
+                    expect(didTriggerDidSeekBefore).to(beFalse())
+                }
             }
 
             describe("#seekToLivePosition") {


### PR DESCRIPTION
### Problem
When we run seek event to any position, didUpdatePosition is triggered before seek event occurs.

### Goal
To adjust the time when the event is triggered
