### PR TITLE
Trigger Quickseek event 

### DIFF
--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -4,4 +4,5 @@ public enum InternalEvent: String {
     case didTappedCore = "Clappr:didTappedCore"
     case willBeginScrubbing = "Clappr:willBeginScrubbing"
     case didFinishScrubbing = "Clappr:didFinishScrubbing"
+    case didTapQuickSeek = "Clappr:didTapQuickSeek"
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/JumpPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/JumpPlugin.swift
@@ -54,8 +54,10 @@ public class JumpPlugin: UICorePlugin {
 
     @objc func jumpSeek(xPosition: CGFloat) {
         guard let activePlayback = core?.activePlayback,
+            let container = core?.activeContainer,
             let coreViewWidth = core?.view.frame.width else { return }
         
+        container.trigger(InternalEvent.didTapQuickSeek.rawValue)
         let didTapLeftSide = xPosition < coreViewWidth / 2
         if didTapLeftSide {
             seekBackward(activePlayback)

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/JumpCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/JumpCorePluginTests.swift
@@ -9,6 +9,7 @@ class JumpCorePluginTests: QuickSpec {
         describe(".JumpCorePluginTests") {
             var jumpPlugin: JumpCorePlugin!
             var core: CoreStub!
+            var eventTrigger = false
             
             beforeEach {
                 core = CoreStub()
@@ -17,6 +18,9 @@ class JumpCorePluginTests: QuickSpec {
                 core.addPlugin(jumpPlugin)
                 core.view.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                 jumpPlugin.render()
+                core._container?.on(InternalEvent.didTapQuickSeek.rawValue) { _ in
+                    eventTrigger = true
+                }
             }
             
             describe("pluginName") {
@@ -35,9 +39,10 @@ class JumpCorePluginTests: QuickSpec {
                 context("and its position is less than half of the view (left)") {
                     it("seeks back 10 seconds") {
                         core.playbackMock?.set(position: 20.0)
-                        
+
                         jumpPlugin.jumpSeek(xPosition: 0)
-                       
+                        
+                        expect(eventTrigger).toEventually(beTrue())
                         expect(core.playbackMock?.didCallSeek).to(beTrue())
                         expect(core.playbackMock?.didCallSeekWithValue).to(equal(10))
                     }
@@ -48,7 +53,8 @@ class JumpCorePluginTests: QuickSpec {
                         core.playbackMock?.set(position: 20.0)
                         
                         jumpPlugin.jumpSeek(xPosition: 100)
-                        
+
+                        expect(eventTrigger).toEventually(beTrue())
                         expect(core.playbackMock?.didCallSeek).to(beTrue())
                         expect(core.playbackMock?.didCallSeekWithValue).to(equal(30))
                     }


### PR DESCRIPTION
## Goal
To create new event:
- didTapQuickSeek: triggered when user double tap to seek 10 seconds.

## How to test
In iOS and tvOS: 
1. Open any vod;
2. Double tap on video
3. Check if didTapQuickSeek event were triggered;