### PR TITLE
Ordering media control plugins

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -120,16 +120,25 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     #if os(iOS)
     private func renderCoreAndMediaControlPlugins() {
-        plugins.forEach { plugin in
-            if isNotMediaControlPlugin(plugin) {
-                view.addSubview(plugin.view)
-                plugin.render()
-            }
+        renderCorePlugins()
+        renderMediaControlPlugins()
+    }
 
+    private func renderCorePlugins() {
+        plugins.filter { isNotMediaControlPlugin($0) }.forEach { plugin in
+            view.addSubview(plugin.view)
+            plugin.render()
+        }
+    }
 
-            if plugin is MediaControl, let mediaControl = plugin as? MediaControl {
-                mediaControl.renderPlugins(plugins)
-            }
+    private func renderMediaControlPlugins() {
+        let mediaControl = plugins.first { $0 is MediaControl }
+
+        if let mediaControl = mediaControl as? MediaControl {
+            let mediaControlPlugins = plugins
+                .filter { $0 is MediaControlPlugin }
+                .map { $0 as! MediaControlPlugin }
+            mediaControl.renderPlugins(mediaControlPlugins)
         }
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -135,9 +135,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         let mediaControl = plugins.first { $0 is MediaControl }
 
         if let mediaControl = mediaControl as? MediaControl {
-            let mediaControlPlugins = plugins
-                .filter { $0 is MediaControlPlugin }
-                .map { $0 as! MediaControlPlugin }
+            let mediaControlPlugins = plugins.compactMap { $0 as? MediaControlPlugin }
             mediaControl.renderPlugins(mediaControlPlugins)
         }
     }

--- a/Sources/Clappr/Classes/Base/Options.swift
+++ b/Sources/Clappr/Classes/Base/Options.swift
@@ -16,7 +16,7 @@ public let kMediaControlAlwaysVisible = "mediaControlAlwaysVisible"
 
 // List of MediaControl Plugins
 public let kMediaControlPlugins = "mediaControlPlugins"
-// Order of MediaControlPlugins
+// Order of MediaControl Plugins
 public let kMediaControlPluginsOrder = "mediaControlPluginsOrder"
 
 public let kLoop = "loop"

--- a/Sources/Clappr/Classes/Base/Options.swift
+++ b/Sources/Clappr/Classes/Base/Options.swift
@@ -16,6 +16,8 @@ public let kMediaControlAlwaysVisible = "mediaControlAlwaysVisible"
 
 // List of MediaControl Plugins
 public let kMediaControlPlugins = "mediaControlPlugins"
+// Order of MediaControlPlugins
+public let kMediaControlPluginsOrder = "mediaControlPluginsOrder"
 
 public let kLoop = "loop"
 public let kMetaData = "metadata"

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Layout/MediaControlView.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Layout/MediaControlView.swift
@@ -43,7 +43,7 @@ class MediaControlView: UIView {
         ]
     }
 
-    func addSubview(_ view: UIView, panel: MediaControlPanel, position: MediaControlPosition) {
+    func addSubview(_ view: UIView, in panel: MediaControlPanel, at position: MediaControlPosition) {
         if position == .center {
             addSubviewAndCenter(view, in: panel)
         } else {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -219,10 +219,23 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     func renderPlugins(_ plugins: [MediaControlPlugin]) {
-        plugins
-            .forEach { plugin in
+        if let mediaControlPluginOrderOption = core?.options[kMediaControlPluginsOrder] as? String {
+            let pluginsOrder = mediaControlPluginOrderOption
+                .replacingOccurrences(of: " ", with: "")
+                .components(separatedBy: ",")
+
+            var orderedPlugins: Array<MediaControlPlugin> = plugins.filter { pluginsOrder.contains($0.pluginName)}
+            orderedPlugins.append(contentsOf: plugins.filter { !pluginsOrder.contains($0.pluginName)})
+
+            orderedPlugins.forEach { plugin in
                 mediaControlView.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
                 plugin.render()
+            }
+        } else {
+            plugins.forEach { plugin in
+                mediaControlView.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
+                plugin.render()
+            }
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -218,10 +218,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         self.view.bindFrameToSuperviewBounds()
     }
 
-    func renderPlugins(_ plugins: [UICorePlugin]) {
+    func renderPlugins(_ plugins: [MediaControlPlugin]) {
         plugins
-            .filter { $0 is MediaControlPlugin }
-            .map { $0 as! MediaControlPlugin }
             .forEach { plugin in
                 mediaControlView.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
                 plugin.render()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -219,24 +219,26 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     func renderPlugins(_ plugins: [MediaControlPlugin]) {
+        let orderedPlugins = sortPluginsIfNeeded(plugins)
+        orderedPlugins.forEach { plugin in
+            mediaControlView.addSubview(plugin.view, in: plugin.panel, at: plugin.position)
+            plugin.render()
+        }
+    }
+
+    private func sortPluginsIfNeeded(_ plugins: [MediaControlPlugin]) -> [MediaControlPlugin] {
         if let mediaControlPluginOrderOption = core?.options[kMediaControlPluginsOrder] as? String {
             let pluginsOrder = mediaControlPluginOrderOption
                 .replacingOccurrences(of: " ", with: "")
                 .components(separatedBy: ",")
 
-            var orderedPlugins: Array<MediaControlPlugin> = plugins.filter { pluginsOrder.contains($0.pluginName)}
+            var orderedPlugins: [MediaControlPlugin] = plugins.filter { pluginsOrder.contains($0.pluginName)}
             orderedPlugins.append(contentsOf: plugins.filter { !pluginsOrder.contains($0.pluginName)})
 
-            orderedPlugins.forEach { plugin in
-                mediaControlView.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
-                plugin.render()
-            }
-        } else {
-            plugins.forEach { plugin in
-                mediaControlView.addSubview(plugin.view, panel: plugin.panel, position: plugin.position)
-                plugin.render()
-            }
+            return orderedPlugins
         }
+
+        return plugins
     }
 
     private func showIfAlwaysVisible() {

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -475,7 +475,8 @@ class MediaControlTests: QuickSpec {
 
                 context("when kMediaControlPluginsOrder is passed") {
                     it("renders the plugins following the kMediaControlPluginsOrder order") {
-                        core.options[kMediaControlPluginsOrder] = "FullscreenButton"
+                        let pluginName = "FullscreenButton"
+                        core.options[kMediaControlPluginsOrder] = pluginName
                         let plugins = [TimeIndicatorPluginMock(context: core), FullscreenButton(context: core)]
                         let mediaControl = MediaControl(context: core)
                         mediaControl.render()
@@ -484,7 +485,7 @@ class MediaControlTests: QuickSpec {
 
                         let bottomRightView = mediaControl.mediaControlView.bottomRight
                         let pluginView = bottomRightView?.subviews[0]
-                        let expectedView = pluginView?.subviews.first?.accessibilityIdentifier == "FullscreenButton"
+                        let expectedView = pluginView?.subviews.first?.accessibilityIdentifier == pluginName
                         expect(expectedView).to(beTrue())
                     }
                 }
@@ -496,7 +497,7 @@ class MediaControlTests: QuickSpec {
                 var didCallAddSubviewWithPanel: MediaControlPanel?
                 var didCallAddSubviewWithPosition: MediaControlPosition?
 
-                override func addSubview(_ view: UIView, panel: MediaControlPanel, position: MediaControlPosition) {
+                override func addSubview(_ view: UIView, in panel: MediaControlPanel, at position: MediaControlPosition) {
                     didCallAddSubviewWithView = view
                     didCallAddSubviewWithPanel = panel
                     didCallAddSubviewWithPosition = position

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -472,6 +472,22 @@ class MediaControlTests: QuickSpec {
                         expect(MediaControlPluginMock.didCallRender).to(beTrue())
                     }
                 }
+
+                context("when kMediaControlPluginsOrder is passed") {
+                    it("renders the plugins following the kMediaControlPluginsOrder order") {
+                        core.options[kMediaControlPluginsOrder] = "FullscreenButton"
+                        let plugins = [TimeIndicatorPluginMock(context: core), FullscreenButton(context: core)]
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.render()
+
+                        mediaControl.renderPlugins(plugins)
+
+                        let bottomRightView = mediaControl.mediaControlView.bottomRight
+                        let pluginView = bottomRightView?.subviews[0]
+                        let expectedView = pluginView?.subviews.first?.accessibilityIdentifier == "FullscreenButton"
+                        expect(expectedView).to(beTrue())
+                    }
+                }
             }
 
             class MediaControlViewMock: MediaControlView {
@@ -514,5 +530,19 @@ class MediaControlPluginMock: MediaControlPlugin {
     
     static func reset() {
         MediaControlPluginMock.didCallRender = false
+    }
+}
+
+class TimeIndicatorPluginMock: TimeIndicator {
+    override var pluginName: String {
+        return "TimeIndicatorPluginMock"
+    }
+
+    open override var panel: MediaControlPanel {
+        return .bottom
+    }
+
+    open override var position: MediaControlPosition {
+        return .right
     }
 }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -472,21 +472,6 @@ class MediaControlTests: QuickSpec {
                         expect(MediaControlPluginMock.didCallRender).to(beTrue())
                     }
                 }
-                
-                context("when passing a plugin that is not MediaControlPlugin") {
-                    it("does not add it to the view") {
-                        let plugins = [MediaControlPluginMock(), UICorePlugin()]
-                        let mediaControl = MediaControl(context: core)
-                        mediaControl.mediaControlView = mediaControlViewMock
-                        mediaControl.render()
-
-                        
-                        mediaControl.renderPlugins(plugins)
-                        
-                        expect(mediaControlViewMock.didCallAddSubviewWithView).to(equal(plugins.first?.view))
-
-                    }
-                }
             }
 
             class MediaControlViewMock: MediaControlView {

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -484,7 +484,7 @@ class MediaControlTests: QuickSpec {
                         mediaControl.renderPlugins(plugins)
 
                         let bottomRightView = mediaControl.mediaControlView.bottomRight
-                        let pluginView = bottomRightView?.subviews[0]
+                        let pluginView = bottomRightView?.subviews.first
                         let expectedView = pluginView?.subviews.first?.accessibilityIdentifier == pluginName
                         expect(expectedView).to(beTrue())
                     }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -697,7 +697,7 @@ class CoreTests: QuickSpec {
 class MediaControlMock: MediaControl {
     var didCallRenderPlugins = false
     
-    override func renderPlugins(_ plugins: [UICorePlugin]) {
+    override func renderPlugins(_ plugins: [MediaControlPlugin]) {
         didCallRenderPlugins = true
     }
 }


### PR DESCRIPTION
# Goal
Order Media Control plugins based in the kMediaControlPluginsOrder option.

# How to test
In the Clappr example app `ViewController.swift` add the option before instantiate Player: `options[kMediaControlPluginsOrder] = "TimeIndicator,FullscreenButton"` 
Change the TimeIndicatorPlugin and FullscreenButton to same position, for example left, run the app and check if the order are correct.

**P.S.** Remind that the order of disposing the plugins in media control follow the position so if position is left the first plugin mentioned in the option came to left and if the position was right the first plugin will be displayed at the right.