### PR TITLE
Handle all plugin types in Core and Container

### DIFF
--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 open class Container: UIObject {
-    private(set) var plugins: [UIContainerPlugin] = []
+    private(set) var plugins: [Plugin] = []
     @objc open var sharedData = SharedData()
     @objc open var options: Options {
         didSet {
@@ -78,22 +78,24 @@ open class Container: UIObject {
         view.sendSubview(toBack: playback.view)
     }
 
-    fileprivate func renderPlugin(_ plugin: UIContainerPlugin) {
-        view.addSubview(plugin.view)
-        do {
-            try ObjC.catchException {
-                plugin.render()
+    fileprivate func renderPlugin(_ plugin: Plugin) {
+        if let plugin = plugin as? UIContainerPlugin {
+            view.addSubview(plugin.view)
+            do {
+                try ObjC.catchException {
+                    plugin.render()
+                }
+            } catch {
+                Logger.logError("\((plugin as Plugin).pluginName) crashed during render (\(error.localizedDescription))", scope: "Container")
             }
-        } catch {
-            Logger.logError("\((plugin as Plugin).pluginName) crashed during render (\(error.localizedDescription))", scope: "Container")
         }
     }
 
-    func addPlugin(_ plugin: UIContainerPlugin) {
+    func addPlugin(_ plugin: Plugin) {
         plugins.append(plugin)
     }
     
-    private func findPlugin(_ name: String) -> UIContainerPlugin? {
+    private func findPlugin(_ name: String) -> Plugin? {
         return plugins.first(where: { $0.pluginName == name })
     }
 
@@ -101,7 +103,7 @@ open class Container: UIObject {
         return findPlugin(name) != nil
     }
     
-    open func getPlugin(_ name: String) -> UIContainerPlugin? {
+    open func getPlugin(_ name: String) -> Plugin? {
         return findPlugin(name)
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -101,14 +101,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     #if os(tvOS)
     private func renderPlugins() {
         plugins.forEach { plugin in
-            view.addSubview(plugin.view)
-            do {
-                try ObjC.catchException {
-                    plugin.render()
-                }
-            } catch {
-                Logger.logError("\((plugin as Plugin).pluginName) crashed during render (\(error.localizedDescription))", scope: "Core")
-            }
+            render(plugin)
         }
     }
     #endif
@@ -121,16 +114,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     private func renderCorePlugins() {
         plugins.filter { isNotMediaControlPlugin($0) }.forEach { plugin in
-            if let plugin = plugin as? UICorePlugin {
-                view.addSubview(plugin.view)
-                do {
-                    try ObjC.catchException {
-                        plugin.render()
-                    }
-                } catch {
-                    Logger.logError("\((plugin as Plugin).pluginName) crashed during render (\(error.localizedDescription))", scope: "Core")
-                }
-            }
+            render(plugin)
         }
     }
 
@@ -147,6 +131,19 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         return !(plugin is MediaControlPlugin)
     }
     #endif
+
+    private func render(_ plugin: Plugin) {
+        if let plugin = plugin as? UICorePlugin {
+            view.addSubview(plugin.view)
+            do {
+                try ObjC.catchException {
+                    plugin.render()
+                }
+            } catch {
+                Logger.logError("\((plugin as Plugin).pluginName) crashed during render (\(error.localizedDescription))", scope: "Core")
+            }
+        }
+    }
 
     fileprivate func addToContainer() {
         #if os(iOS)

--- a/Sources/Clappr/Classes/Base/Factories/ContainerFactory.swift
+++ b/Sources/Clappr/Classes/Base/Factories/ContainerFactory.swift
@@ -5,9 +5,7 @@ struct ContainerFactory {
         let container = Container(options: options)
 
         Loader.shared.containerPlugins.forEach { plugin in
-            if let containerPlugin = plugin.init(context: container) as? UIContainerPlugin {
-                container.addPlugin(containerPlugin)
-            }
+            container.addPlugin(plugin.init(context: container))
         }
 
         if let source = options[kSourceUrl] as? String {

--- a/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
@@ -9,5 +9,7 @@ open class UIContainerPlugin: ContainerPlugin, UIPlugin {
         }
     }
     
-    open func render() {}
+    open func render() {
+        NSException(name: NSExceptionName("RenderNotOverriden"), reason: "UIContainerPlugins should always override the render method").raise()
+    }
 }

--- a/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
@@ -9,5 +9,7 @@ open class UICorePlugin: CorePlugin, UIPlugin {
         }
     }
     
-    open func render() {}
+    open func render() {
+        NSException(name: NSExceptionName("RenderNotOverriden"), reason: "UICorePlugins should always override the render method").raise()
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/JumpCorePlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/JumpCorePlugin.swift
@@ -21,7 +21,9 @@ public class JumpCorePlugin: JumpPlugin {
     }
     
     override func shouldSeek(point: CGPoint) -> Bool {
-        let pluginColidingWithGesture = core?.activeContainer?.plugins.first(where: {
+        let pluginColidingWithGesture = core?.activeContainer?.plugins
+            .compactMap({ $0 as? UIContainerPlugin })
+            .first(where: {
             !$0.view.isHidden && $0.view.point(inside: core!.view.convert(point, to: $0.view), with: nil)
         })
         return pluginColidingWithGesture == nil

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/JumpMediaControlPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/JumpMediaControlPlugin.swift
@@ -34,7 +34,9 @@ public class JumpMediaControlPlugin: JumpPlugin {
     
     private func filteredOutModalPlugins() -> [UICorePlugin]? {
         let pluginsWithoutMediaControl = core?.plugins.filter({ $0.pluginName != MediaControl.name })
-        return pluginsWithoutMediaControl?.filter({ ($0 as? MediaControlPlugin)?.panel != .modal })
+        return pluginsWithoutMediaControl?
+            .filter({ ($0 as? MediaControlPlugin)?.panel != .modal })
+            .compactMap({ $0 as? UICorePlugin })
     }
     
     override func shouldSeek(point: CGPoint) -> Bool {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/JumpMediaControlPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/JumpMediaControlPlugin.swift
@@ -35,8 +35,8 @@ public class JumpMediaControlPlugin: JumpPlugin {
     private func filteredOutModalPlugins() -> [UICorePlugin]? {
         let pluginsWithoutMediaControl = core?.plugins.filter({ $0.pluginName != MediaControl.name })
         return pluginsWithoutMediaControl?
-            .filter({ ($0 as? MediaControlPlugin)?.panel != .modal })
             .compactMap({ $0 as? UICorePlugin })
+            .filter({ ($0 as? MediaControlPlugin)?.panel != .modal })
     }
     
     override func shouldSeek(point: CGPoint) -> Bool {

--- a/Tests/Clappr_Tests/Classes/Plugins/Container/UIContainerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Container/UIContainerPluginTests.swift
@@ -31,6 +31,17 @@ class UIContainerPluginTests: QuickSpec {
                     expect(StubContainerPlugin(context: context)).to(raiseException(named: "WrongContextType"))
                 }
             }
+
+            describe("#render") {
+                it("crashes if render is not overriden") {
+                    let container = Container()
+                    let plugin = StubContainerPlugin(context: container)
+                    let expectedExceptionName = "RenderNotOverriden"
+                    let expectedExceptionReason = "UIContainerPlugins should always override the render method"
+
+                    expect(plugin.render()).to(raiseException(named: expectedExceptionName, reason: expectedExceptionReason))
+                }
+            }
         }
     }
     

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -91,12 +91,32 @@ class ContainerTests: QuickSpec {
                         expect(option) == "option"
                     }
 
-                    it("add a container context to all plugins") {
+                    it("stores all plugin instances") {
+                        Loader.shared.resetPlugins()
+                        Loader.shared.register(plugins: [FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
+                        let container = ContainerFactory.create(with: [:])
+
+                        expect(container.plugins.count).to(equal(2))
+                        expect(container.plugins.compactMap({ $0 as? FakeContainerPlugin })).toNot(beNil())
+                        expect(container.plugins.compactMap({ $0 as? AnotherFakeContainerPlugin })).toNot(beNil())
+                    }
+
+                    it("add a container context to all UIContainerPlugin") {
                         Loader.shared.register(plugins: [FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
                         let container = ContainerFactory.create(with: [:])
 
                         expect(container.plugins).toNot(beEmpty())
-                        container.plugins.forEach { plugin in
+                        container.plugins.compactMap({ $0 as? UIContainerPlugin }).forEach { plugin in
+                            expect(plugin.container) == container
+                        }
+                    }
+
+                    it("add a container context to all ContainerPlugin") {
+                        Loader.shared.register(plugins: [FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
+                        let container = ContainerFactory.create(with: [:])
+
+                        expect(container.plugins).toNot(beEmpty())
+                        container.plugins.compactMap({ $0 as? ContainerPlugin }).forEach { plugin in
                             expect(plugin.container) == container
                         }
                     }
@@ -347,7 +367,7 @@ class ContainerTests: QuickSpec {
         }
     }
 
-    class FakeContainerPlugin: UIContainerPlugin {
+    class FakeContainerPlugin: ContainerPlugin {
         override var pluginName: String {
             return "FakeContainerPlugin"
         }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -56,6 +56,16 @@ class CoreTests: QuickSpec {
                 it("containers list is not empty") {
                     expect(core.containers).toNot(beEmpty())
                 }
+
+                it("stores plugin instances") {
+                    Loader.shared.register(plugins: [UICorePluginMock.self, CorePluginMock.self])
+
+                    let core = CoreFactory.create(with: options as Options)
+
+                    expect(core.plugins.count).to(equal(2))
+                    expect(core.plugins.compactMap({ $0 as? UICorePluginMock })).toNot(beNil())
+                    expect(core.plugins.compactMap({ $0 as? CorePluginMock })).toNot(beNil())
+                }
                 
                 #if os(iOS)
                 it("add gesture recognizer") {
@@ -554,9 +564,9 @@ class CoreTests: QuickSpec {
 
                 it("protect the main thread when plugin crashes in render") {
                     let expectation = QuickSpec.current.expectation(description: "doesn't crash")
-                    CorePluginMock.crashOnDestroy = true
+                    UICorePluginMock.crashOnDestroy = true
                     let core = Core()
-                    let plugin = CorePluginMock()
+                    let plugin = UICorePluginMock()
                     core.addPlugin(plugin)
 
                     core.destroy()
@@ -680,9 +690,9 @@ class CoreTests: QuickSpec {
 
                 it("protect the main thread when plugin crashes in render") {
                     let expectation = QuickSpec.current.expectation(description: "doesn't crash")
-                    CorePluginMock.crashOnRender = true
+                    UICorePluginMock.crashOnRender = true
                     let core = Core()
-                    let plugin = CorePluginMock()
+                    let plugin = UICorePluginMock()
                     core.addPlugin(plugin)
 
                     core.render()
@@ -726,39 +736,45 @@ class CoreTests: QuickSpec {
     }
 }
 
-class CorePluginMock: UICorePlugin {
+class UICorePluginMock: UICorePlugin {
     static var didCallRender = false
     static var crashOnRender = false
     static var didCallDestroy = false
     static var crashOnDestroy = false
 
     override var pluginName: String {
-        return "CorePluginMock"
+        return "UICorePluginMock"
     }
 
     override func render() {
-        CorePluginMock.didCallRender = true
+        UICorePluginMock.didCallRender = true
 
-        if CorePluginMock.crashOnRender {
+        if UICorePluginMock.crashOnRender {
             codeThatCrashes()
         }
     }
 
 
     override func destroy() {
-        CorePluginMock.didCallDestroy = true
+        UICorePluginMock.didCallDestroy = true
 
-        if CorePluginMock.crashOnDestroy {
+        if UICorePluginMock.crashOnDestroy {
             codeThatCrashes()
         }
     }
 
     static func reset() {
-        CorePluginMock.didCallRender = false
+        UICorePluginMock.didCallRender = false
     }
 
     private func codeThatCrashes() {
         NSException(name:NSExceptionName(rawValue: "TestError"), reason:"Test Error", userInfo:nil).raise()
+    }
+}
+
+class CorePluginMock: CorePlugin {
+    override var pluginName: String {
+        return "CorePluginMock"
     }
 }
 

--- a/Tests/Clappr_Tests/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/PosterPluginTests.swift
@@ -129,6 +129,6 @@ class PosterPluginTests: QuickSpec {
     }
 
     private func getPosterPlugin(_ container: Container) -> PosterPlugin {
-        return container.plugins.filter({ $0.isKind(of: PosterPlugin.self) }).first as! PosterPlugin
+        return container.plugins.filter({ $0.pluginName == PosterPlugin.name }).first as! PosterPlugin
     }
 }

--- a/Tests/Clappr_Tests/UICorePluginTests.swift
+++ b/Tests/Clappr_Tests/UICorePluginTests.swift
@@ -31,6 +31,17 @@ class UICorePluginTests: QuickSpec {
                     expect(StubCorePlugin(context: context)).to(raiseException(named: "WrongContextType"))
                 }
             }
+
+            describe("#render") {
+                it("crashes if render is not overriden") {
+                    let core = Core()
+                    let plugin = StubCorePlugin(context: core)
+                    let expectedExceptionName = "RenderNotOverriden"
+                    let expectedExceptionReason = "UICorePlugins should always override the render method"
+
+                    expect(plugin.render()).to(raiseException(named: expectedExceptionName, reason: expectedExceptionReason))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
# Goal

* To handle both `UIPlugin`'s and `Plugin`'s in `Core` and `Container`
* To force `UIPlugin`'s to implement `render()` method

# How to test

* Make sure that the player still behaves consistently