### PR TITLE
Add a way to listenTo events without having to pass in the event rawValue

### DIFF
--- a/Sources/Clappr/Classes/Base/BaseObject.swift
+++ b/Sources/Clappr/Classes/Base/BaseObject.swift
@@ -129,11 +129,15 @@ open class BaseObject: NSObject, EventProtocol {
 }
 
 public extension BaseObject {
-    public func trigger(_ event: Event) {
+    func trigger(_ event: Event) {
         trigger(event.rawValue)
     }
 
-    public func trigger(_ event: Event, userInfo: EventUserInfo) {
+    func trigger(_ event: Event, userInfo: EventUserInfo) {
         trigger(event.rawValue, userInfo: userInfo)
+    }
+
+    func listenTo<T: EventProtocol>(_ contextObject: T, event: Event, callback: @escaping EventCallback) {
+        listenTo(contextObject, eventName: event.rawValue, callback: callback)
     }
 }

--- a/Tests/Clappr_Tests/BaseObjectTests.swift
+++ b/Tests/Clappr_Tests/BaseObjectTests.swift
@@ -121,6 +121,16 @@ class BaseObjectTests: QuickSpec {
 
                     expect(callbackWasCalled) == true
                 }
+
+                it("Should fire callback for an event on a given context by passing the Event itself") {
+                    callbackWasCalled = false
+                    let contextObject = BaseObject()
+
+                    baseObject.listenTo(contextObject, event: .ready, callback: callback)
+                    contextObject.trigger(.ready)
+
+                    expect(callbackWasCalled) == true
+                }
             }
 
             describe("listenToOnce") {


### PR DESCRIPTION
## 🏁 Goal
- To reduce the "verbosity on listenTo events
- Remove the public keyword within a public extension to remove redundancy

## ✅ How to test
1. On any listenTo events, try to replace it with event: .eventName instead. Is should still work