### PR TITLE
Fix memory leak

### DIFF
--- a/Sources/Clappr/Classes/Base/BaseObject.swift
+++ b/Sources/Clappr/Classes/Base/BaseObject.swift
@@ -2,7 +2,7 @@ import Foundation
 
 private struct EventHolder {
     var eventHandler: EventHandler
-    var contextObject: BaseObject
+    weak var contextObject: BaseObject?
     var name: String
 }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -67,7 +67,6 @@ open class TimeIndicator: MediaControlPlugin {
 
     required public init(context: UIObject) {
         super.init(context: context)
-        stopListening()
         bindEvents()
     }
 
@@ -76,6 +75,7 @@ open class TimeIndicator: MediaControlPlugin {
     }
 
     private func bindEvents() {
+        stopListening()
         bindContainerEvents()
         bindPlaybackEvents()
         bindCoreEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -81,7 +81,7 @@ open class TimeIndicator: MediaControlPlugin {
         bindCoreEvents()
     }
 
-    private func bindContainerEvents() {
+    open func bindContainerEvents() {
         if let container = activeContainer {
             listenTo(container, eventName: Event.didChangePlayback.rawValue) { [weak self] (_: EventUserInfo) in self?.bindEvents() }
         }


### PR DESCRIPTION
# Goal

To fix memory leak issues.

When using `load` or `configure` before, the player ended up using so much memory and processing that the app was freezing.

# How to test

1. First, change the video that will be loaded. In `DashboardViewController.swift` change the option `kSourceUrl` to:

```
kSourceUrl: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8"
```

2. In `ViewController.swift` change the `playing` listener to:

```
        player.on(Event.playing) { _ in
            print("on Play")
            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
                self.player.configure(options: self.options)
            }
        }
```

And `ready` listener to:

```
player.on(Event.ready) { _ in print("on Ready"); self.player.play() }
```

Load a video, grab a coffee, and just wait a couple of minutes. The app should not freeze and the video will be reloaded every 4 sec.