### PR TITLE
Refactor plugins lifecycle

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -60,14 +60,19 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
         addTapRecognizer()
         bindEventListeners()
-
-        let container = ContainerFactory.create(with: options)
-
+        
+        Loader.shared.corePlugins.forEach { plugin in
+            if let corePlugin = plugin.init(context: self) as? UICorePlugin {
+                self.addPlugin(corePlugin)
+            }
+        }
+    }
+    
+    public func add(container: Container) {
         containers.append(container)
-        setActive(container: container)
     }
 
-    fileprivate func setActive(container: Container) {
+    public func setActive(container: Container) {
         if activeContainer != container {
             activeContainer = container
         }

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -195,8 +195,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         plugins.forEach { plugin in plugin.destroy() }
         plugins.removeAll()
 
-        trigger(Event.didDestroy.rawValue)
-
         Logger.logDebug("destroyed", scope: "Core")
         #if os(iOS)
         fullscreenHandler?.destroy()
@@ -204,6 +202,8 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         fullscreenController = nil
         #endif
         view.removeFromSuperview()
+
+        trigger(Event.didDestroy.rawValue)
     }
 
     @objc func didTappedView() {

--- a/Sources/Clappr/Classes/Base/Factories/CoreFactory.swift
+++ b/Sources/Clappr/Classes/Base/Factories/CoreFactory.swift
@@ -3,13 +3,11 @@ import Foundation
 struct CoreFactory {
     static func create(with options: Options) -> Core {
         let core = Core(options: options)
-
-        Loader.shared.corePlugins.forEach { plugin in
-            if let corePlugin = plugin.init(context: core) as? UICorePlugin {
-                core.addPlugin(corePlugin)
-            }
-        }
-
+        
+        let container = ContainerFactory.create(with: options)
+        core.add(container: container)
+        core.setActive(container: container)
+        
         return core
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -197,10 +197,10 @@ open class Player: BaseObject {
 
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Player")
-        stopListening()
         Logger.logDebug("destroying core", scope: "Player")
         self.core?.destroy()
         self.core = nil
+        stopListening()
         Logger.logDebug("destroyed", scope: "Player")
     }
 }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -31,7 +31,7 @@ class CoreTests: QuickSpec {
             describe("#init") {
 
                 beforeEach {
-                    core = Core(options: options as Options)
+                    core = CoreFactory.create(with: options as Options)
                 }
                 
                 it("set backgroundColor to black") {

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -275,6 +275,24 @@ class PlayerTests: QuickSpec {
                     expect(playerOptionValue).to(equal("bar"))
                 }
             }
+            
+            fdescribe("#lifecycle") {
+                it("triggers events of destruction correctly") {
+                    var triggeredEvents = [String]()
+                    player = Player(options: options)
+                    player.listenTo(player.core!, eventName: Event.didDestroy.rawValue) { _ in
+                        triggeredEvents.append("core")
+                    }
+                    player.listenTo(player.activeContainer!, eventName: Event.didDestroy.rawValue) { _ in
+                        triggeredEvents.append("container")
+                    }
+                    player.destroy()
+
+                    expect(triggeredEvents).toEventually(equal(["container", "core"]))
+                    expect(player.core).to(beNil())
+                    expect(player.activeContainer).to(beNil())
+                }
+            }
         }
     }
 

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -224,7 +224,7 @@ class PlayerTests: QuickSpec {
                         let player = Player(options: options)
 
                         player.load(PlayerTests.specialSource)
-                        
+
                         expect(player.activePlayback).to(beAKindOf(SpecialStubPlayback.self))
                     }
                 }
@@ -275,8 +275,8 @@ class PlayerTests: QuickSpec {
                     expect(playerOptionValue).to(equal("bar"))
                 }
             }
-            
-            fdescribe("#lifecycle") {
+
+            describe("#lifecycle") {
                 it("triggers events of destruction correctly") {
                     var triggeredEvents = [String]()
                     player = Player(options: options)


### PR DESCRIPTION
Goal
===
Review the Core and Container's lifecycle (creation and destruction).
That should be coherent with the documentation, specified in [clappr-docs](https://github.com/clappr/clappr-docs/wiki/Architecture#loader).

The creation order should be:
**Core -> Core Plugins -> Container -> Container Plugins**
The destruction should happen in the opposite order.

How to Test
===
1. Run `make test`.
2. Check if there are new memory leaks after this change.
3. Test the player manually and check if it works normally.