### PR TITLE
Create media start time property on playback

### DIFF
--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -17,6 +17,8 @@ open class Playback: UIObject, Plugin {
     fileprivate(set) open var subtitles: [MediaOption]?
     fileprivate(set) open var audioSources: [MediaOption]?
 
+    @objc open var mediaStartTime: NSDate?
+
     @objc internal(set) open var options: Options {
         didSet {
             trigger(Event.didUpdateOptions)

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -422,9 +422,16 @@ open class AVFoundationPlayback: Playback {
 
             triggerDvrStatusIfNeeded()
         case .playing:
+            initializeMediaStartTime()
             trigger(.playing)
         default:
             break
+        }
+    }
+
+    private func initializeMediaStartTime() {
+        if mediaStartTime == nil {
+            mediaStartTime = NSDate()
         }
     }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -1118,6 +1118,19 @@ class AVFoundationPlaybackTests: QuickSpec {
                             expect(playback.currentState).to(equal(.buffering))
                         }
                     }
+                    
+                    context("when video has playing state") {
+                        it("initializes mediaStartTime property") {
+                            let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
+                            
+                            expect(playback.mediaStartTime).to(beNil())
+                            
+                            playback.play()
+                            
+                            expect(playback.mediaStartTime).toEventuallyNot(beNil())
+                        }
+                    }
                 }
 
                 describe("#paused") {


### PR DESCRIPTION
### Goal
To create media start time property on playback

### How to test
- run tests
- listen to `.playing` event and inspect `container.playback.mediaStartTime`