### PR TITLE
Handle double tap to seek on live videos

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
@@ -56,17 +56,27 @@ public class DoubleTapPlugin: UICorePlugin {
         guard let activePlayback = core?.activePlayback,
             let coreViewWidth = core?.view.frame.width else { return }
         
-        let playBackPosition = activePlayback.position
+        let tapIsOnTheLeftSide = xPosition < coreViewWidth / 2
         impactFeedback()
-        if xPosition < coreViewWidth / 2 {
-            activePlayback.seek(playBackPosition - 10)
-            guard playBackPosition - 10 > 0.0 else { return }
-            animatonHandler?.animateBackward()
+        if (tapIsOnTheLeftSide) {
+            seekBackward(activePlayback)
         } else {
-            activePlayback.seek(playBackPosition + 10)
-            guard playBackPosition + 10 < activePlayback.duration else { return }
-            animatonHandler?.animateForward()
+            seekForward(activePlayback)
         }
+    }
+    
+    private func seekBackward(_ playback: Playback) {
+        guard playback.isDvrAvailable || playback.playbackType != .live else { return }
+        playback.seek(playback.position - 10)
+        guard playback.position - 10 > 0.0 else { return }
+        animatonHandler?.animateBackward()
+    }
+    
+    private func seekForward(_ playback: Playback) {
+        guard playback.playbackType != .live else { return }
+        playback.seek(playback.position + 10)
+        guard playback.position + 10 < playback.duration else { return }
+        animatonHandler?.animateForward()
     }
     
     private func impactFeedback() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
@@ -56,9 +56,9 @@ public class DoubleTapPlugin: UICorePlugin {
         guard let activePlayback = core?.activePlayback,
             let coreViewWidth = core?.view.frame.width else { return }
         
-        let tapIsOnTheLeftSide = xPosition < coreViewWidth / 2
+        let didTapLeftSide = xPosition < coreViewWidth / 2
         impactFeedback()
-        if (tapIsOnTheLeftSide) {
+        if didTapLeftSide {
             seekBackward(activePlayback)
         } else {
             seekForward(activePlayback)

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
@@ -66,7 +66,6 @@ public class DoubleTapPlugin: UICorePlugin {
     }
     
     private func seekBackward(_ playback: Playback) {
-        guard playback.playbackType != .live else { return }
         playback.seek(playback.position - 10)
         guard playback.position - 10 > 0.0 else { return }
         animatonHandler?.animateBackward()

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
@@ -65,6 +65,7 @@ public class DoubleTapPlugin: UICorePlugin {
     }
     
     private func seekBackward(_ playback: Playback) {
+        guard playback.playbackType == .vod || playback.isDvrAvailable else { return }
         impactFeedback()
         playback.seek(playback.position - 10)
         guard playback.position - 10 > 0.0 else { return }
@@ -72,7 +73,7 @@ public class DoubleTapPlugin: UICorePlugin {
     }
     
     private func seekForward(_ playback: Playback) {
-        guard playback.playbackType == .vod || playback.isDvrInUse else { return }
+        guard playback.playbackType == .vod || playback.isDvrAvailable && playback.isDvrInUse else { return }
         impactFeedback()
         playback.seek(playback.position + 10)
         guard playback.position + 10 < playback.duration else { return }

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
@@ -66,14 +66,14 @@ public class DoubleTapPlugin: UICorePlugin {
     }
     
     private func seekBackward(_ playback: Playback) {
-        guard playback.isDvrAvailable || playback.playbackType != .live else { return }
+        guard playback.playbackType != .live else { return }
         playback.seek(playback.position - 10)
         guard playback.position - 10 > 0.0 else { return }
         animatonHandler?.animateBackward()
     }
     
     private func seekForward(_ playback: Playback) {
-        guard playback.playbackType != .live else { return }
+        guard playback.playbackType == .vod || playback.isDvrInUse else { return }
         playback.seek(playback.position + 10)
         guard playback.position + 10 < playback.duration else { return }
         animatonHandler?.animateForward()

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/DoubleTapPlugin.swift
@@ -57,7 +57,6 @@ public class DoubleTapPlugin: UICorePlugin {
             let coreViewWidth = core?.view.frame.width else { return }
         
         let didTapLeftSide = xPosition < coreViewWidth / 2
-        impactFeedback()
         if didTapLeftSide {
             seekBackward(activePlayback)
         } else {
@@ -66,6 +65,7 @@ public class DoubleTapPlugin: UICorePlugin {
     }
     
     private func seekBackward(_ playback: Playback) {
+        impactFeedback()
         playback.seek(playback.position - 10)
         guard playback.position - 10 > 0.0 else { return }
         animatonHandler?.animateBackward()
@@ -73,6 +73,7 @@ public class DoubleTapPlugin: UICorePlugin {
     
     private func seekForward(_ playback: Playback) {
         guard playback.playbackType == .vod || playback.isDvrInUse else { return }
+        impactFeedback()
         playback.seek(playback.position + 10)
         guard playback.position + 10 < playback.duration else { return }
         animatonHandler?.animateForward()

--- a/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
+++ b/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
@@ -16,6 +16,7 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     var videoPosition: Double = 0
     var _isDvrInUse = false
     var didCallSeekToLivePosition = false
+    var _playbackType: PlaybackType = .vod
     
     override var duration: Double {
         return videoDuration
@@ -27,6 +28,10 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     
     override var isDvrInUse: Bool {
         return _isDvrInUse
+    }
+    
+    override var playbackType: PlaybackType {
+        return _playbackType
     }
     
     func set(isPlaying: Bool) {
@@ -45,6 +50,10 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     
     func set(isDvrAvailable: Bool) {
         _isDvrAvailable = isDvrAvailable
+    }
+    
+    func set(playbackType: PlaybackType) {
+        _playbackType = playbackType
     }
     
     func set(position: Double) {

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
@@ -54,7 +54,7 @@ class DoubleTapCorePluginTests: QuickSpec {
                     }
                 }
                 
-                describe("and it is a live video") {
+                describe("live video") {
                     context("with DVR") {
                         it("should seek forward") {
                             core.playbackMock?.set(playbackType: .live)

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
@@ -56,7 +56,7 @@ class DoubleTapCorePluginTests: QuickSpec {
                 
                 describe("live video") {
                     context("with DVR") {
-                        it("should seek forward") {
+                        it("seeks forward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: true)
                             core.playbackMock?.set(isDvrInUse: true)
@@ -67,7 +67,7 @@ class DoubleTapCorePluginTests: QuickSpec {
                             expect(core.playbackMock?.didCallSeek).to(beTrue())
                         }
                         
-                        it("should seek backward") {
+                        it("seeks backward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: true)
                             
@@ -77,7 +77,7 @@ class DoubleTapCorePluginTests: QuickSpec {
                         }
                         
                         context("with DVR not in use") {
-                            it("should not seek forward") {
+                            it("does not seek forward") {
                                 core.playbackMock?.set(playbackType: .live)
                                 core.playbackMock?.set(isDvrAvailable: true)
                                 core.playbackMock?.set(isDvrInUse: false)
@@ -90,7 +90,7 @@ class DoubleTapCorePluginTests: QuickSpec {
                     }
                     
                     context("without DVR") {
-                        it("should not seek forward") {
+                        it("does not seek forward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: false)
                             
@@ -99,7 +99,7 @@ class DoubleTapCorePluginTests: QuickSpec {
                             expect(core.playbackMock?.didCallSeek).to(beFalse())
                         }
                         
-                        it("should not seek backward") {
+                        it("does not seek backward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: false)
                             

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
@@ -77,7 +77,7 @@ class DoubleTapCorePluginTests: QuickSpec {
                         }
                     }
                     
-                    context("widhout DVR") {
+                    context("without DVR") {
                         it("should not seek forward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: false)

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
@@ -53,6 +53,50 @@ class DoubleTapCorePluginTests: QuickSpec {
                         expect(core.playbackMock?.didCallSeekWithValue).to(equal(30))
                     }
                 }
+                
+                describe("and it is a live video") {
+                    context("with DVR") {
+                        it("should seek forward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: true)
+                            core.playbackMock?.set(isDvrInUse: true)
+                            core.playbackMock?.set(position: 0)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beTrue())
+                        }
+                        
+                        it("should seek backward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: true)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: 0)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beTrue())
+                        }
+                    }
+                    
+                    context("widhout DVR") {
+                        it("should not seek forward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: false)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beFalse())
+                        }
+                        
+                        it("should not seek backward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: false)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: 0)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beFalse())
+                        }
+                    }
+                }
             }
         }
     }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/DoubleTapCorePluginTests.swift
@@ -75,6 +75,18 @@ class DoubleTapCorePluginTests: QuickSpec {
                             
                             expect(core.playbackMock?.didCallSeek).to(beTrue())
                         }
+                        
+                        context("with DVR not in use") {
+                            it("should not seek forward") {
+                                core.playbackMock?.set(playbackType: .live)
+                                core.playbackMock?.set(isDvrAvailable: true)
+                                core.playbackMock?.set(isDvrInUse: false)
+                                
+                                doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
+                                
+                                expect(core.playbackMock?.didCallSeek).to(beFalse())
+                            }
+                        }
                     }
                     
                     context("without DVR") {

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
@@ -78,7 +78,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                     }
                 }
                 
-                describe("and it is a live video") {
+                describe("live video") {
                     context("with DVR") {
                         it("should seek forward") {
                             core.playbackMock?.set(playbackType: .live)

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
@@ -68,7 +68,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                 }
                 
                 context("and it colides with another UICorePlugin") {
-                    it("should not seek") {
+                    it("does not seek") {
                         playButton.view.layoutIfNeeded()
                         mediaControl.view.layoutIfNeeded()
                         
@@ -80,7 +80,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                 
                 describe("live video") {
                     context("with DVR") {
-                        it("should seek forward") {
+                        it("seeks forward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: true)
                             core.playbackMock?.set(isDvrInUse: true)
@@ -91,7 +91,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                             expect(core.playbackMock?.didCallSeek).to(beTrue())
                         }
                         
-                        it("should seek backward") {
+                        it("seeks backward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: true)
                             
@@ -102,7 +102,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                     }
                     
                     context("with DVR not in use") {
-                        it("should not seek forward") {
+                        it("does not seek forward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: true)
                             core.playbackMock?.set(isDvrInUse: false)
@@ -114,7 +114,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                     }
                     
                     context("without DVR") {
-                        it("should not seek forward") {
+                        it("does not seek forward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: false)
                             
@@ -123,7 +123,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                             expect(core.playbackMock?.didCallSeek).to(beFalse())
                         }
                         
-                        it("should not seek backward") {
+                        it("does not seek backward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: false)
                             

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
@@ -101,6 +101,18 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                         }
                     }
                     
+                    context("with DVR not in use") {
+                        it("should not seek forward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: true)
+                            core.playbackMock?.set(isDvrInUse: false)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beFalse())
+                        }
+                    }
+                    
                     context("without DVR") {
                         it("should not seek forward") {
                             core.playbackMock?.set(playbackType: .live)

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
@@ -78,21 +78,47 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                     }
                 }
                 
-                context("and it is a live video") {
-                    it("should not seek forward") {
-                        core.playbackMock?.set(playbackType: .live)
+                describe("and it is a live video") {
+                    context("with DVR") {
+                        it("should seek forward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: true)
+                            core.playbackMock?.set(isDvrInUse: true)
+                            core.playbackMock?.set(position: 0)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beTrue())
+                        }
                         
-                        doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
-                        
-                        expect(core.playbackMock?.didCallSeek).to(beFalse())
+                        it("should seek backward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: true)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: 0)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beTrue())
+                        }
                     }
                     
-                    it("should seek backward") {
-                        core.playbackMock?.set(playbackType: .live)
+                    context("widhout DVR") {
+                        it("should not seek forward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: false)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beFalse())
+                        }
                         
-                        doubleTapPlugin.doubleTapSeek(xPosition: 0)
-                        
-                        expect(core.playbackMock?.didCallSeek).to(beTrue())
+                        it("should not seek backward") {
+                            core.playbackMock?.set(playbackType: .live)
+                            core.playbackMock?.set(isDvrAvailable: false)
+                            
+                            doubleTapPlugin.doubleTapSeek(xPosition: 0)
+                            
+                            expect(core.playbackMock?.didCallSeek).to(beFalse())
+                        }
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
@@ -101,7 +101,7 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                         }
                     }
                     
-                    context("widhout DVR") {
+                    context("without DVR") {
                         it("should not seek forward") {
                             core.playbackMock?.set(playbackType: .live)
                             core.playbackMock?.set(isDvrAvailable: false)

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
@@ -77,6 +77,25 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                         expect(shouldSeek).to(beFalse())
                     }
                 }
+                
+                context("and it is a live video") {
+                    it("should not seek forward") {
+                        core.playbackMock?.set(playbackType: .live)
+                        
+                        doubleTapPlugin.doubleTapSeek(xPosition: core.view.frame.width)
+                        
+                        expect(core.playbackMock?.didCallSeek).to(beFalse())
+                    }
+                    
+                    it("should not seek backward if dvr is disabled") {
+                        core.playbackMock?.set(playbackType: .live)
+                        core.playbackMock?.set(isDvrAvailable: false)
+                        
+                        doubleTapPlugin.doubleTapSeek(xPosition: 0)
+                        
+                        expect(core.playbackMock?.didCallSeek).to(beFalse())
+                    }
+                }
             }
         }
     }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/DoubleTapMediaControlPluginTests.swift
@@ -87,13 +87,12 @@ class DoubleTapMediaControlPluginTests: QuickSpec {
                         expect(core.playbackMock?.didCallSeek).to(beFalse())
                     }
                     
-                    it("should not seek backward if dvr is disabled") {
+                    it("should seek backward") {
                         core.playbackMock?.set(playbackType: .live)
-                        core.playbackMock?.set(isDvrAvailable: false)
                         
                         doubleTapPlugin.doubleTapSeek(xPosition: 0)
                         
-                        expect(core.playbackMock?.didCallSeek).to(beFalse())
+                        expect(core.playbackMock?.didCallSeek).to(beTrue())
                     }
                 }
             }


### PR DESCRIPTION
## 🏁 Goal
- To prevent double tap seek forward when a video is live.
- To make sure we double tap seek when video is live and it has DVR enabled.

## ✅ How to test
- Make sure double tap works as it should
- Run the tests and check if they pass