### PR TITLE
Change the way plugin order option is passed

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -227,11 +227,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     private func sortPluginsIfNeeded(_ plugins: [MediaControlPlugin]) -> [MediaControlPlugin] {
-        if let mediaControlPluginOrderOption = core?.options[kMediaControlPluginsOrder] as? String {
-            let pluginsOrder = mediaControlPluginOrderOption
-                .replacingOccurrences(of: " ", with: "")
-                .components(separatedBy: ",")
-
+        if let pluginsOrder = core?.options[kMediaControlPluginsOrder] as? [String] {
             var orderedPlugins: [MediaControlPlugin] = plugins.filter { pluginsOrder.contains($0.pluginName)}
             orderedPlugins.append(contentsOf: plugins.filter { !pluginsOrder.contains($0.pluginName)})
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -228,7 +228,12 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     private func sortPluginsIfNeeded(_ plugins: [MediaControlPlugin]) -> [MediaControlPlugin] {
         if let pluginsOrder = core?.options[kMediaControlPluginsOrder] as? [String] {
-            var orderedPlugins: [MediaControlPlugin] = plugins.filter { pluginsOrder.contains($0.pluginName)}
+            var orderedPlugins = [MediaControlPlugin]()
+            pluginsOrder.forEach { pluginName in
+                if let selectedPlugin = plugins.first(where: { $0.pluginName == pluginName }) {
+                    orderedPlugins.append(selectedPlugin)
+                }
+            }
             orderedPlugins.append(contentsOf: plugins.filter { !pluginsOrder.contains($0.pluginName)})
 
             return orderedPlugins

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -232,9 +232,11 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
             pluginsOrder.forEach { pluginName in
                 if let selectedPlugin = plugins.first(where: { $0.pluginName == pluginName }) {
                     orderedPlugins.append(selectedPlugin)
+                } else {
+                    Logger.logInfo("Plugin \(pluginName) not found.")
                 }
             }
-            orderedPlugins.append(contentsOf: plugins.filter { !pluginsOrder.contains($0.pluginName)})
+            orderedPlugins.append(contentsOf: plugins.filter { !pluginsOrder.contains($0.pluginName) })
 
             return orderedPlugins
         }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -474,19 +474,34 @@ class MediaControlTests: QuickSpec {
                 }
 
                 context("when kMediaControlPluginsOrder is passed") {
-                    it("renders the plugins following the kMediaControlPluginsOrder order") {
-                        let pluginName = "FullscreenButton"
-                        core.options[kMediaControlPluginsOrder] = [pluginName]
-                        let plugins = [TimeIndicatorPluginMock(context: core), FullscreenButton(context: core)]
+                    it("renders the plugins following the kMediaControlPluginsOrder with all plugins specified in the option") {
+                        core.options[kMediaControlPluginsOrder] = ["FullscreenButton", "TimeIndicatorPluginMock", "SecondPlugin", "FirstPlugin"]
+                        let plugins = [FirstPlugin(context: core), SecondPlugin(context: core), TimeIndicatorPluginMock(context: core), FullscreenButton(context: core), ]
                         let mediaControl = MediaControl(context: core)
                         mediaControl.render()
 
                         mediaControl.renderPlugins(plugins)
 
                         let bottomRightView = mediaControl.mediaControlView.bottomRight
-                        let pluginView = bottomRightView?.subviews.first
-                        let expectedView = pluginView?.subviews.first?.accessibilityIdentifier == pluginName
-                        expect(expectedView).to(beTrue())
+                        expect(bottomRightView?.subviews[0].subviews.first?.accessibilityIdentifier).to(equal("FullscreenButton"))
+                        expect(bottomRightView?.subviews[1].subviews.first?.accessibilityIdentifier).to(equal("timeIndicator"))
+                        expect(bottomRightView?.subviews[2].subviews.first?.accessibilityIdentifier).to(equal("SecondPlugin"))
+                        expect(bottomRightView?.subviews[3].subviews.first?.accessibilityIdentifier).to(equal("FirstPlugin"))
+                    }
+
+                    it("renders the plugins following the kMediaControlPluginsOrder with only two plugins specified in the option") {
+                        core.options[kMediaControlPluginsOrder] = ["FullscreenButton", "TimeIndicatorPluginMock"]
+                        let plugins = [FirstPlugin(context: core), SecondPlugin(context: core), TimeIndicatorPluginMock(context: core), FullscreenButton(context: core), ]
+                        let mediaControl = MediaControl(context: core)
+                        mediaControl.render()
+
+                        mediaControl.renderPlugins(plugins)
+
+                        let bottomRightView = mediaControl.mediaControlView.bottomRight
+                        expect(bottomRightView?.subviews[0].subviews.first?.accessibilityIdentifier).to(equal("FullscreenButton"))
+                        expect(bottomRightView?.subviews[1].subviews.first?.accessibilityIdentifier).to(equal("timeIndicator"))
+                        expect(bottomRightView?.subviews[2].subviews.first?.accessibilityIdentifier).to(equal("FirstPlugin"))
+                        expect(bottomRightView?.subviews[3].subviews.first?.accessibilityIdentifier).to(equal("SecondPlugin"))
                     }
                 }
             }
@@ -537,6 +552,56 @@ class MediaControlPluginMock: MediaControlPlugin {
 class TimeIndicatorPluginMock: TimeIndicator {
     override var pluginName: String {
         return "TimeIndicatorPluginMock"
+    }
+
+    open override var panel: MediaControlPanel {
+        return .bottom
+    }
+
+    open override var position: MediaControlPosition {
+        return .right
+    }
+}
+
+class FirstPlugin: MediaControlPlugin {
+    override var pluginName: String {
+        return "FirstPlugin"
+    }
+    
+    var button: UIButton! {
+        didSet {
+            button.accessibilityIdentifier = pluginName
+            view.addSubview(button)
+        }
+    }
+
+    override open func render() {
+        button = UIButton(type: .custom)
+    }
+
+    open override var panel: MediaControlPanel {
+        return .bottom
+    }
+
+    open override var position: MediaControlPosition {
+        return .right
+    }
+}
+
+class SecondPlugin: MediaControlPlugin {
+    override var pluginName: String {
+        return "SecondPlugin"
+    }
+
+    var button: UIButton! {
+        didSet {
+            button.accessibilityIdentifier = pluginName
+            view.addSubview(button)
+        }
+    }
+
+    override open func render() {
+        button = UIButton(type: .custom)
     }
 
     open override var panel: MediaControlPanel {

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -476,7 +476,7 @@ class MediaControlTests: QuickSpec {
                 context("when kMediaControlPluginsOrder is passed") {
                     it("renders the plugins following the kMediaControlPluginsOrder order") {
                         let pluginName = "FullscreenButton"
-                        core.options[kMediaControlPluginsOrder] = pluginName
+                        core.options[kMediaControlPluginsOrder] = [pluginName]
                         let plugins = [TimeIndicatorPluginMock(context: core), FullscreenButton(context: core)]
                         let mediaControl = MediaControl(context: core)
                         mediaControl.render()


### PR DESCRIPTION
# Goal
Order Media Control plugins based in the kMediaControlPluginsOrder option.

# How to test
In the Clappr example app `ViewController.swift` add the option before instantiate Player: `options[kMediaControlPluginsOrder] = ["TimeIndicator", "FullscreenButton"]` 
Change the TimeIndicatorPlugin and FullscreenButton to same position, for example left, run the app and check if the order are correct.

**P.S.** Remind that the order of disposing the plugins in media control follow the position so if position is left the first plugin mentioned in the option came to left and if the position was right the first plugin will be displayed at the right.