### PR TITLE
Fix tvOS playback events

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		57937C571FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */; };
 		57937C5A1FB0DD2C000A239E /* AVURLAssetWithCookiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */; };
 		57AB0E882253CAB70096BCA4 /* PassthroughView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AB0E872253CAB70096BCA4 /* PassthroughView.swift */; };
+		57D80BAC2279E1D2003F72CD /* TVRemoteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D80BAA2279E1BA003F72CD /* TVRemoteHandler.swift */; };
+		57D80BAF2279E1F6003F72CD /* TVRemoteHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D80BAD2279E1F2003F72CD /* TVRemoteHandlerTests.swift */; };
 		57F1354921836EE000111BC6 /* Array+appendOrReplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */; };
 		96036D671CBD89500022CCCA /* PlaybackFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */; };
 		9603A06C1C05E6D100B55D8F /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9603A06B1C05E6D100B55D8F /* PlayerTests.swift */; };
@@ -431,6 +433,8 @@
 		57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesBuilder.swift; sourceTree = "<group>"; };
 		57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVURLAssetWithCookiesTests.swift; sourceTree = "<group>"; };
 		57AB0E872253CAB70096BCA4 /* PassthroughView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughView.swift; sourceTree = "<group>"; };
+		57D80BAA2279E1BA003F72CD /* TVRemoteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVRemoteHandler.swift; sourceTree = "<group>"; };
+		57D80BAD2279E1F2003F72CD /* TVRemoteHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TVRemoteHandlerTests.swift; sourceTree = "<group>"; };
 		57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+appendOrReplace.swift"; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* Clappr_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clappr_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACE51AFB9204008FA782 /* Clappr_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Clappr_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -697,6 +701,7 @@
 				FC7785BB2005251800EC879F /* AVFoundationPlaybackNowPlayingServiceTests.swift */,
 				32E4020E1FF43262001C2096 /* Info.plist */,
 				FB0A223D21754C1700D2180F /* PlayerTests.swift */,
+				57D80BAD2279E1F2003F72CD /* TVRemoteHandlerTests.swift */,
 			);
 			path = Clappr_tvOS_Tests;
 			sourceTree = "<group>";
@@ -1336,6 +1341,7 @@
 			isa = PBXGroup;
 			children = (
 				FC77859E2005233D00EC879F /* Player.swift */,
+				57D80BAA2279E1BA003F72CD /* TVRemoteHandler.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1852,6 +1858,7 @@
 				FBD47AAD21AD6733003265AF /* CoreFactory.swift in Sources */,
 				32E401BC1FF422E0001C2096 /* Logger.swift in Sources */,
 				48A29BFD221D81910004AD3B /* BaseObject.swift in Sources */,
+				57D80BAC2279E1D2003F72CD /* TVRemoteHandler.swift in Sources */,
 				32E401BD1FF422E0001C2096 /* LogLevel.swift in Sources */,
 				5744C05821EE37270087D9FB /* EventHandler.swift in Sources */,
 				32FC971B20B7257800ABA0C2 /* AVURLAssetWithCookiesBuilder.swift in Sources */,
@@ -1876,6 +1883,7 @@
 			files = (
 				5733D1BF21BAA6E4002107D2 /* Dictionary+ExtTests.swift in Sources */,
 				FC7785C2200526D900EC879F /* AVFoundationPlaybackNowPlayingServiceTests.swift in Sources */,
+				57D80BAF2279E1F6003F72CD /* TVRemoteHandlerTests.swift in Sources */,
 				571B7B2B2175015F005C0942 /* AVURLAssetStub.swift in Sources */,
 				571B7B292175013F005C0942 /* AVFoundationPlaybackTests.swift in Sources */,
 				32755E2421503A830088724E /* PlaybackTests.swift in Sources */,

--- a/Example/Clappr_tvOS/ViewController.swift
+++ b/Example/Clappr_tvOS/ViewController.swift
@@ -25,8 +25,12 @@ class ViewController: UIViewController {
     }
 
     func listenToPlayerEvents() {
+        player.on(Event.willPlay) { _ in print("on willPlay") }
+
         player.on(Event.playing) { _ in print("on Play") }
 
+        player.on(Event.willPause) { _ in print("on willPause") }
+        
         player.on(Event.didPause) { _ in print("on Pause") }
 
         player.on(Event.didStop) { _ in print("on Stop") }

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -5,9 +5,10 @@ open class Player: UIViewController {
     fileprivate var playbackEventsListenIds: [String] = []
     fileprivate(set) var core: Core?
     static var hasAlreadyRegisteredPlaybacks = false
-    fileprivate var viewController: AVPlayerViewController?
+    fileprivate var viewController: AVPlayerViewController!
     private let baseObject = BaseObject()
     private var tvRemoteGesture: UITapGestureRecognizer?
+    private var tvRemoteHandler: TVRemoteHandler?
 
     override open func viewDidLoad() {
         core?.parentView = view
@@ -16,45 +17,19 @@ open class Player: UIViewController {
             viewController = AVPlayerViewController()
             core?.parentView = viewController?.contentOverlayView
             core?.parentController = self
-            if let vc = viewController {
-                addChild(vc)
-                vc.view.frame = view.bounds
-                vc.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-                view.addSubview(vc.view)
-                vc.didMove(toParent: self)
-                
-                addTvRemoveGestureIfNeeded(vc)
-            }
+            addChild(viewController)
+            viewController.view.frame = view.bounds
+            viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            view.addSubview(viewController.view)
+            viewController.didMove(toParent: self)
+
+            tvRemoteHandler = TVRemoteHandler(playerViewController: viewController, player: self)
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(Player.willEnterForeground), name:
             UIApplication.willEnterForegroundNotification, object: nil)
 
         core?.render()
-    }
-    
-    func addTvRemoveGestureIfNeeded(_ viewController: AVPlayerViewController) {
-        if let tvRemoteGesture = tvRemoteGesture,
-            let viewGestures = viewController.view.gestureRecognizers,
-            viewGestures.contains(tvRemoteGesture) {
-            return
-        }
-        
-        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTvRemoteGesture))
-        gestureRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.playPause.rawValue),
-                                               NSNumber(value: UIPress.PressType.select.rawValue)]
-        
-        viewController.view.addGestureRecognizer(gestureRecognizer)
-        self.tvRemoteGesture = gestureRecognizer
-    }
-
-    @objc func handleTvRemoteGesture() {
-        guard let playback = activePlayback as? AVFoundationPlayback else { return }
-        if playback.isPaused {
-            playback.play()
-        } else {
-            playback.pause()
-        }
     }
 
     open var isMediaControlEnabled: Bool {

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -7,6 +7,7 @@ open class Player: UIViewController {
     static var hasAlreadyRegisteredPlaybacks = false
     fileprivate var viewController: AVPlayerViewController?
     private let baseObject = BaseObject()
+    private var tvRemoteGesture: UITapGestureRecognizer?
 
     override open func viewDidLoad() {
         core?.parentView = view
@@ -21,6 +22,8 @@ open class Player: UIViewController {
                 vc.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
                 view.addSubview(vc.view)
                 vc.didMove(toParent: self)
+                
+                addTvRemoveGestureIfNeeded(vc)
             }
         }
 
@@ -28,6 +31,30 @@ open class Player: UIViewController {
             UIApplication.willEnterForegroundNotification, object: nil)
 
         core?.render()
+    }
+    
+    func addTvRemoveGestureIfNeeded(_ viewController: AVPlayerViewController) {
+        if let tvRemoteGesture = tvRemoteGesture,
+            let viewGestures = viewController.view.gestureRecognizers,
+            viewGestures.contains(tvRemoteGesture) {
+            return
+        }
+        
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTvRemoteGesture))
+        gestureRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.playPause.rawValue),
+                                               NSNumber(value: UIPress.PressType.select.rawValue)]
+        
+        viewController.view.addGestureRecognizer(gestureRecognizer)
+        self.tvRemoteGesture = gestureRecognizer
+    }
+
+    @objc func handleTvRemoteGesture() {
+        guard let playback = activePlayback as? AVFoundationPlayback else { return }
+        if playback.isPaused {
+            playback.play()
+        } else {
+            playback.pause()
+        }
     }
 
     open var isMediaControlEnabled: Bool {

--- a/Sources/Clappr_tvOS/Classes/Base/TVRemoteHandler.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/TVRemoteHandler.swift
@@ -1,0 +1,29 @@
+import AVKit
+
+class TVRemoteHandler {
+    weak var playerViewController: AVPlayerViewController?
+    weak var player: Player?
+
+    private var tvRemoteGesture: UITapGestureRecognizer?
+
+    init(playerViewController: AVPlayerViewController, player: Player) {
+        self.playerViewController = playerViewController
+        self.player = player
+
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTvRemoteGesture))
+        gestureRecognizer.allowedPressTypes = [NSNumber(value: UIPress.PressType.playPause.rawValue),
+                                               NSNumber(value: UIPress.PressType.select.rawValue)]
+
+        playerViewController.view.addGestureRecognizer(gestureRecognizer)
+        tvRemoteGesture = gestureRecognizer
+    }
+
+    @objc func handleTvRemoteGesture() {
+        guard let playback = player?.activePlayback else { return }
+        if playback.isPaused {
+            playback.play()
+        } else {
+            playback.pause()
+        }
+    }
+}

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -79,6 +79,36 @@ class PlayerTests: QuickSpec {
 
                 expect(Loader.shared.playbacks.first).to(be(AVFoundationPlayback.self))
             }
+            
+            context("when handleTvRemoteGesture is called") {
+                context("and media is playing") {
+                    it("pauses the playback") {
+                        var callbackWasCalled = false
+                        playback.play()
+                        player.on(.willPause) { _ in
+                            callbackWasCalled = true
+                        }
+                        
+                        player.handleTvRemoteGesture()
+                        
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                }
+                
+                context("and media is paused") {
+                    it("plays the playback") {
+                        var callbackWasCalled = false
+                        playback.pause()
+                        player.on(.willPlay) { _ in
+                            callbackWasCalled = true
+                        }
+                        
+                        player.handleTvRemoteGesture()
+                        
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                }
+            }
         }
     }
     

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -79,36 +79,6 @@ class PlayerTests: QuickSpec {
 
                 expect(Loader.shared.playbacks.first).to(be(AVFoundationPlayback.self))
             }
-            
-            context("when handleTvRemoteGesture is called") {
-                context("and media is playing") {
-                    it("pauses the playback") {
-                        var callbackWasCalled = false
-                        playback.play()
-                        player.on(.willPause) { _ in
-                            callbackWasCalled = true
-                        }
-                        
-                        player.handleTvRemoteGesture()
-                        
-                        expect(callbackWasCalled).to(beTrue())
-                    }
-                }
-                
-                context("and media is paused") {
-                    it("plays the playback") {
-                        var callbackWasCalled = false
-                        playback.pause()
-                        player.on(.willPlay) { _ in
-                            callbackWasCalled = true
-                        }
-                        
-                        player.handleTvRemoteGesture()
-                        
-                        expect(callbackWasCalled).to(beTrue())
-                    }
-                }
-            }
         }
     }
     

--- a/Tests/Clappr_tvOS_Tests/TVRemoteHandlerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/TVRemoteHandlerTests.swift
@@ -1,0 +1,90 @@
+import Quick
+import Nimble
+import AVKit
+
+@testable import Clappr
+
+class TVRemoteHandlerTests: QuickSpec {
+    static let specialSource = "specialSource"
+
+    override func spec() {
+        describe("TV Remote Controller Handler") {
+
+            let options = [kSourceUrl: "http://clappr.com/video.mp4"]
+
+            var player: Player!
+            var playback: Playback!
+            var playerViewController: AVPlayerViewController!
+            var handler: TVRemoteHandler!
+
+            beforeEach {
+                Loader.shared.resetPlugins()
+                player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+                playback = player.activePlayback
+                playerViewController = AVPlayerViewController()
+                handler = TVRemoteHandler(playerViewController: playerViewController, player: player)
+            }
+
+            describe("init") {
+                it("adds gesture recognizer on the view controller") {
+                    let playerViewController = AVPlayerViewController()
+                    let gestureCount = playerViewController.view.gestureRecognizers?.count ?? 0
+
+                    _ = TVRemoteHandler(playerViewController: playerViewController, player: player)
+
+                    expect(playerViewController.view.gestureRecognizers?.count).to(equal(gestureCount + 1))
+                }
+            }
+
+            describe("handleTvRemoteGesture") {
+                context("when media is playing") {
+                    it("pauses the playback") {
+                        var callbackWasCalled = false
+                        playback.play()
+                        player.on(.willPause) { _ in
+                            callbackWasCalled = true
+                        }
+
+                        handler.handleTvRemoteGesture()
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                }
+
+                context("when media is paused") {
+                    it("plays the playback") {
+                        var callbackWasCalled = false
+                        playback.pause()
+                        player.on(.willPlay) { _ in
+                            callbackWasCalled = true
+                        }
+
+                        handler.handleTvRemoteGesture()
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                }
+            }
+        }
+
+        class StubPlayback: Playback {
+            override var pluginName: String {
+                return "StubPlayback"
+            }
+
+            override class func canPlay(_: Options) -> Bool {
+                return true
+            }
+        }
+
+        class SpecialStubPlayback: Playback {
+            override var pluginName: String {
+                return "SpecialStubPlayback"
+            }
+
+            override class func canPlay(_ options: Options) -> Bool {
+                return options[kSourceUrl] as! String == PlayerTests.specialSource
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Problem
`willPlay` and `willPause` playback events are not been triggered on tvOS if users request it using the remote

### Goal
To trigger `willPlay` and `willPause` events on tvOS player

### How to test
1 - Check if those events are been triggered
2 - Run tests

