### PR TITLE
didResize event

### DIFF
--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -53,4 +53,5 @@ public enum Event: String, CaseIterable {
     case didHideModal = "Clappr:didHideModal"
     case willShowModal = "Clappr:willShowModal"
     case willHideModal = "Clappr:willHideModal"
+    case didResize = "Clappr:didResize"
 }

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -337,7 +337,6 @@ class ContainerTests: QuickSpec {
             }
 
             describe("Container sharedData") {
-
                 context("when stores a value on sharedData") {
 
                     beforeEach {
@@ -348,6 +347,24 @@ class ContainerTests: QuickSpec {
                     it("retrieves stored value") {
                         expect(container.sharedData.storeDictionary["testKey"] as? String) == "testValue"
                     }
+                }
+            }
+
+            context("when resized") {
+                it("triggers didResize event") {
+                    let container = Container()
+                    container.render()
+                    container.view.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
+                    var didResizeTriggered = false
+
+                    container.on(Event.didResize.rawValue) { _ in
+                        didResizeTriggered = true
+                    }
+
+                    container.view.setWidthAndHeight(with: CGSize(width: 10, height: 10))
+                    container.view.layoutIfNeeded()
+
+                    expect(didResizeTriggered).toEventually(beTrue())
                 }
             }
         }


### PR DESCRIPTION
# Goal

To trigger a `didResize` event when player resizes.

# How to test

1. Subscribe to the container event `didResize`
2. Change the player size (by putting it in fullscreen or resizing the container view)
3. Check that the event is triggered