### PR TITLE
Fix nowplaying on tvos

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -545,6 +545,9 @@ open class AVFoundationPlayback: Playback {
         seekOnReadyIfNeeded()
         addTimeElapsedCallback()
         trigger(.didUpdateDuration, userInfo: ["duration": duration])
+        #if os(tvOS)
+            loadMetadata()
+        #endif
     }
 
     internal func selectDefaultSubtitleIfNeeded() {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1274,6 +1274,20 @@ class AVFoundationPlaybackTests: QuickSpec {
                         expect(nowPlayingService.countOfCallsOfSetItems).toEventually(equal(0))
                     }
                 }
+
+                context("when avplayer has playerItem and is ready to play") {
+
+                    it("calls loadMetadata when the player is ready to play") {
+                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
+                        let nowPlayingService = NowPlayingServiceStub()
+                        playback = AVFoundationPlayback(options: options)
+                        playback.nowPlayingService = nowPlayingService
+
+                        playback.play()
+
+                        expect(nowPlayingService.countOfCallsOfSetItems).toEventually(equal(1))
+                    }
+                }
             }
             
             describe("#playerViewController") {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1277,7 +1277,7 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                 context("when avplayer has playerItem and is ready to play") {
 
-                    it("calls loadMetadata when the player is ready to play") {
+                    it("calls loadMetadata") {
                         let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
                         let nowPlayingService = NowPlayingServiceStub()
                         playback = AVFoundationPlayback(options: options)


### PR DESCRIPTION
## Goal
Fix Now Playing to tvOS

## How to test
1 - run tests
2 - On `AVFoundationNowPlayingService` put a breakpoint at line `16` and check if items property is been set with video information(title, description, date, content identifier, watched time)