### PR TITLE
Plugin.pluginName refactor

### DIFF
--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -4,12 +4,13 @@ open class Playback: UIObject, Plugin {
     open class var type: PluginType { return .playback }
 
     @objc open class var name: String {
-        return self.init().pluginName
+        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Playback Plugins should always declare a name", userInfo: nil).raise()
+        return ""
     }
 
     @objc open var pluginName: String {
-        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Playback Plugins should always declare a name", userInfo: nil).raise()
-        return ""
+        guard let selfType = theType(of: self) else { return "" }
+        return selfType.name
     }
 
     open var selectedSubtitle: MediaOption?

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -59,12 +59,6 @@ open class Playback: UIObject, Plugin {
         return false
     }
 
-    public required override init() {
-        options = [:]
-        super.init()
-        view.backgroundColor = UIColor.clear
-    }
-
     @objc public required init(options: Options) {
         Logger.logDebug("loading with \(options)", scope: "\(Swift.type(of: self))")
         self.options = options

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 
-open class Playback: UIObject, Plugin {
+open class Playback: UIObject, Nameable {
     open class var type: PluginType { return .playback }
 
     @objc open class var name: String {

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 
-open class Playback: UIObject, Nameable {
+open class Playback: UIObject, NamedType {
     open class var type: PluginType { return .playback }
 
     @objc open class var name: String {

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -8,11 +8,6 @@ open class Playback: UIObject, Plugin {
         return ""
     }
 
-    @objc open var pluginName: String {
-        guard let selfType = theType(of: self) else { return "" }
-        return selfType.name
-    }
-
     open var selectedSubtitle: MediaOption?
     open var selectedAudioSource: MediaOption?
     fileprivate(set) open var subtitles: [MediaOption]?

--- a/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
+++ b/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
@@ -13,11 +13,7 @@ open class PlaybackFactory {
         return playback.init(options: options)
     }
 
-    fileprivate func canPlay(_ type: Plugin.Type) -> Bool {
-        guard let type = type as? Playback.Type else {
-            return false
-        }
-
+    fileprivate func canPlay(_ type: Playback.Type) -> Bool {
         return type.canPlay(options)
     }
 }

--- a/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
+++ b/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
@@ -14,10 +14,6 @@ open class NoOpPlayback: Playback {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public required init() {
-        super.init()
-    }
-
     public required init(context _: UIObject) {
         fatalError("init(context:) has not been implemented")
     }

--- a/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
+++ b/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
@@ -1,7 +1,7 @@
 open class NoOpPlayback: Playback {
     fileprivate var errorLabel = UILabel(frame: CGRect.zero)
 
-    open override var pluginName: String {
+    open class override var name: String {
         return "NoOp"
     }
 

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -6,10 +6,6 @@ open class ContainerPlugin: BaseObject, Plugin {
         NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Container Plugins should always declare a name", userInfo: nil).raise()
         return ""
     }
-
-    public required override init() {
-        super.init()
-    }
     
     @objc public required init(context: UIObject) {
         super.init()

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -3,12 +3,13 @@ open class ContainerPlugin: BaseObject, Plugin {
     open class var type: PluginType { return .container }
 
     @objc open class var name: String {
-        return self.init().pluginName
+        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Container Plugins should always declare a name", userInfo: nil).raise()
+        return ""
     }
 
     @objc open var pluginName: String {
-        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Container Plugins should always declare a name", userInfo: nil).raise()
-        return ""
+        guard let selfType = theType(of: self) else { return "" }
+        return selfType.name
     }
 
     public required override init() {

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -7,11 +7,6 @@ open class ContainerPlugin: BaseObject, Plugin {
         return ""
     }
 
-    @objc open var pluginName: String {
-        guard let selfType = theType(of: self) else { return "" }
-        return selfType.name
-    }
-
     public required override init() {
         super.init()
     }

--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -6,10 +6,6 @@ open class SpinnerPlugin: UIContainerPlugin {
         return spinningWheel.isAnimating
     }
 
-    public required init() {
-        super.init()
-    }
-
     open class override var name: String {
         return "spinner"
     }

--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -10,7 +10,7 @@ open class SpinnerPlugin: UIContainerPlugin {
         super.init()
     }
 
-    open override var pluginName: String {
+    open class override var name: String {
         return "spinner"
     }
 

--- a/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
@@ -1,6 +1,6 @@
 open class UIContainerPlugin: ContainerPlugin, UIPlugin {
     var uiObject = UIObject()
-    
+
     public var view: UIView {
         get {
             return uiObject.view

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -7,11 +7,6 @@ open class CorePlugin: BaseObject, Plugin {
         return ""
     }
     
-    @objc open var pluginName: String {
-        guard let selfType = theType(of: self) else { return "" }
-        return selfType.name
-    }
-    
     public required override init() {
         super.init()
     }

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -7,10 +7,6 @@ open class CorePlugin: BaseObject, Plugin {
         return ""
     }
     
-    public required override init() {
-        super.init()
-    }
-    
     @objc public required init(context: UIObject) {
         super.init()
         if let core = context as? Core {

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -3,12 +3,13 @@ open class CorePlugin: BaseObject, Plugin {
     open class var type: PluginType { return .core }
     
     @objc open class var name: String {
-        return self.init().pluginName
+        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "CorePlugin Plugins should always declare a name", userInfo: nil).raise()
+        return ""
     }
     
     @objc open var pluginName: String {
-        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "CorePlugin Plugins should always declare a name", userInfo: nil).raise()
-        return ""
+        guard let selfType = theType(of: self) else { return "" }
+        return selfType.name
     }
     
     public required override init() {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -202,10 +202,6 @@ open class AVFoundationPlayback: Playback {
         fatalError("init(coder:) has not been implemented")
     }
 
-    public required init() {
-        super.init()
-    }
-
     public required init(context _: UIObject) {
         fatalError("init(context:) has not been implemented")
     }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -51,7 +51,7 @@ open class AVFoundationPlayback: Playback {
 
     private var backgroundSessionBackup: AVAudioSession.Category?
 
-    open override var pluginName: String {
+    open class override var name: String {
         return "AVPlayback"
     }
 

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -12,7 +12,7 @@ public func theType<T>(of value: T) -> Plugin.Type? {
 
 extension Plugin {
 
-    var pluginName: String {
+    public var pluginName: String {
         guard let selfType = theType(of: self) else { return "" }
         return selfType.name
     }

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -1,7 +1,6 @@
 public protocol Plugin: EventProtocol {
     static var type: PluginType { get }
     static var name: String { get }
-    init()
     init(context: UIObject)
     func destroy()
 }

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -6,3 +6,7 @@ public protocol Plugin: EventProtocol {
     init(context: UIObject)
     func destroy()
 }
+
+public func theType<T>(of value: T) -> Plugin.Type? {
+    return type(of: value) as? Plugin.Type
+}

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -1,18 +1,15 @@
-public protocol Plugin: EventProtocol {
+public protocol Plugin: EventProtocol, Nameable {
     static var type: PluginType { get }
-    static var name: String { get }
     init(context: UIObject)
     func destroy()
 }
 
-public func theType<T>(of value: T) -> Plugin.Type? {
-    return type(of: value) as? Plugin.Type
+public protocol Nameable {
+    static var name: String { get }
 }
 
-extension Plugin {
-
+extension Nameable {
     public var pluginName: String {
-        guard let selfType = theType(of: self) else { return "" }
-        return selfType.name
+        return type(of: self).name
     }
 }

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -1,7 +1,6 @@
 public protocol Plugin: EventProtocol {
     static var type: PluginType { get }
     static var name: String { get }
-    var pluginName: String { get }
     init()
     init(context: UIObject)
     func destroy()
@@ -9,4 +8,12 @@ public protocol Plugin: EventProtocol {
 
 public func theType<T>(of value: T) -> Plugin.Type? {
     return type(of: value) as? Plugin.Type
+}
+
+extension Plugin {
+
+    var pluginName: String {
+        guard let selfType = theType(of: self) else { return "" }
+        return selfType.name
+    }
 }

--- a/Sources/Clappr/Classes/Protocol/Plugin.swift
+++ b/Sources/Clappr/Classes/Protocol/Plugin.swift
@@ -1,14 +1,14 @@
-public protocol Plugin: EventProtocol, Nameable {
+public protocol Plugin: EventProtocol, NamedType {
     static var type: PluginType { get }
     init(context: UIObject)
     func destroy()
 }
 
-public protocol Nameable {
+public protocol NamedType {
     static var name: String { get }
 }
 
-extension Nameable {
+extension NamedType {
     public var pluginName: String {
         return type(of: self).name
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -3,8 +3,8 @@ import UIKit
 public class QuickSeekPlugin: UICorePlugin {
     
     var doubleTapGesture: UITapGestureRecognizer!
-    
-    override open var pluginName: String {
+
+    open class override var name: String {
         return "QuickSeekPlugin"
     }
     

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -20,10 +20,6 @@ public class QuickSeekPlugin: UICorePlugin {
         bindEvents()
     }
     
-    required init() {
-        super.init()
-    }
-  
     private func bindEvents() {
         stopListening()
         bindCoreEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -2,7 +2,7 @@ open class PosterPlugin: UIContainerPlugin {
     internal(set) var poster = UIImageView(frame: CGRect.zero)
     fileprivate var playButton = UIButton(frame: CGRect.zero)
 
-    open override var pluginName: String {
+    open override class var name: String {
         return "poster"
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -6,10 +6,6 @@ open class PosterPlugin: UIContainerPlugin {
         return "poster"
     }
 
-    public required init() {
-        super.init()
-    }
-
     public required init(context: UIObject) {
         super.init(context: context)
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
@@ -41,10 +41,6 @@ open class FullscreenButton: MediaControlPlugin {
         bindEvents()
     }
     
-    required public init() {
-        super.init()
-    }
-    
     private func bindEvents() {
         stopListening()
         bindCoreEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
@@ -24,7 +24,7 @@ open class FullscreenButton: MediaControlPlugin {
         }
     }
 
-    override open var pluginName: String {
+    open class override var name: String {
         return "FullscreenButton"
     }
     

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -38,10 +38,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         bindEvents()
     }
 
-    required public init() {
-        super.init()
-    }
-
     private func bindEvents() {
         stopListening()
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -17,7 +17,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         return core?.activePlayback
     }
 
-    override open var pluginName: String {
+    open class override var name: String {
         return "MediaControl"
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -1,5 +1,5 @@
 open class PlayButton: MediaControlPlugin {
-    override open var pluginName: String {
+    open class override var name: String {
         return "PlayButton"
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -37,10 +37,6 @@ open class PlayButton: MediaControlPlugin {
         bindEvents()
     }
 
-    required public init() {
-        super.init()
-    }
-
     private func bindEvents() {
         stopListening()
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public class QuickSeekMediaControlPlugin: QuickSeekPlugin {
     
-    override open var pluginName: String {
+    open class override var name: String {
         return "QuickSeekMediaControlPlugin"
     }
     

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Seekbar.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Seekbar.swift
@@ -28,10 +28,6 @@ class Seekbar: MediaControlPlugin {
         bindEvents()
     }
 
-    required init() {
-        super.init()
-    }
-
     private func bindEvents() {
         stopListening()
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Seekbar.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Seekbar.swift
@@ -1,6 +1,6 @@
 class Seekbar: MediaControlPlugin {
 
-    override var pluginName: String {
+    open override class var name: String {
         return "Seekbar"
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -1,5 +1,5 @@
 open class TimeIndicator: MediaControlPlugin {
-    override open var pluginName: String {
+    open class override var name: String {
         return "TimeIndicator"
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -70,10 +70,6 @@ open class TimeIndicator: MediaControlPlugin {
         bindEvents()
     }
 
-    required public init() {
-        super.init()
-    }
-
     private func bindEvents() {
         stopListening()
         bindContainerEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
@@ -2,7 +2,7 @@ import UIKit
 
 public class QuickSeekCorePlugin: QuickSeekPlugin {
     
-    override open var pluginName: String {
+    open class override var name: String {
         return "QuickSeekCorePlugin"
     }
     

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -26,7 +26,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 player = AVPlayerStub()
                 player.set(currentItem: item)
 
-                playback = AVFoundationPlayback()
+                playback = AVFoundationPlayback(options: [:])
                 playback.player = player
                 
                 stub(condition: isHost("clappr.sample")) { result in
@@ -445,7 +445,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     player = AVPlayerStub()
                     player.set(currentItem: item)
 
-                    playback = AVFoundationPlayback()
+                    playback = AVFoundationPlayback(options: [:])
                     playback.player = player
                 }
 
@@ -575,7 +575,7 @@ class AVFoundationPlaybackTests: QuickSpec {
             describe("#isReadyToSeek") {
                 context("when AVPlayer status is readyToPlay") {
                     it("returns true") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
                         let playerStub = AVPlayerStub()
                         playback.player = playerStub
 
@@ -588,7 +588,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 context("when AVPlayer status is unknown") {
 
                     it("returns false") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
                         let playerStub = AVPlayerStub()
                         playback.player = playerStub
 
@@ -601,7 +601,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 context("when AVPlayer status is failed") {
 
                     it("returns false") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
                         let playerStub = AVPlayerStub()
                         playback.player = playerStub
 
@@ -652,7 +652,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 context("when AVPlayer status is readyToPlay") {
 
                     it("doesn't store the desired seek time") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
                         let player = AVPlayerStub()
                         player.setStatus(to: .readyToPlay)
                         playback.player = player
@@ -663,7 +663,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
 
                     it("calls seek right away") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
                         let player = AVPlayerStub()
                         player.setStatus(to: .readyToPlay)
                         playback.player = player
@@ -677,7 +677,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 context("when AVPlayer status is not readyToPlay") {
 
                     it("stores the desired seek time") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
 
                         playback.seek(20)
 
@@ -685,7 +685,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
 
                     it("doesn't calls seek right away") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
                         let player = AVPlayerStub()
                         playback.player = player
 
@@ -713,7 +713,7 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     context("when seekToTimeWhenReadyToPlay is nil") {
                         it("doesnt perform a seek") {
-                            let playback = AVFoundationPlayback()
+                            let playback = AVFoundationPlayback(options: [:])
                             let player = AVPlayerStub()
                             playback.player = player
                             player.setStatus(to: .readyToPlay)
@@ -727,7 +727,7 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     context("when seekToTimeWhenReadyToPlay is not nil") {
                         it("does perform a seek") {
-                            let playback = AVFoundationPlayback()
+                            let playback = AVFoundationPlayback(options: [:])
                             let player = AVPlayerStub()
                             playback.player = player
                             player.setStatus(to: .unknown)
@@ -743,7 +743,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 it("triggers willSeek event") {
-                    let playback = AVFoundationPlayback()
+                    let playback = AVFoundationPlayback(options: [:])
                     let player = AVPlayerStub()
                     playback.player = player
                     player.setStatus(to: .readyToPlay)
@@ -758,7 +758,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 it("triggers didSeek when a seek is completed") {
-                    let playback = AVFoundationPlayback()
+                    let playback = AVFoundationPlayback(options: [:])
                     let player = AVPlayerStub()
                     playback.player = player
                     player.setStatus(to: .readyToPlay)
@@ -773,7 +773,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 it("triggers didUpdatePosition for the desired position") {
-                    let playback = AVFoundationPlayback()
+                    let playback = AVFoundationPlayback(options: [:])
                     let player = AVPlayerStub()
                     playback.player = player
                     player.setStatus(to: .readyToPlay)
@@ -788,7 +788,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
                 
                 it("triggers didUpdatePosition before didSeek event") {
-                    let playback = AVFoundationPlayback()
+                    let playback = AVFoundationPlayback(options: [:])
                     let player = AVPlayerStub()
                     playback.player = player
                     player.setStatus(to: .readyToPlay)
@@ -818,7 +818,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                 var playerItem: AVPlayerItemStub!
                 
                 beforeEach {
-                    playback = AVFoundationPlayback()
+                    playback = AVFoundationPlayback(options: [:])
                     let url = URL(string: "http://clappr.sample/master.m3u8")!
                     let playerAsset = AVURLAssetStub(url: url)
                     playerItem = AVPlayerItemStub(asset: playerAsset)

--- a/Tests/Clappr_Tests/AVFoundationPlaybackViewPortTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackViewPortTests.swift
@@ -10,7 +10,7 @@ class AVFoundationPlaybackViewPortTests: QuickSpec {
             if #available(iOS 11.0, *) {
                 context("#setupMaxResolution") {
                     it("sets preferredMaximumResolution according to the size") {
-                        let playback = AVFoundationPlayback()
+                        let playback = AVFoundationPlayback(options: [:])
                         playback.player = AVPlayerStub()
                         var expectedSize = CGSize(width: 200, height: 200)
 

--- a/Tests/Clappr_Tests/Classes/Extensions/Array+appendOrReplaceTests.swift
+++ b/Tests/Clappr_Tests/Classes/Extensions/Array+appendOrReplaceTests.swift
@@ -52,37 +52,37 @@ class ArrayAppendOrReplaceTests: QuickSpec {
 }
 
 class PluginA: UIContainerPlugin {
-    override static var name: String {
+    override class var name: String {
         return "pluginA"
     }
 }
 
 class PluginB: UIContainerPlugin {
-    override static var name: String {
+    override class var name: String {
         return "pluginB"
     }
 }
 
 class PluginAReplace: UIContainerPlugin {
-    override static var name: String {
+    override class var name: String {
         return "pluginA"
     }
 }
 
 class PlaybackA: Playback {
-    override static var name: String {
+    override class var name: String {
         return "playbackA"
     }
 }
 
 class PlaybackB: Playback {
-    override static var name: String {
+    override class var name: String {
         return "playbackB"
     }
 }
 
 class PlaybackAReplace: Playback {
-    override static var name: String {
+    override class var name: String {
         return "playbackA"
     }
 }

--- a/Tests/Clappr_Tests/Classes/Plugins/Container/UIContainerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Container/UIContainerPluginTests.swift
@@ -46,7 +46,7 @@ class UIContainerPluginTests: QuickSpec {
     }
     
     class StubContainerPlugin: UIContainerPlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "StubContainerPlugin"
         }
     }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/FullscreenButtonTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/FullscreenButtonTests.swift
@@ -8,12 +8,13 @@ class FullscreenButtonTests: QuickSpec {
         describe(".FullscreenButton") {
             var fullscreenButton: FullscreenButton!
             var core: Core!
-            
+
+            beforeEach {
+                core = CoreStub()
+                fullscreenButton = FullscreenButton(context: core)
+            }
+
             describe("properties") {
-                beforeEach {
-                    fullscreenButton = FullscreenButton()
-                }
-                
                 describe("pluginName") {
                     it("has a name") {
                         expect(fullscreenButton.pluginName).to(equal("FullscreenButton"))
@@ -115,8 +116,6 @@ class FullscreenButtonTests: QuickSpec {
             
             context("when the player is on fullscreen mode") {
                 beforeEach {
-                    core = Core()
-                    fullscreenButton = FullscreenButton(context: core)
                     fullscreenButton.render()
                     core.trigger(Event.didEnterFullscreen.rawValue)
                 }
@@ -137,8 +136,6 @@ class FullscreenButtonTests: QuickSpec {
             
             context("when the player is on embed mode") {
                 beforeEach {
-                    core = Core()
-                    fullscreenButton = FullscreenButton(context: core)
                     fullscreenButton.render()
                     core.trigger(Event.didExitFullscreen.rawValue)
                 }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlPluginTests.swift
@@ -5,16 +5,20 @@ import Nimble
 
 class MediaControlPluginTests: QuickSpec {
     override func spec() {
+        var mediaControlPlugin: MediaControlPlugin!
+        var core: Core!
+
+        beforeEach {
+            core = CoreStub()
+            mediaControlPlugin = MediaControlPlugin(context: core)
+        }
+
         describe("MediaControlPlugin") {
             it("is a UICorePlugin") {
-                let mediaControlPlugin = MediaControlPlugin()
-
                 expect(mediaControlPlugin).to(beAKindOf(UICorePlugin.self))
             }
 
             it("has a view") {
-                let mediaControlPlugin = MediaControlPlugin()
-
                 expect(mediaControlPlugin.view).to(beAKindOf(UIView.self))
                 expect(mediaControlPlugin.view).toNot(beNil())
             }
@@ -22,8 +26,6 @@ class MediaControlPluginTests: QuickSpec {
 
         describe("panel") {
             it("is a MediaControlPanel type") {
-                let mediaControlPlugin = MediaControlPlugin()
-
                 expect(mediaControlPlugin.panel).to(beAKindOf(MediaControlPanel.self))
             }
 
@@ -37,8 +39,6 @@ class MediaControlPluginTests: QuickSpec {
 
         describe("position") {
             it("is a MediaControlPosition type") {
-                let mediaControlPlugin = MediaControlPlugin()
-
                 expect(mediaControlPlugin.position).to(beAKindOf(MediaControlPosition.self))
             }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -6,43 +6,40 @@ import Nimble
 class MediaControlTests: QuickSpec {
     override func spec() {
         describe(".MediaControl") {
+            var coreStub: CoreStub!
+            var mediaControl: MediaControl!
+
+            beforeEach {
+                coreStub = CoreStub()
+                mediaControl = MediaControl(context: coreStub)
+            }
+
             describe("pluginName") {
                 it("returns the pluginName") {
-                    let mediaControl = MediaControl()
-
                     expect(mediaControl.pluginName).to(equal("MediaControl"))
                 }
             }
 
             describe("#animationDuration") {
                 it("is 0.3 seconds") {
-                    let mediaControl = MediaControl()
-
                     expect(ClapprAnimationDuration.mediaControlShow).to(equal(0.3))
                 }
             }
 
             describe("#secondsToHideControlFast") {
                 it("is 0.4 seconds") {
-                    let mediaControl = MediaControl()
-
                     expect(mediaControl.shortTimeToHideMediaControl).to(equal(0.4))
                 }
             }
 
             describe("#secondsToHideControlSlow") {
                 it("is 4 seconds") {
-                    let mediaControl = MediaControl()
-
                     expect(mediaControl.longTimeToHideMediaControl).to(equal(4))
                 }
             }
 
             describe("#view") {
                 it("has 1 gesture recognizer") {
-                    let coreStub = CoreStub()
-                    let mediaControl = MediaControl(context: coreStub)
-
                     mediaControl.render()
 
                     expect(mediaControl.view.gestureRecognizers?.count).to(equal(1))
@@ -51,8 +48,6 @@ class MediaControlTests: QuickSpec {
 
             describe("#tapped") {
                 it("hides the mediacontrol and stop timer") {
-                    let coreStub = CoreStub()
-                    let mediaControl = MediaControl(context: coreStub)
                     mediaControl.render()
 
                     mediaControl.tapped()
@@ -77,31 +72,19 @@ class MediaControlTests: QuickSpec {
             }
 
             describe("#render") {
-                var coreStub: CoreStub!
-
-                beforeEach {
-                    coreStub = CoreStub()
-                }
-
                 it("starts hidden") {
-                    let mediaControl = MediaControl(context: coreStub)
-
                     mediaControl.render()
 
                     expect(mediaControl.view.isHidden).to(beTrue())
                 }
 
                 it("has clear background") {
-                    let mediaControl = MediaControl(context: coreStub)
-
                     mediaControl.render()
 
                     expect(mediaControl.view.backgroundColor).to(equal(UIColor.clear))
                 }
 
                 it("has constrastView with black background with 60% of opacity") {
-                    let mediaControl = MediaControl(context: coreStub)
-
                     mediaControl.render()
 
                     expect(mediaControl.mediaControlView.contrastView.backgroundColor).to(equal(UIColor.clapprBlack60Color()))
@@ -110,17 +93,14 @@ class MediaControlTests: QuickSpec {
                 it("fills the superview") {
                     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                     let superview = UIView(frame: frame)
-                    let mediaControl = MediaControl(context: coreStub)
-
                     superview.addSubview(mediaControl.view)
+
                     mediaControl.render()
 
                     expect(superview.constraints.count).to(equal(4))
                 }
 
                 it("inflates the MediaControl xib in the view") {
-                    let mediaControl = MediaControl(context: coreStub)
-
                     mediaControl.render()
 
                     expect(mediaControl.mediaControlView).to(beAKindOf(MediaControlView.self))
@@ -141,13 +121,7 @@ class MediaControlTests: QuickSpec {
             }
 
             describe("Events") {
-                var coreStub: CoreStub!
-                var mediaControl: MediaControl!
-
                 beforeEach {
-                    coreStub = CoreStub()
-
-                    mediaControl = MediaControl(context: coreStub)
                     mediaControl.mediaControlShow = 0.1
                     mediaControl.mediaControlHide = 0.1
                     mediaControl.shortTimeToHideMediaControl = 0.1
@@ -339,13 +313,11 @@ class MediaControlTests: QuickSpec {
             
             describe("show") {
                 it("triggers willShowMediaControl before showing the view") {
-                    let core = CoreStub()
-                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     
                     mediaControl.render()
-                    core.on(Event.willShowMediaControl.rawValue) { _ in
+                    coreStub.on(Event.willShowMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.view.isHidden
                     }
@@ -356,13 +328,11 @@ class MediaControlTests: QuickSpec {
                 }
                 
                 it("triggers didShowMediaControl after showing the view") {
-                    let core = CoreStub()
-                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     mediaControl.view.isHidden = true
                     
-                    core.on(Event.didShowMediaControl.rawValue) { _ in
+                    coreStub.on(Event.didShowMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.view.isHidden
                     }
@@ -375,12 +345,10 @@ class MediaControlTests: QuickSpec {
             
             describe("hide") {
                 it("triggers willHideMediaControl before hiding the view") {
-                    let core = CoreStub()
-                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     
-                    core.on(Event.willHideMediaControl.rawValue) { _ in
+                    coreStub.on(Event.willHideMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.view.isHidden
                     }
@@ -391,12 +359,10 @@ class MediaControlTests: QuickSpec {
                 }
                 
                 it("triggers didHideMediaControl after showing the view") {
-                    let core = CoreStub()
-                    let mediaControl = MediaControl(context: core)
                     var eventTriggered = false
                     var viewIsVisible: Bool?
                     
-                    core.on(Event.didHideMediaControl.rawValue) { _ in
+                    coreStub.on(Event.didHideMediaControl.rawValue) { _ in
                         eventTriggered = true
                         viewIsVisible = !mediaControl.view.isHidden
                     }
@@ -409,20 +375,17 @@ class MediaControlTests: QuickSpec {
 
             describe("renderPlugins") {
                 var plugins: [MediaControlPlugin]!
-                var core: Core!
                 var mediaControlViewMock: MediaControlViewMock!
 
                 beforeEach {
-                    plugins = [MediaControlPluginMock()]
-
-                    core = Core(options: [:])
+                    plugins = [MediaControlPluginMock(context: coreStub)]
                     mediaControlViewMock = MediaControlViewMock()
                     MediaControlPluginMock.reset()
                 }
 
                 context("for any plugin configuration") {
                     it("always calls the MediaControlView to position the view") {
-                        let mediaControl = MediaControl(context: core)
+                        let mediaControl = MediaControl(context: coreStub)
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
                         
@@ -432,7 +395,6 @@ class MediaControlTests: QuickSpec {
                     }
 
                     it("always calls the MediaControlView passing the plugin's view") {
-                        let mediaControl = MediaControl(context: core)
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
                         
@@ -443,7 +405,6 @@ class MediaControlTests: QuickSpec {
 
                     it("always calls the MediaControlView passing the plugin's panel") {
                         MediaControlPluginMock._panel = .center
-                        let mediaControl = MediaControl(context: core)
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
                         
@@ -454,7 +415,6 @@ class MediaControlTests: QuickSpec {
 
                     it("always calls the MediaControlView passing the plugin's position") {
                         MediaControlPluginMock._position = .left
-                        let mediaControl = MediaControl(context: core)
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
 
@@ -465,7 +425,6 @@ class MediaControlTests: QuickSpec {
 
                     it("always calls the method render") {
                         MediaControlPluginMock._panel = .top
-                        let mediaControl = MediaControl(context: core)
                         mediaControl.render()
                         
                         mediaControl.renderPlugins(plugins)
@@ -475,7 +434,6 @@ class MediaControlTests: QuickSpec {
 
                     it("protect the main thread when plugin crashes in render") {
                         MediaControlPluginMock.crashOnRender = true
-                        let mediaControl = MediaControl(context: core)
                         mediaControl.render()
 
                         mediaControl.renderPlugins(plugins)
@@ -486,6 +444,7 @@ class MediaControlTests: QuickSpec {
 
                 context("when kMediaControlPluginsOrder is passed") {
                     it("renders the plugins following the kMediaControlPluginsOrder with all plugins specified in the option") {
+                        let core = Core()
                         core.options[kMediaControlPluginsOrder] = ["FullscreenButton", "TimeIndicatorPluginMock", "SecondPlugin", "FirstPlugin"]
                         let plugins = [FirstPlugin(context: core), SecondPlugin(context: core), TimeIndicatorPluginMock(context: core), FullscreenButton(context: core), ]
                         let mediaControl = MediaControl(context: core)
@@ -501,6 +460,7 @@ class MediaControlTests: QuickSpec {
                     }
 
                     it("renders the plugins following the kMediaControlPluginsOrder with only two plugins specified in the option") {
+                        let core = Core()
                         core.options[kMediaControlPluginsOrder] = ["FullscreenButton", "TimeIndicatorPluginMock"]
                         let plugins = [FirstPlugin(context: core), SecondPlugin(context: core), TimeIndicatorPluginMock(context: core), FullscreenButton(context: core), ]
                         let mediaControl = MediaControl(context: core)

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -540,7 +540,7 @@ class MediaControlPluginMock: MediaControlPlugin {
     static var didCallRender = false
     static var crashOnRender = false
     
-    override var pluginName: String {
+    override class var name: String {
         return "MediaControlPluginMock"
     }
     
@@ -570,7 +570,7 @@ class MediaControlPluginMock: MediaControlPlugin {
 }
 
 class TimeIndicatorPluginMock: TimeIndicator {
-    override var pluginName: String {
+    override class var name: String {
         return "TimeIndicatorPluginMock"
     }
 
@@ -584,7 +584,7 @@ class TimeIndicatorPluginMock: TimeIndicator {
 }
 
 class FirstPlugin: MediaControlPlugin {
-    override var pluginName: String {
+    override class var name: String {
         return "FirstPlugin"
     }
     
@@ -609,7 +609,7 @@ class FirstPlugin: MediaControlPlugin {
 }
 
 class SecondPlugin: MediaControlPlugin {
-    override var pluginName: String {
+    override class var name: String {
         return "SecondPlugin"
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/Seekbar/SeekbarTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/Seekbar/SeekbarTests.swift
@@ -6,34 +6,34 @@ import CoreMedia
 
 class SeekbarTests: QuickSpec {
     override func spec() {
+        var coreStub: CoreStub!
+        var seekbar: Seekbar!
+
+        beforeEach {
+            coreStub = CoreStub()
+            seekbar = Seekbar(context: coreStub)
+        }
+
         describe("Seekbar") {
             it("is a MediaControlPlugin") {
-                let seekbar = Seekbar()
-
                 expect(seekbar).to(beAKindOf(MediaControlPlugin.self))
             }
         }
 
         describe("#pluginName") {
             it("is Seekbar") {
-                let seekbar = Seekbar()
-
                 expect(seekbar.pluginName).to(equal("Seekbar"))
             }
         }
 
         describe("#panel") {
             it("is positioned in the bottom panel") {
-                let seekbar = Seekbar()
-
                 expect(seekbar.panel).to(equal(MediaControlPanel.bottom))
             }
         }
 
         describe("#position") {
             it("is positioned in the left side") {
-                let seekbar = Seekbar()
-
                 expect(seekbar.position).to(equal(MediaControlPosition.none))
             }
         }
@@ -41,9 +41,6 @@ class SeekbarTests: QuickSpec {
         describe("#seek") {
             context("when VOD") {
                 it("calls activePlayback seek with the correct value") {
-                    let coreStub = CoreStub()
-                    let seekbar = Seekbar(context: coreStub)
-
                     seekbar.seek(10)
 
                     expect(coreStub.playbackMock?.didCallSeek).to(beTrue())
@@ -53,8 +50,6 @@ class SeekbarTests: QuickSpec {
 
             context("when LIVE and the user seeks to the end") {
                 it("seeks to infinity to resync live broadcast") {
-                    let coreStub = CoreStub()
-                    let seekbar = Seekbar(context: coreStub)
                     coreStub.playbackMock?.videoDuration = 10
                     coreStub.playbackMock?.set(isDvrInUse: true)
 
@@ -67,11 +62,7 @@ class SeekbarTests: QuickSpec {
 
         describe("#render") {
 
-            var seekbar: Seekbar!
-
             beforeEach {
-                seekbar = Seekbar()
-
                 seekbar.render()
             }
 
@@ -97,8 +88,6 @@ class SeekbarTests: QuickSpec {
             describe("when a video is playing") {
 
                 it("sets the SeekbarView to live") {
-                    let coreStub = CoreStub()
-                    let seekbar = Seekbar(context: coreStub)
                     seekbar.seekbarView.isLive = true
 
                     seekbar.render()
@@ -111,8 +100,6 @@ class SeekbarTests: QuickSpec {
                 }
 
                 it("sets the SeekbarView to VOD") {
-                    let coreStub = CoreStub()
-                    let seekbar = Seekbar(context: coreStub)
                     seekbar.seekbarView.isLive = false
 
                     seekbar.render()
@@ -127,14 +114,9 @@ class SeekbarTests: QuickSpec {
             }
 
             describe("Events") {
-                var coreStub: CoreStub!
-                var seekbar: Seekbar!
                 var seekbarViewMock: SeekbarViewMock!
 
                 beforeEach {
-                    coreStub = CoreStub()
-                    seekbar = Seekbar(context: coreStub)
-
                     seekbar.render()
                 }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/TimeIndicatorTests.swift
@@ -5,44 +5,39 @@ import Nimble
 
 class TimeIndicatorTests: QuickSpec {
     override func spec() {
+        var timeIndicator: TimeIndicator!
+        var coreStub: CoreStub!
+
+        beforeEach {
+            coreStub = CoreStub()
+            timeIndicator = TimeIndicator(context: coreStub)
+        }
+
         describe(".TimeIndicatorTests") {
             it("is a MediaControlPlugin") {
-                let timeIndicator = TimeIndicator()
-
                 expect(timeIndicator).to(beAKindOf(MediaControlPlugin.self))
             }
 
             describe("#pluginName") {
                 it("is TimeIndicator") {
-                    let timeIndicator = TimeIndicator()
-
                     expect(timeIndicator.pluginName).to(equal("TimeIndicator"))
                 }
             }
 
             describe("#panel") {
                 it("is positioned in the bottom panel") {
-                    let timeIndicator = TimeIndicator()
-
                     expect(timeIndicator.panel).to(equal(MediaControlPanel.bottom))
                 }
             }
 
             describe("#position") {
                 it("is positioned in the left side") {
-                    let timeIndicator = TimeIndicator()
-
                     expect(timeIndicator.position).to(equal(MediaControlPosition.left))
                 }
             }
 
             describe("#render") {
-
-                var timeIndicator: TimeIndicator!
-
                 beforeEach {
-                    timeIndicator = TimeIndicator()
-
                     timeIndicator.render()
                 }
 
@@ -123,13 +118,7 @@ class TimeIndicatorTests: QuickSpec {
             }
 
             describe("when playback receives didUpdateDuration event") {
-                var coreStub: CoreStub!
-                var timeIndicator: TimeIndicator!
-
                 beforeEach {
-                    coreStub = CoreStub()
-                    timeIndicator = TimeIndicator(context: coreStub)
-
                     timeIndicator.render()
                 }
 
@@ -167,14 +156,8 @@ class TimeIndicatorTests: QuickSpec {
             }
 
             describe("Fullscreen") {
-                var coreStub: CoreStub!
-                var timeIndicator: TimeIndicator!
-
                 beforeEach {
                     Loader.shared.resetPlugins()
-                    coreStub = CoreStub()
-                    timeIndicator = TimeIndicator(context: coreStub)
-
                     timeIndicator.render()
                 }
 

--- a/Tests/Clappr_Tests/Classes/Stubs/ContainerPluginStub.swift
+++ b/Tests/Clappr_Tests/Classes/Stubs/ContainerPluginStub.swift
@@ -1,7 +1,7 @@
 @testable import Clappr
 
 class ContainerPluginStub: ContainerPlugin {
-    override var pluginName: String {
+    override class var name: String {
         return "ContainerPluginStub"
     }
 }

--- a/Tests/Clappr_Tests/Classes/Stubs/ContainerStub.swift
+++ b/Tests/Clappr_Tests/Classes/Stubs/ContainerStub.swift
@@ -14,5 +14,5 @@ class ContainerStub: Container {
         super.trigger(eventName)
     }
     
-    var _playback: Playback? = AVFoundationPlaybackMock()
+    var _playback: Playback? = AVFoundationPlaybackMock(options:[:])
 }

--- a/Tests/Clappr_Tests/Classes/Stubs/CorePluginStub.swift
+++ b/Tests/Clappr_Tests/Classes/Stubs/CorePluginStub.swift
@@ -1,7 +1,7 @@
 @testable import Clappr
 
 class CorePluginStub: CorePlugin {
-    override var pluginName: String {
+    override class var name: String {
         return "CorePluginStub"
     }
 }

--- a/Tests/Clappr_Tests/Classes/Stubs/UIPluginStub.swift
+++ b/Tests/Clappr_Tests/Classes/Stubs/UIPluginStub.swift
@@ -8,8 +8,6 @@ class UIPluginStub: BaseObject, UIPlugin {
     
     static var name: String = "UIPluginStub"
     
-    var pluginName: String = "UIPluginStub"
-    
     required override init() { }
     
     required init(context: UIObject) { }

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -371,7 +371,7 @@ class ContainerTests: QuickSpec {
     }
 
     class StubPlayback: Playback {
-        override var pluginName: String {
+        override class var name: String {
             return "AVPlayback"
         }
 
@@ -385,7 +385,7 @@ class ContainerTests: QuickSpec {
     }
 
     class FakeContainerPlugin: ContainerPlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "FakeContainerPlugin"
         }
 
@@ -400,7 +400,7 @@ class ContainerTests: QuickSpec {
         static var didCallDestroy = false
         static var crashOnDestroy = false
 
-        override var pluginName: String {
+         override class var name: String {
             return "AnotherFakeContainerPlugin"
         }
 

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -143,7 +143,7 @@ class ContainerTests: QuickSpec {
                     let expectation = QuickSpec.current.expectation(description: "doesn't crash")
                     AnotherFakeContainerPlugin.crashOnRender = true
                     let container = Container()
-                    let plugin = AnotherFakeContainerPlugin()
+                    let plugin = AnotherFakeContainerPlugin(context: container)
                     container.addPlugin(plugin)
 
                     container.render()
@@ -214,7 +214,7 @@ class ContainerTests: QuickSpec {
                     var countOfDestroyedPlugins = 0
 
                     container.plugins.forEach { plugin in
-                        plugin.on(Event.didDestroy.rawValue) { _ in
+                        _ = plugin.on(Event.didDestroy.rawValue) { _ in
                             countOfDestroyedPlugins += 1
                         }
                     }
@@ -229,7 +229,7 @@ class ContainerTests: QuickSpec {
                     let expectation = QuickSpec.current.expectation(description: "doesn't crash")
                     AnotherFakeContainerPlugin.crashOnDestroy = true
                     let container = Container()
-                    let plugin = AnotherFakeContainerPlugin()
+                    let plugin = AnotherFakeContainerPlugin(context: container)
                     container.addPlugin(plugin)
 
                     container.destroy()

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -23,7 +23,7 @@ class CoreTests: QuickSpec {
         beforeEach {
             core = Core(options: options as Options)
             Loader.shared.resetPlugins()
-            Loader.shared.register(plugins: [StubPlayback.self])
+            Loader.shared.register(playbacks: [StubPlayback.self])
         }
 
         describe(".Core") {

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -588,7 +588,7 @@ class CoreTests: QuickSpec {
                     }
 
                     core.activeContainer = container
-                    core.activeContainer?.playback = AVFoundationPlayback()
+                    core.activeContainer?.playback = AVFoundationPlayback(options: [:])
                     expect(didCallEvent).toEventually(beTrue())
                 }
 
@@ -602,7 +602,7 @@ class CoreTests: QuickSpec {
                     }
 
                     core.activeContainer = container
-                    core.activeContainer?.playback = AVFoundationPlayback()
+                    core.activeContainer?.playback = AVFoundationPlayback(options: [:])
                     expect(didCallEvent).toEventually(beTrue())
                 }
             }
@@ -641,13 +641,13 @@ class CoreTests: QuickSpec {
                     var didCallEvent = false
 
                     core.activeContainer = container
-                    core.activeContainer?.playback = AVFoundationPlayback()
+                    core.activeContainer?.playback = AVFoundationPlayback(options: [:])
                     container.on(Event.didChangeActivePlayback.rawValue)   { userInfo in
                         didCallEvent = true
                     }
 
                     core.activeContainer = container
-                    container.playback = AVFoundationPlayback()
+                    container.playback = AVFoundationPlayback(options: [:])
 
                     expect(didCallEvent).toEventually(beFalse())
                 }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -6,13 +6,13 @@ class CoreTests: QuickSpec {
     override func spec() {
 
         class StubPlayback: Playback {
-            override var pluginName: String {
+            override class var name: String {
                 return "stupPlayback"
             }
         }
 
         class FakeCorePlugin: UICorePlugin {
-            override var pluginName: String {
+            override class var name: String {
                 return "FakeCorePLugin"
             }
         }
@@ -742,7 +742,7 @@ class UICorePluginMock: UICorePlugin {
     static var didCallDestroy = false
     static var crashOnDestroy = false
 
-    override var pluginName: String {
+    override class var name: String {
         return "UICorePluginMock"
     }
 
@@ -773,7 +773,7 @@ class UICorePluginMock: UICorePlugin {
 }
 
 class CorePluginMock: CorePlugin {
-    override var pluginName: String {
+    override class var name: String {
         return "CorePluginMock"
     }
 }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -566,7 +566,7 @@ class CoreTests: QuickSpec {
                     let expectation = QuickSpec.current.expectation(description: "doesn't crash")
                     UICorePluginMock.crashOnDestroy = true
                     let core = Core()
-                    let plugin = UICorePluginMock()
+                    let plugin = UICorePluginMock(context: core)
                     core.addPlugin(plugin)
 
                     core.destroy()
@@ -656,7 +656,7 @@ class CoreTests: QuickSpec {
             describe("#render") {
                 it("add plugin as subview after rendered") {
                     let core = Core()
-                    let plugin = FakeCorePlugin()
+                    let plugin = FakeCorePlugin(context: core)
                     
                     core.addPlugin(plugin)
                     core.render()
@@ -667,7 +667,7 @@ class CoreTests: QuickSpec {
                 #if os(iOS)
                 it("doesnt add plugin as subview if it is a MediaControlPlugin") {
                     let core = Core()
-                    let plugin = MediaControlPluginMock()
+                    let plugin = MediaControlPluginMock(context: core)
                     
                     core.addPlugin(plugin)
                     core.render()
@@ -677,8 +677,8 @@ class CoreTests: QuickSpec {
                 
                 it("calls the mediacontrol to add the plugins into the panels") {
                     let core = CoreFactory.create(with: [:])
-                    let mediaControlMock = MediaControlMock()
-                    let mediaControlPluginMock = MediaControlPluginMock()
+                    let mediaControlMock = MediaControlMock(context: core)
+                    let mediaControlPluginMock = MediaControlPluginMock(context: core)
                     
                     core.addPlugin(mediaControlMock)
                     core.addPlugin(mediaControlPluginMock)
@@ -692,7 +692,7 @@ class CoreTests: QuickSpec {
                     let expectation = QuickSpec.current.expectation(description: "doesn't crash")
                     UICorePluginMock.crashOnRender = true
                     let core = Core()
-                    let plugin = UICorePluginMock()
+                    let plugin = UICorePluginMock(context: core)
                     core.addPlugin(plugin)
 
                     core.render()

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -87,31 +87,31 @@ class LoaderTests: QuickSpec {
     }
 
     class StubPlayback: Playback {
-        override var pluginName: String {
+        override class var name: String {
             return "stupPlayback"
         }
     }
 
     class StubUIContainerPlugin: UIContainerPlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "uicontainer"
         }
     }
 
     class StubUICorePlugin: UICorePlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "uicore"
         }
     }
 
     class StubSpinnerPlugin: UIContainerPlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "spinner"
         }
     }
     
     class StubCorePlugin: CorePlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "core"
         }
     }

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -10,6 +10,7 @@ class LoaderTests: QuickSpec {
 
             beforeEach {
                 Loader.shared.resetPlugins()
+                Loader.shared.resetPlaybacks()
             }
 
             context("when adds external playbacks") {

--- a/Tests/Clappr_Tests/NoOpPlaybackTests.swift
+++ b/Tests/Clappr_Tests/NoOpPlaybackTests.swift
@@ -11,7 +11,7 @@ class NoOpPlaybackTests: QuickSpec {
         describe(".NoOpPlayback") {
             describe("#render") {
                 it("doesn't trigger ready event") {
-                    let playback = NoOpPlayback()
+                    let playback = NoOpPlayback(options: [:])
                     var didCallEvent = false
                     playback.on(Event.ready.rawValue) { _ in
                         didCallEvent = true

--- a/Tests/Clappr_Tests/PlayButtonTests.swift
+++ b/Tests/Clappr_Tests/PlayButtonTests.swift
@@ -6,14 +6,15 @@ import Nimble
 class PlayButtonTests: QuickSpec {
     override func spec() {
         describe(".PlayButton") {
+            var coreStub: CoreStub!
+            var playButton: PlayButton!
+
+            beforeEach {
+                coreStub = CoreStub()
+                playButton = PlayButton(context: coreStub)
+            }
 
             describe("Plugin structure") {
-                var playButton: PlayButton!
-
-                beforeEach {
-                    playButton = PlayButton()
-                }
-
                 context("#init") {
                     it("is an MediaControlPlugin type") {
                         expect(playButton).to(beAKindOf(MediaControlPlugin.self))
@@ -40,15 +41,6 @@ class PlayButtonTests: QuickSpec {
             }
 
             describe("when a video is loaded") {
-
-                var coreStub: CoreStub!
-                var playButton: PlayButton!
-
-                beforeEach {
-                    coreStub = CoreStub()
-                    playButton = PlayButton(context: coreStub)
-                }
-
                 context("and video is vod") {
                     it("shows button") {
                         playButton.render()
@@ -61,13 +53,7 @@ class PlayButtonTests: QuickSpec {
             }
 
             context("when click on button") {
-
-                var coreStub: CoreStub!
-                var playButton: PlayButton!
-
                 beforeEach {
-                    coreStub = CoreStub()
-                    playButton = PlayButton(context: coreStub)
                     playButton.render()
                 }
 
@@ -99,13 +85,7 @@ class PlayButtonTests: QuickSpec {
             }
 
             context("when click on button during playback") {
-
-                var coreStub: CoreStub!
-                var playButton: PlayButton!
-
                 beforeEach {
-                    coreStub = CoreStub()
-                    playButton = PlayButton(context: coreStub)
                     playButton.render()
                 }
 
@@ -183,8 +163,6 @@ class PlayButtonTests: QuickSpec {
             describe("render") {
 
                 it("set's acessibilityIdentifier to button") {
-                    let playButton = PlayButton()
-
                     playButton.render()
 
                     expect(playButton.button.accessibilityIdentifier).to(equal("PlayPauseButton"))
@@ -192,7 +170,6 @@ class PlayButtonTests: QuickSpec {
 
                 describe("button") {
                     it("adds it in the view") {
-                        let playButton = PlayButton()
 
                         playButton.render()
 
@@ -200,7 +177,6 @@ class PlayButtonTests: QuickSpec {
                     }
 
                     it("has scaleAspectFit content mode") {
-                        let playButton = PlayButton()
 
                         playButton.render()
 
@@ -212,8 +188,6 @@ class PlayButtonTests: QuickSpec {
 
             context("when stalling") {
                 it("hides the plugin") {
-                    let coreStub = CoreStub()
-                    let playButton = PlayButton(context: coreStub)
 
                     coreStub.activePlayback?.trigger(Event.stalling.rawValue)
 
@@ -221,8 +195,6 @@ class PlayButtonTests: QuickSpec {
                 }
 
                 it("hides the plugin") {
-                    let coreStub = CoreStub()
-                    let playButton = PlayButton(context: coreStub)
 
                     coreStub.activePlayback?.trigger(Event.playing.rawValue)
 

--- a/Tests/Clappr_Tests/PlaybackFactoryTests.swift
+++ b/Tests/Clappr_Tests/PlaybackFactoryTests.swift
@@ -33,7 +33,7 @@ class PlaybackFactoryTests: QuickSpec {
             return options[kSourceUrl] as! String != "invalid"
         }
 
-        override var pluginName: String {
+        override class var name: String {
             return "AVPlayback"
         }
     }

--- a/Tests/Clappr_Tests/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/PlaybackTests.swift
@@ -143,7 +143,7 @@ class PlaybackTests: QuickSpec {
         var seekWasCalledWithValue: TimeInterval = -1
         var type: PlaybackType = .unknown
 
-        override var pluginName: String {
+        override class var name: String {
             return "stupPlayback"
         }
 

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -307,7 +307,7 @@ class PlayerTests: QuickSpec {
     }
 
     class StubPlayback: Playback {
-        override var pluginName: String {
+        override class var name: String {
             return "StubPlayback"
         }
 
@@ -317,7 +317,7 @@ class PlayerTests: QuickSpec {
     }
 
     class SpecialStubPlayback: Playback {
-        override var pluginName: String {
+        override class var name: String {
             return "SpecialStubPlayback"
         }
 
@@ -327,7 +327,7 @@ class PlayerTests: QuickSpec {
     }
 
     class LoggerPlugin: UICorePlugin {
-        override var pluginName: String { return "Logger" }
+        override class var name: String { return "Logger" }
 
         required init(context: UIObject) {
             super.init(context: context)
@@ -353,7 +353,7 @@ class PlayerTests: QuickSpec {
     }
     
     class FakeContainerPlugin: UIContainerPlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "FakeContainerPlugin"
         }
     }

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -19,7 +19,7 @@ class PlayerTests: QuickSpec {
 
                     beforeEach {
                         Loader.shared.resetPlugins()
-                        Player.register(plugins: [SpecialStubPlayback.self, StubPlayback.self])
+                        Player.register(playbacks: [SpecialStubPlayback.self, StubPlayback.self])
                         player = Player(options: options)
                         playback = player.activePlayback
                         callbackWasCalled = false
@@ -262,7 +262,7 @@ class PlayerTests: QuickSpec {
 
                     it("ignore plugins registered after player initialization") {
                         Loader.shared.resetPlugins()
-                        Player.register(plugins: [SpecialStubPlayback.self, StubPlayback.self])
+                        Player.register(playbacks: [SpecialStubPlayback.self, StubPlayback.self])
                         player = Player(options: options)
 
                         Player.register(plugins: [LoggerPlugin.self])
@@ -276,7 +276,7 @@ class PlayerTests: QuickSpec {
             describe("#configure") {
                 it("changes Core options") {
                     Loader.shared.resetPlugins()
-                    Player.register(plugins: [SpecialStubPlayback.self, StubPlayback.self])
+                    Player.register(playbacks: [SpecialStubPlayback.self, StubPlayback.self])
                     player = Player(options: options)
                     player.configure(options: ["foo": "bar"])
 

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -334,10 +334,6 @@ class PlayerTests: QuickSpec {
             bindEvents()
         }
 
-        required init() {
-            super.init()
-        }
-
         private func bindEvents() {
             stopListening()
             bindPlaybackEvents()

--- a/Tests/Clappr_Tests/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/PosterPluginTests.swift
@@ -57,7 +57,7 @@ class PosterPluginTests: QuickSpec {
                 context("to NoOpPlayback") {
 
                     beforeEach {
-                        container.playback = NoOpPlayback()
+                        container.playback = NoOpPlayback(options: [:])
                         posterPlugin = self.getPosterPlugin(container)
                     }
 
@@ -72,7 +72,7 @@ class PosterPluginTests: QuickSpec {
                     context("and change again to another playback") {
 
                         beforeEach {
-                            container.playback = AVFoundationPlayback()
+                            container.playback = AVFoundationPlayback(options: [:])
                             posterPlugin = self.getPosterPlugin(container)
                         }
 
@@ -85,7 +85,7 @@ class PosterPluginTests: QuickSpec {
                 context("to another a playback diferent from NoOpPlayback") {
 
                     beforeEach {
-                        container.playback = AVFoundationPlayback()
+                        container.playback = AVFoundationPlayback(options: [:])
                         posterPlugin = self.getPosterPlugin(container)
                     }
 

--- a/Tests/Clappr_Tests/SpinnerPluginTests.swift
+++ b/Tests/Clappr_Tests/SpinnerPluginTests.swift
@@ -14,7 +14,7 @@ class SpinnerPluginTests: QuickSpec {
         beforeEach {
             container = Container()
             spinnerPlugin = SpinnerPlugin(context: container)
-            playback = AVFoundationPlayback()
+            playback = AVFoundationPlayback(options: [:])
             container.playback = playback
         }
 

--- a/Tests/Clappr_Tests/SpinnerPluginTests.swift
+++ b/Tests/Clappr_Tests/SpinnerPluginTests.swift
@@ -114,6 +114,6 @@ class SpinnerPluginTests: QuickSpec {
     }
 
     class PlaybackStub: Playback {
-        override var pluginName: String { return "playbackstub" }
+        override class var name: String { return "playbackstub" }
     }
 }

--- a/Tests/Clappr_Tests/UICorePluginTests.swift
+++ b/Tests/Clappr_Tests/UICorePluginTests.swift
@@ -46,7 +46,7 @@ class UICorePluginTests: QuickSpec {
     }
 
     class StubCorePlugin: UICorePlugin {
-        override var pluginName: String {
+        override class var name: String {
             return "StubCorePlugin"
         }
     }

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -83,7 +83,7 @@ class PlayerTests: QuickSpec {
     }
     
     class StubPlayback: Playback {
-        override var pluginName: String {
+        override class var name: String {
             return "StubPlayback"
         }
         
@@ -93,7 +93,7 @@ class PlayerTests: QuickSpec {
     }
     
     class SpecialStubPlayback: Playback {
-        override var pluginName: String {
+        override class var name: String {
             return "SpecialStubPlayback"
         }
         

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -17,7 +17,7 @@ class PlayerTests: QuickSpec {
             
             beforeEach {
                 Loader.shared.resetPlugins()
-                player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+                player = Player(options: options, externalPlugins: [AContainerPlugin.self])
                 playback = player.activePlayback
             }
             
@@ -74,6 +74,7 @@ class PlayerTests: QuickSpec {
 
             it("contains AVFoundationPlayback") {
                 Loader.shared.resetPlugins()
+                Loader.shared.resetPlaybacks()
                 Player.hasAlreadyRegisteredPlaybacks = false
                 _ = Player(options: options)
 
@@ -100,5 +101,11 @@ class PlayerTests: QuickSpec {
         override class func canPlay(_ options: Options) -> Bool {
             return options[kSourceUrl] as! String == PlayerTests.specialSource
         }
+    }
+}
+
+class AContainerPlugin : ContainerPlugin {
+    override class var name: String {
+        return "AContainerPlugin"
     }
 }

--- a/Tests/Clappr_tvOS_Tests/TVRemoteHandlerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/TVRemoteHandlerTests.swift
@@ -19,7 +19,7 @@ class TVRemoteHandlerTests: QuickSpec {
 
             beforeEach {
                 Loader.shared.resetPlugins()
-                player = Player(options: options, externalPlugins: [SpecialStubPlayback.self, StubPlayback.self])
+                player = Player(options: options, externalPlugins: [AContainerPlugin.self])
                 playback = player.activePlayback
                 playerViewController = AVPlayerViewController()
                 handler = TVRemoteHandler(playerViewController: playerViewController, player: player)

--- a/Tests/Clappr_tvOS_Tests/TVRemoteHandlerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/TVRemoteHandlerTests.swift
@@ -68,7 +68,7 @@ class TVRemoteHandlerTests: QuickSpec {
         }
 
         class StubPlayback: Playback {
-            override var pluginName: String {
+            override class var name: String {
                 return "StubPlayback"
             }
 
@@ -78,7 +78,7 @@ class TVRemoteHandlerTests: QuickSpec {
         }
 
         class SpecialStubPlayback: Playback {
-            override var pluginName: String {
+            override class var name: String {
                 return "SpecialStubPlayback"
             }
 


### PR DESCRIPTION
# Goal
Reduce the startup time related to instantiating plugins unnecessarily. The current implementation of `Plugin.name`, requires a call to the instance method `pluginName`, therefore instantiating plugins unnecessarily during the `Loader.register` flow.

The meat of this refactoring is inside `Plugin.swift`, `CorePlugin.swift` and `ContainerPlugin.swift`, where the implementations of `name` and `pluginName` were changed.

As a side effect, the parameterless `init()` method was not required anymore and was also removed from all Plugins.

# How to test
* `make test` and  Run the example application.
 
