### PR TITLE
Do not filter cookies by domain

### DIFF
--- a/Sources/Clappr/Classes/Helper/AVURLAssetWithCookiesBuilder.swift
+++ b/Sources/Clappr/Classes/Helper/AVURLAssetWithCookiesBuilder.swift
@@ -34,6 +34,6 @@ struct AVURLAssetWithCookiesBuilder: AVURLAssetWithCookies {
     }
 
     private func getCookies() -> [HTTPCookie]? {
-        return HTTPCookieStorage.shared.cookies?.filter { self.url.host == $0.domain }
+        return HTTPCookieStorage.shared.cookies
     }
 }

--- a/Tests/Clappr_Tests/AVURLAssetWithCookiesTests.swift
+++ b/Tests/Clappr_Tests/AVURLAssetWithCookiesTests.swift
@@ -43,19 +43,6 @@ class AVURLAssetWithCookiesTests: QuickSpec {
                 expect(avUrlAssetWithCookies.options[AVURLAssetHTTPCookiesKey]).toNot(beNil())
             }
 
-            it("doesn't sets cookies that aren't associated with the media url") {
-                let anotherCookie = HTTPCookie(properties: [HTTPCookiePropertyKey.domain: "anotherdomain.io",
-                                                 HTTPCookiePropertyKey.path: "/",
-                                                 HTTPCookiePropertyKey.name: "testing",
-                                                 HTTPCookiePropertyKey.value: "don't send me"])!
-                HTTPCookieStorage.shared.setCookie(anotherCookie)
-
-                let avUrlAssetWithCookies = AVURLAssetWithCookiesBuilder(url: URL(string: "http://clappr.io/highline.mp4")!)
-
-                expect(avUrlAssetWithCookies.cookies?.count).to(equal(1))
-                expect(avUrlAssetWithCookies.cookies).toNot(contain(anotherCookie))
-            }
-
             it("sets the cookies and maintains the existing options") {
                 let avUrlAssetWithCookies = AVURLAssetWithCookiesBuilder(
                     url: URL(string: "http://clappr.io/highline.mp4")!,


### PR DESCRIPTION
**DO NOT MERGE THIS PR**

# Goal

To not filter which cookies are sent to `AVURLAsset`.

# How to test

1. Just check if a video plays correctly