### PR TITLE
Fix AVFoundationPlayback flaky tests

### DIFF
--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -1,14 +1,13 @@
 import Quick
 import Nimble
 import AVFoundation
-import Swifter
+import OHHTTPStubs
 
 @testable import Clappr
 
 class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
     override func spec() {
         describe("AVFoundationPlayback Tests") {
-            let server = HTTPStub()
             let unwantedEvents: [Event] = [
                 .didUpdateBuffer, .didUpdatePosition,
                 .seekableUpdate, .didFindAudio,
@@ -16,18 +15,27 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                 .didUpdateDuration
             ]
 
-            beforeSuite {
-                server.start()
-            }
-
-            afterSuite {
-                server.stop()
+            beforeEach {
+                OHHTTPStubs.removeAllStubs()
+                stub(condition: isHost("clappr.sample")) { result in
+                    if result.url?.path == "/master.m3u8" {
+                        let stubPath = OHPathForFile("master.m3u8", type(of: self))
+                        return fixture(filePath: stubPath!, headers: [:])
+                    } else if result.url!.path.contains(".ts") {
+                        let stubPath = OHPathForFile(result.url!.path.replacingOccurrences(of: "/", with: ""), type(of: self))
+                        return fixture(filePath: stubPath!, headers: [:])
+                    }
+                    
+                    print("ERRO STUB")
+                    let stubPath = OHPathForFile("master.m3u8", type(of: self))
+                    return fixture(filePath: stubPath!, headers: [:])
+                }
             }
 
             describe("#state machine events") {
                 context("when play, pause, seek, play and stop") {
                     it("triggers events following the state machine pattern") {
-                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
                             .ready, .willPlay, .stalling, .willPlay, .playing,
@@ -63,7 +71,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
 
                 context("when play and seek to end") {
                     it("triggers events following the state machine pattern") {
-                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
                             .ready, .willPlay, .stalling, .willPlay, .playing,
@@ -91,7 +99,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
 
                 context("when pause, play and stop") {
                     it("triggers events following the state machine pattern") {
-                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
                             .ready, .willPause, .didPause,
@@ -116,7 +124,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
 
                 context("when pause, play, pause and stop") {
                     it("triggers events following the state machine pattern") {
-                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
                             .ready, .willPause, .didPause,
@@ -143,17 +151,9 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
             }
 
             describe("#state machine error events") {
-                beforeEach {
-                    server.stop()
-                }
-
-                afterEach {
-                    server.start()
-                }
-
                 context("when play and an error occurs") {
                     it("triggers events following the state machine pattern") {
-                        let options = [kSourceUrl: "http://localhost:8080/sample.m3u8"]
+                        let options = [kSourceUrl: "http://clappr8.sample/master.m3u8"]
                         let playback = AVFoundationPlayback(options: options)
                         let expectedEvents: [Event] = [
                             .ready, .willPlay, .stalling, .error, .didPause

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -26,7 +26,6 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         return fixture(filePath: stubPath!, headers: [:])
                     }
                     
-                    print("ERRO STUB")
                     let stubPath = OHPathForFile("master.m3u8", type(of: self))
                     return fixture(filePath: stubPath!, headers: [:])
                 }


### PR DESCRIPTION
Goal
===
Fix the AVFoundationPlayback state machine tests that were flaky by removing the use of Swifter and start using OHTTPStubs instead.

How to Test
===
1. Run `make test`.