### PR TITLE
Make it possible to load audio sources without blocking the  main thread

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		4856322B220B4C9C0096CDAE /* QuickSeekMediaControlPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4856322A220B4C9C0096CDAE /* QuickSeekMediaControlPlugin.swift */; };
 		4856322E220B54B90096CDAE /* QuickSeekPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4856322D220B54B90096CDAE /* QuickSeekPlugin.swift */; };
 		487747D5220B5BFB000167CE /* QuickSeekMediaControlPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 487747D3220B5BCD000167CE /* QuickSeekMediaControlPluginTests.swift */; };
+		488849B022845D97004B4AD1 /* AVAsset+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488849AF22845D97004B4AD1 /* AVAsset+Ext.swift */; };
+		488849B122845D97004B4AD1 /* AVAsset+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488849AF22845D97004B4AD1 /* AVAsset+Ext.swift */; };
 		48A29BF8221C8F100004AD3B /* ContainerStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EDF8552162D10B00789E2F /* ContainerStub.swift */; };
 		48A29BF9221C8F1A0004AD3B /* AVFoundationPlaybackMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EDF8532162D0DD00789E2F /* AVFoundationPlaybackMock.swift */; };
 		48A29BFA221C8F290004AD3B /* CoreStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EDF8512162D07D00789E2F /* CoreStub.swift */; };
@@ -414,6 +416,7 @@
 		4856322A220B4C9C0096CDAE /* QuickSeekMediaControlPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSeekMediaControlPlugin.swift; sourceTree = "<group>"; };
 		4856322D220B54B90096CDAE /* QuickSeekPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSeekPlugin.swift; sourceTree = "<group>"; };
 		487747D3220B5BCD000167CE /* QuickSeekMediaControlPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSeekMediaControlPluginTests.swift; sourceTree = "<group>"; };
+		488849AF22845D97004B4AD1 /* AVAsset+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVAsset+Ext.swift"; sourceTree = "<group>"; };
 		48A29C02221DBE740004AD3B /* ContainerPluginStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerPluginStub.swift; sourceTree = "<group>"; };
 		48A29C06221DEF640004AD3B /* CorePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorePluginTests.swift; sourceTree = "<group>"; };
 		48A29C0A221DEFC10004AD3B /* CorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorePlugin.swift; sourceTree = "<group>"; };
@@ -943,6 +946,7 @@
 			isa = PBXGroup;
 			children = (
 				9EED97002088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift */,
+				488849AF22845D97004B4AD1 /* AVAsset+Ext.swift */,
 				96D362A31D41339400CCB866 /* UIView+Ext.swift */,
 				C9EDF8572163A9A900789E2F /* UIColor+ClapprAdditions.swift */,
 				C9177B2D21664D1C001D0292 /* UIImage+Ext.swift */,
@@ -1848,6 +1852,7 @@
 				4822B6B522158FA300D1C134 /* ClapprAnimationDuration.swift in Sources */,
 				32E401CE1FF42386001C2096 /* GradientView.swift in Sources */,
 				32755E22215038CB0088724E /* Playback.swift in Sources */,
+				488849B122845D97004B4AD1 /* AVAsset+Ext.swift in Sources */,
 				3251114721359BD8001FEEBA /* Core.swift in Sources */,
 				FC7785B8200523E400EC879F /* AVFoundationNowPlayingService.swift in Sources */,
 				FC7785AE2005233D00EC879F /* Player.swift in Sources */,
@@ -2039,6 +2044,7 @@
 				48563229220B47B10096CDAE /* Core+Ext.swift in Sources */,
 				9EED97012088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift in Sources */,
 				96D362C41D41339400CCB866 /* BaseObject.swift in Sources */,
+				488849B022845D97004B4AD1 /* AVAsset+Ext.swift in Sources */,
 				57AB0E882253CAB70096BCA4 /* PassthroughView.swift in Sources */,
 				96D362CB1D41339400CCB866 /* MediaOption.swift in Sources */,
 				C9EDF8582163A9A900789E2F /* UIColor+ClapprAdditions.swift in Sources */,

--- a/Sources/Clappr/Classes/Extension/AVAsset+Ext.swift
+++ b/Sources/Clappr/Classes/Extension/AVAsset+Ext.swift
@@ -1,0 +1,17 @@
+import AVKit
+
+public typealias AsyncResult<T> = ((_ value: T?) -> ())
+public extension AVAsset {
+    func async<T>(get property: String, completion: @escaping AsyncResult<T>) {
+        self.loadValuesAsynchronously(forKeys: [property]) { [weak self] in
+            var error: NSError? = nil
+            let status: AVKeyValueStatus = self?.statusOfValue(forKey: property, error: &error) ?? .failed
+            switch status {
+            case .loaded:
+                completion(self?.value(forKey: property) as? T)
+            default:
+                completion(nil)
+            }
+        }
+    }
+}

--- a/Sources/Clappr/Classes/Extension/AVAsset+Ext.swift
+++ b/Sources/Clappr/Classes/Extension/AVAsset+Ext.swift
@@ -1,16 +1,10 @@
 import AVKit
 
-public typealias AsyncResult<T> = ((_ value: T?) -> ())
 public extension AVAsset {
-    func async<T>(get property: String, completion: @escaping AsyncResult<T>) {
-        self.loadValuesAsynchronously(forKeys: [property]) { [weak self] in
-            var error: NSError? = nil
-            let status: AVKeyValueStatus = self?.statusOfValue(forKey: property, error: &error) ?? .failed
-            switch status {
-            case .loaded:
-                completion(self?.value(forKey: property) as? T)
-            default:
-                completion(nil)
+    func wait(for property: String, then completion: @escaping () -> ()) {
+        self.loadValuesAsynchronously(forKeys: [property]) {
+            DispatchQueue.main.async {
+                completion()
             }
         }
     }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -60,12 +60,12 @@ open class AVFoundationPlayback: Playback {
     open override var selectedSubtitle: MediaOption? {
         get {
             guard let subtitles = self.subtitles, subtitles.count > 0 else { return nil }
-            let option = getSelectedMediaOptionWithCharacteristic(AVMediaCharacteristic.legible.rawValue)
+            let option = getSelectedMediaOptionWithCharacteristic(.legible)
             return MediaOptionFactory.fromAVMediaOption(option, type: .subtitle) ?? MediaOptionFactory.offSubtitle()
         }
         set {
             let newOption = newValue?.raw as? AVMediaSelectionOption
-            setMediaSelectionOption(newOption, characteristic: AVMediaCharacteristic.legible.rawValue)
+            setMediaSelectionOption(newOption, characteristic: .legible)
             triggerMediaOptionSelectedEvent(option: newValue, event: Event.didSelectSubtitle)
         }
     }
@@ -73,12 +73,12 @@ open class AVFoundationPlayback: Playback {
     private var hasSelectedDefaultAudio = false
     open override var selectedAudioSource: MediaOption? {
         get {
-            let option = getSelectedMediaOptionWithCharacteristic(AVMediaCharacteristic.audible.rawValue)
+            let option = getSelectedMediaOptionWithCharacteristic(.audible)
             return MediaOptionFactory.fromAVMediaOption(option, type: .audioSource)
         }
         set {
             if let newOption = newValue?.raw as? AVMediaSelectionOption {
-                setMediaSelectionOption(newOption, characteristic: AVMediaCharacteristic.audible.rawValue)
+                setMediaSelectionOption(newOption, characteristic: .audible)
             }
             triggerMediaOptionSelectedEvent(option: newValue, event: Event.didSelectAudio)
         }
@@ -95,7 +95,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override var subtitles: [MediaOption]? {
-        guard let mediaGroup = mediaSelectionGroup(AVMediaCharacteristic.legible.rawValue) else {
+        guard let mediaGroup = mediaSelectionGroup(.legible) else {
             return []
         }
 
@@ -104,7 +104,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override var audioSources: [MediaOption]? {
-        guard let mediaGroup = mediaSelectionGroup(AVMediaCharacteristic.audible.rawValue) else {
+        guard let mediaGroup = mediaSelectionGroup(.audible) else {
             return []
         }
         return mediaGroup.options.compactMap({ MediaOptionFactory.fromAVMediaOption($0, type: .audioSource) })
@@ -563,7 +563,7 @@ open class AVFoundationPlayback: Playback {
             let selectedOption = defaultSubtitle.raw as? AVMediaSelectionOption,
             !hasSelectedDefaultSubtitle {
 
-            setMediaSelectionOption(selectedOption, characteristic: AVMediaCharacteristic.legible.rawValue)
+            setMediaSelectionOption(selectedOption, characteristic: .legible)
             trigger(.didFindSubtitle, userInfo: ["subtitles": AvailableMediaOptions(subtitles, hasDefaultSelected: true)])
             hasSelectedDefaultSubtitle = true
         } else {
@@ -578,7 +578,7 @@ open class AVFoundationPlayback: Playback {
             let selectedOption = defaultAudioSource.raw as? AVMediaSelectionOption,
             !hasSelectedDefaultAudio {
 
-            setMediaSelectionOption(selectedOption, characteristic: AVMediaCharacteristic.audible.rawValue)
+            setMediaSelectionOption(selectedOption, characteristic: .audible)
             trigger(.didFindAudio, userInfo: ["audios": AvailableMediaOptions(audioSources, hasDefaultSelected: true)])
             hasSelectedDefaultAudio = true
         } else {
@@ -600,21 +600,21 @@ open class AVFoundationPlayback: Playback {
     }
 
 
-    private func setMediaSelectionOption(_ option: AVMediaSelectionOption?, characteristic: String) {
+    private func setMediaSelectionOption(_ option: AVMediaSelectionOption?, characteristic: AVMediaCharacteristic) {
         if let group = mediaSelectionGroup(characteristic) {
             player?.currentItem?.select(option, in: group)
         }
     }
 
-    private func getSelectedMediaOptionWithCharacteristic(_ characteristic: String) -> AVMediaSelectionOption? {
+    private func getSelectedMediaOptionWithCharacteristic(_ characteristic: AVMediaCharacteristic) -> AVMediaSelectionOption? {
         if let group = mediaSelectionGroup(characteristic) {
             return player?.currentItem?.selectedMediaOption(in: group)
         }
         return nil
     }
 
-    private func mediaSelectionGroup(_ characteristic: String) -> AVMediaSelectionGroup? {
-        return player?.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: AVMediaCharacteristic(rawValue: characteristic))
+    private func mediaSelectionGroup(_ characteristic: AVMediaCharacteristic) -> AVMediaSelectionGroup? {
+        return player?.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic)
     }
 
     deinit {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -247,9 +247,7 @@ open class AVFoundationPlayback: Playback {
                 seek(startAt)
             }
 
-            asset.async(get: characteristicsKey) { [weak self] (_: Any?) in
-                DispatchQueue.main.async { self?.selectDefaultAudioIfNeeded() }
-            }
+            asset.wait(for: characteristicsKey, then: selectDefaultAudioIfNeeded)
 
             addObservers()
         } else {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -237,8 +237,7 @@ open class AVFoundationPlayback: Playback {
 
     private func setupPlayer() {
         if let asset = self.asset {
-            let item = AVPlayerItem(asset: asset)
-            createPlayerInstance(with: item)
+            createPlayerInstance(with: AVPlayerItem(asset: asset))
             playerLayer = AVPlayerLayer(player: player)
             view.layer.addSublayer(playerLayer!)
             playerLayer?.frame = view.bounds

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -248,10 +248,8 @@ open class AVFoundationPlayback: Playback {
                 seek(startAt)
             }
 
-            item.asset.async(get: characteristicsKey) { [weak self] (_: [AVMediaCharacteristic]?) in
-                DispatchQueue.main.async {
-                    self?.selectDefaultAudioIfNeeded()
-                }
+            asset.async(get: characteristicsKey) { [weak self] (_: Any?) in
+                DispatchQueue.main.async { self?.selectDefaultAudioIfNeeded() }
             }
 
             addObservers()


### PR DESCRIPTION
## Goal
- To use `loadValuesAsynchronously` from `AVAsset` to get audio and subtitle characteristics, which may block the main thread if you directly access such property.

## How to test
1. run `make test` and nothing should break
2. If you wish, you can go even further and add a tableView to the player viewController and keep scrolling it while the video is being loaded.
