### PR TITLE
Fix full screen event trigger after device rotation

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -101,12 +101,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     open override func render() {
         containers.forEach(renderContainer)
         addToContainer()
-        
-        #if os(iOS)
-        renderCoreAndMediaControlPlugins()
-        #elseif os(tvOS)
-        renderPlugins()
-        #endif
     }
 
     #if os(tvOS)
@@ -147,13 +141,17 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     fileprivate func addToContainer() {
         #if os(iOS)
-        if optionsUnboxer.fullscreen && !optionsUnboxer.fullscreenControledByApp {
+        let isFullScreen = optionsUnboxer.fullscreen && !optionsUnboxer.fullscreenControledByApp
+        if isFullScreen {
+            renderCoreAndMediaControlPlugins()
             fullscreenHandler?.enterInFullscreen()
         } else {
             renderInContainerView()
         }
+        renderCoreAndMediaControlPlugins()
         #else
         renderInContainerView()
+        renderPlugins()
         #endif
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -100,13 +100,13 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     open override func render() {
         containers.forEach(renderContainer)
+        addToContainer()
+        
         #if os(iOS)
         renderCoreAndMediaControlPlugins()
         #elseif os(tvOS)
         renderPlugins()
         #endif
-
-        addToContainer()
     }
 
     #if os(tvOS)

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -146,8 +146,8 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
             fullscreenHandler?.enterInFullscreen()
         } else {
             renderInContainerView()
+            renderCoreAndMediaControlPlugins()
         }
-        renderCoreAndMediaControlPlugins()
         #else
         renderInContainerView()
         renderPlugins()

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -141,8 +141,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     fileprivate func addToContainer() {
         #if os(iOS)
-        let isFullScreen = optionsUnboxer.fullscreen && !optionsUnboxer.fullscreenControledByApp
-        if isFullScreen {
+        if optionsUnboxer.fullscreen && !optionsUnboxer.fullscreenControledByApp {
             renderCoreAndMediaControlPlugins()
             fullscreenHandler?.enterInFullscreen()
         } else {

--- a/Sources/Clappr/Classes/Extension/UIView+Ext.swift
+++ b/Sources/Clappr/Classes/Extension/UIView+Ext.swift
@@ -3,6 +3,7 @@ extension UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         addSubview(view)
         addMatchingConstraints(view)
+        view.layoutIfNeeded()
     }
 
     @objc func addMatchingConstraints(_ view: UIView) {

--- a/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
+++ b/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
@@ -46,10 +46,11 @@ struct FullscreenByPlayer: FullscreenStateHandler {
         core.isFullscreen = true
         fullscreenController.view.backgroundColor = UIColor.black
         fullscreenController.modalPresentationStyle = .overFullScreen
-        core.parentController?.present(fullscreenController, animated: false, completion: nil)
-        fullscreenController.view.addSubviewMatchingConstraints(core.view)
-        core.trigger(Event.didEnterFullscreen.rawValue)
-        core.trigger(InternalEvent.userRequestEnterInFullscreen.rawValue)
+        core.parentController?.present(fullscreenController, animated: false) {
+            fullscreenController.view.addSubviewMatchingConstraints(self.core.view)
+            self.core.trigger(Event.didEnterFullscreen.rawValue)
+            self.core.trigger(InternalEvent.userRequestEnterInFullscreen.rawValue)
+        }
     }
 
     func exitFullscreen() {


### PR DESCRIPTION
# Goal
In order to use the `core.view` frame/bounds to render other plugins, we need to render it before everything else.