### PR TITLE
Change getPlugin to accept a plugin name instead of a class type

### DIFF
--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -93,16 +93,16 @@ open class Container: UIObject {
         plugins.append(plugin)
     }
     
-    private func findPlugin(_ pluginClass: AnyClass) -> UIContainerPlugin? {
-        return plugins.first(where: { $0.isKind(of: pluginClass) })
+    private func findPlugin(_ name: String) -> UIContainerPlugin? {
+        return plugins.first(where: { $0.pluginName == name })
     }
 
-    @objc open func hasPlugin(_ pluginClass: AnyClass) -> Bool {
-        return findPlugin(pluginClass) != nil
+    @objc open func hasPlugin(_ name: String) -> Bool {
+        return findPlugin(name) != nil
     }
     
-    open func getPlugin(_ pluginClass: AnyClass) -> UIContainerPlugin? {
-        return findPlugin(pluginClass)
+    open func getPlugin(_ name: String) -> UIContainerPlugin? {
+        return findPlugin(name)
     }
 
     @objc open func destroy() {

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -55,8 +55,8 @@ class ContainerTests: QuickSpec {
                         }
 
                         it("saves plugins on container") {
-                            expect(container.hasPlugin(FakeContainerPlugin.self)).to(beTrue())
-                            expect(container.hasPlugin(AnotherFakeContainerPlugin.self)).to(beTrue())
+                            expect(container.hasPlugin(FakeContainerPlugin.name)).to(beTrue())
+                            expect(container.hasPlugin(AnotherFakeContainerPlugin.name)).to(beTrue())
                         }
                     }
 


### PR DESCRIPTION
## Goal
- To search plugins by name instead of class type

## How to test
- Run the test schemes to ensure that everything runs ok