### PR TITLE
Bind events refactor

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -272,6 +272,10 @@
 		C9F6D7B72182650B0055A599 /* SeekbarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C9F6D7B52182650A0055A599 /* SeekbarView.xib */; };
 		C9F6D7B9218265140055A599 /* Seekbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F6D7B8218265140055A599 /* Seekbar.swift */; };
 		CDCECC42228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCECC41228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift */; };
+		CD57FCEF22949B0F00AB24CF /* ActiveCorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */; };
+		CD57FCF122949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */; };
+		CD57FCF222949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */; };
+		CD57FCF322949BBB00AB24CF /* ActiveCorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */; };
 		E7BEEB59217506C100B8F7FA /* TimeIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEEB58217506C100B8F7FA /* TimeIndicator.swift */; };
 		E7BEEB5C21751EE600B8F7FA /* TimeIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEEB5A21751D9600B8F7FA /* TimeIndicatorTests.swift */; };
 		E7C6E891219225B900A74149 /* SeekbarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C6E88F2192239500A74149 /* SeekbarViewTests.swift */; };
@@ -553,6 +557,8 @@
 		C9F6D7B52182650A0055A599 /* SeekbarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SeekbarView.xib; sourceTree = "<group>"; };
 		C9F6D7B8218265140055A599 /* Seekbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Seekbar.swift; sourceTree = "<group>"; };
 		CDCECC41228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratedPressAVPlayerViewController.swift; sourceTree = "<group>"; };
+		CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveCorePlugin.swift; sourceTree = "<group>"; };
+		CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveContainerPlugin.swift; sourceTree = "<group>"; };
 		D105480873032552EC2B57ED /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		D8810057D2C05E1F7A2759D7 /* Clappr.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = Clappr.podspec; sourceTree = "<group>"; };
 		E7BEEB58217506C100B8F7FA /* TimeIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIndicator.swift; sourceTree = "<group>"; };
@@ -994,6 +1000,7 @@
 				96D362AD1D41339400CCB866 /* SpinnerPlugin.swift */,
 				96D362AF1D41339400CCB866 /* UIContainerPlugin.swift */,
 				C94D8CEF221B22C300C7855D /* ContainerPlugin.swift */,
+				CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */,
 			);
 			path = Container;
 			sourceTree = "<group>";
@@ -1003,6 +1010,7 @@
 			children = (
 				96D362B11D41339400CCB866 /* UICorePlugin.swift */,
 				48A29C0A221DEFC10004AD3B /* CorePlugin.swift */,
+				CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1842,6 +1850,7 @@
 				32B3D23D2007FA7D00D81C0A /* ClapprDateFormatter.swift in Sources */,
 				48A29C12221DF8CD0004AD3B /* CorePlugin.swift in Sources */,
 				32E401C31FF42321001C2096 /* InternalEvent.swift in Sources */,
+				CD57FCF322949BBB00AB24CF /* ActiveCorePlugin.swift in Sources */,
 				48A29C01221D82700004AD3B /* UIObject.swift in Sources */,
 				48EC492122A1908300DC7A2D /* AVPlayerItem+Ext.swift in Sources */,
 				C9EDF8592163A9A900789E2F /* UIColor+ClapprAdditions.swift in Sources */,
@@ -1858,6 +1867,7 @@
 				3251114721359BD8001FEEBA /* Core.swift in Sources */,
 				FC7785B8200523E400EC879F /* AVFoundationNowPlayingService.swift in Sources */,
 				FC7785AE2005233D00EC879F /* Player.swift in Sources */,
+				CD57FCF222949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */,
 				32DA341A1FFBD02A00484C90 /* Loader.swift in Sources */,
 				AB24DCD62152ED0E002D4660 /* AvailableMediaOptions.swift in Sources */,
 				C94D8CF1221B22C300C7855D /* ContainerPlugin.swift in Sources */,
@@ -2003,6 +2013,7 @@
 				96D362DD1D41339400CCB866 /* PlaybackFactory.swift in Sources */,
 				AB163506215AB97800635233 /* MediaControlPlugin.swift in Sources */,
 				96D362E61D41339400CCB866 /* EventProtocol.swift in Sources */,
+				CD57FCF122949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */,
 				C9F6D7B9218265140055A599 /* Seekbar.swift in Sources */,
 				C9177B2E21664D1C001D0292 /* UIImage+Ext.swift in Sources */,
 				4822B6B1220C72D100D1C134 /* SeekBubbleSide.swift in Sources */,
@@ -2015,6 +2026,7 @@
 				96D362E21D41339400CCB866 /* UICorePlugin.swift in Sources */,
 				96D362D31D41339400CCB866 /* MediaControlState.swift in Sources */,
 				C9B6D6E7216FDD5400588896 /* FullscreenButton.swift in Sources */,
+				CD57FCEF22949B0F00AB24CF /* ActiveCorePlugin.swift in Sources */,
 				968E5BDB1D6CC0680092F372 /* LogLevel.swift in Sources */,
 				57937C571FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift in Sources */,
 				4822B6B42214961900D1C134 /* ClapprAnimationDuration.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -272,10 +272,10 @@
 		C9F6D7B72182650B0055A599 /* SeekbarView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C9F6D7B52182650A0055A599 /* SeekbarView.xib */; };
 		C9F6D7B9218265140055A599 /* Seekbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F6D7B8218265140055A599 /* Seekbar.swift */; };
 		CDCECC42228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCECC41228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift */; };
-		CD57FCEF22949B0F00AB24CF /* ActiveCorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */; };
-		CD57FCF122949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */; };
-		CD57FCF222949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */; };
-		CD57FCF322949BBB00AB24CF /* ActiveCorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */; };
+		CD57FCEF22949B0F00AB24CF /* SimpleCorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCEE22949B0F00AB24CF /* SimpleCorePlugin.swift */; };
+		CD57FCF122949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* SimpleContainerPlugin.swift */; };
+		CD57FCF222949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* SimpleContainerPlugin.swift */; };
+		CD57FCF322949BBB00AB24CF /* SimpleCorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCEE22949B0F00AB24CF /* SimpleCorePlugin.swift */; };
 		E7BEEB59217506C100B8F7FA /* TimeIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEEB58217506C100B8F7FA /* TimeIndicator.swift */; };
 		E7BEEB5C21751EE600B8F7FA /* TimeIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEEB5A21751D9600B8F7FA /* TimeIndicatorTests.swift */; };
 		E7C6E891219225B900A74149 /* SeekbarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C6E88F2192239500A74149 /* SeekbarViewTests.swift */; };
@@ -557,8 +557,8 @@
 		C9F6D7B52182650A0055A599 /* SeekbarView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SeekbarView.xib; sourceTree = "<group>"; };
 		C9F6D7B8218265140055A599 /* Seekbar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Seekbar.swift; sourceTree = "<group>"; };
 		CDCECC41228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratedPressAVPlayerViewController.swift; sourceTree = "<group>"; };
-		CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveCorePlugin.swift; sourceTree = "<group>"; };
-		CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveContainerPlugin.swift; sourceTree = "<group>"; };
+		CD57FCEE22949B0F00AB24CF /* SimpleCorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCorePlugin.swift; sourceTree = "<group>"; };
+		CD57FCF022949BB300AB24CF /* SimpleContainerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleContainerPlugin.swift; sourceTree = "<group>"; };
 		D105480873032552EC2B57ED /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		D8810057D2C05E1F7A2759D7 /* Clappr.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = Clappr.podspec; sourceTree = "<group>"; };
 		E7BEEB58217506C100B8F7FA /* TimeIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIndicator.swift; sourceTree = "<group>"; };
@@ -1000,7 +1000,7 @@
 				96D362AD1D41339400CCB866 /* SpinnerPlugin.swift */,
 				96D362AF1D41339400CCB866 /* UIContainerPlugin.swift */,
 				C94D8CEF221B22C300C7855D /* ContainerPlugin.swift */,
-				CD57FCF022949BB300AB24CF /* ActiveContainerPlugin.swift */,
+				CD57FCF022949BB300AB24CF /* SimpleContainerPlugin.swift */,
 			);
 			path = Container;
 			sourceTree = "<group>";
@@ -1010,7 +1010,7 @@
 			children = (
 				96D362B11D41339400CCB866 /* UICorePlugin.swift */,
 				48A29C0A221DEFC10004AD3B /* CorePlugin.swift */,
-				CD57FCEE22949B0F00AB24CF /* ActiveCorePlugin.swift */,
+				CD57FCEE22949B0F00AB24CF /* SimpleCorePlugin.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1850,7 +1850,7 @@
 				32B3D23D2007FA7D00D81C0A /* ClapprDateFormatter.swift in Sources */,
 				48A29C12221DF8CD0004AD3B /* CorePlugin.swift in Sources */,
 				32E401C31FF42321001C2096 /* InternalEvent.swift in Sources */,
-				CD57FCF322949BBB00AB24CF /* ActiveCorePlugin.swift in Sources */,
+				CD57FCF322949BBB00AB24CF /* SimpleCorePlugin.swift in Sources */,
 				48A29C01221D82700004AD3B /* UIObject.swift in Sources */,
 				48EC492122A1908300DC7A2D /* AVPlayerItem+Ext.swift in Sources */,
 				C9EDF8592163A9A900789E2F /* UIColor+ClapprAdditions.swift in Sources */,
@@ -1867,7 +1867,7 @@
 				3251114721359BD8001FEEBA /* Core.swift in Sources */,
 				FC7785B8200523E400EC879F /* AVFoundationNowPlayingService.swift in Sources */,
 				FC7785AE2005233D00EC879F /* Player.swift in Sources */,
-				CD57FCF222949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */,
+				CD57FCF222949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */,
 				32DA341A1FFBD02A00484C90 /* Loader.swift in Sources */,
 				AB24DCD62152ED0E002D4660 /* AvailableMediaOptions.swift in Sources */,
 				C94D8CF1221B22C300C7855D /* ContainerPlugin.swift in Sources */,
@@ -2013,7 +2013,7 @@
 				96D362DD1D41339400CCB866 /* PlaybackFactory.swift in Sources */,
 				AB163506215AB97800635233 /* MediaControlPlugin.swift in Sources */,
 				96D362E61D41339400CCB866 /* EventProtocol.swift in Sources */,
-				CD57FCF122949BB300AB24CF /* ActiveContainerPlugin.swift in Sources */,
+				CD57FCF122949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */,
 				C9F6D7B9218265140055A599 /* Seekbar.swift in Sources */,
 				C9177B2E21664D1C001D0292 /* UIImage+Ext.swift in Sources */,
 				4822B6B1220C72D100D1C134 /* SeekBubbleSide.swift in Sources */,
@@ -2026,7 +2026,7 @@
 				96D362E21D41339400CCB866 /* UICorePlugin.swift in Sources */,
 				96D362D31D41339400CCB866 /* MediaControlState.swift in Sources */,
 				C9B6D6E7216FDD5400588896 /* FullscreenButton.swift in Sources */,
-				CD57FCEF22949B0F00AB24CF /* ActiveCorePlugin.swift in Sources */,
+				CD57FCEF22949B0F00AB24CF /* SimpleCorePlugin.swift in Sources */,
 				968E5BDB1D6CC0680092F372 /* LogLevel.swift in Sources */,
 				57937C571FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift in Sources */,
 				4822B6B42214961900D1C134 /* ClapprAnimationDuration.swift in Sources */,

--- a/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
+++ b/Sources/Clappr/Classes/Factory/PlaybackFactory.swift
@@ -6,10 +6,7 @@ open class PlaybackFactory {
     }
 
     open func createPlayback() -> Playback {
-        let availablePlayback = Loader.shared.playbacks.first { playback in canPlay(playback) }
-        guard let playback = availablePlayback, playback.type == .playback else {
-            return NoOpPlayback(options: options)
-        }
+        let playback = Loader.shared.playbacks.first(where: canPlay) ?? NoOpPlayback.self
         return playback.init(options: options)
     }
 

--- a/Sources/Clappr/Classes/Plugin/Container/ActiveContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ActiveContainerPlugin.swift
@@ -1,0 +1,22 @@
+open class ActiveContainerPlugin : ContainerPlugin {
+
+    @objc public required init(context: UIObject) {
+        super.init(context: context)
+        bindAllEvents()
+    }
+
+    func bindAllEvents() {
+        stopListening()
+        bindEvents()
+        guard let container = container else { return }
+        listenTo(container, event: .didChangePlayback) { [weak self] _ in
+            self?.bindAllEvents()
+            self?.onDidChangePlayback()
+        }
+    }
+
+    open func bindEvents() { }
+
+    open func onDidChangePlayback() { }
+
+}

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -19,17 +19,16 @@ open class ContainerPlugin: BaseObject, Plugin {
 
     func bindAllEvents() {
         stopListening()
+        bindEvents()
 
         guard let container = container else { return }
         listenTo(container, event: .didChangePlayback) { [weak self] _ in
             self?.bindAllEvents()
             self?.onDidChangePlayback()
         }
-
-        bindEvents()
     }
 
-    open func bindEvents() {    }
+    open func bindEvents() { }
 
     open func onDidChangePlayback() { }
 

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -14,22 +14,7 @@ open class ContainerPlugin: BaseObject, Plugin {
         } else {
             NSException(name: NSExceptionName(rawValue: "WrongContextType"), reason: "Container Plugins should always be initialized with a Container context", userInfo: nil).raise()
         }
-        bindAllEvents()
     }
-
-    func bindAllEvents() {
-        stopListening()
-        bindEvents()
-        guard let container = container else { return }
-        listenTo(container, event: .didChangePlayback) { [weak self] _ in
-            self?.bindAllEvents()
-            self?.onDidChangePlayback()
-        }
-    }
-
-    open func bindEvents() { }
-
-    open func onDidChangePlayback() { }
 
     open func destroy() {
         Logger.logDebug("destroying", scope: "ContainerPlugin")

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -20,7 +20,6 @@ open class ContainerPlugin: BaseObject, Plugin {
     func bindAllEvents() {
         stopListening()
         bindEvents()
-
         guard let container = container else { return }
         listenTo(container, event: .didChangePlayback) { [weak self] _ in
             self?.bindAllEvents()

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -14,8 +14,25 @@ open class ContainerPlugin: BaseObject, Plugin {
         } else {
             NSException(name: NSExceptionName(rawValue: "WrongContextType"), reason: "Container Plugins should always be initialized with a Container context", userInfo: nil).raise()
         }
+        bindAllEvents()
     }
-    
+
+    func bindAllEvents() {
+        stopListening()
+
+        guard let container = container else { return }
+        listenTo(container, event: .didChangePlayback) { [weak self] _ in
+            self?.bindAllEvents()
+            self?.onDidChangePlayback()
+        }
+
+        bindEvents()
+    }
+
+    open func bindEvents() {    }
+
+    open func onDidChangePlayback() { }
+
     open func destroy() {
         Logger.logDebug("destroying", scope: "ContainerPlugin")
         Logger.logDebug("destroying listeners", scope: "ContainerPlugin")

--- a/Sources/Clappr/Classes/Plugin/Container/SimpleContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SimpleContainerPlugin.swift
@@ -1,4 +1,4 @@
-open class ActiveCorePlugin: CorePlugin {
+open class SimpleContainerPlugin : ContainerPlugin {
 
     @objc public required init(context: UIObject) {
         super.init(context: context)
@@ -8,12 +8,7 @@ open class ActiveCorePlugin: CorePlugin {
     func bindAllEvents() {
         stopListening()
         bindEvents()
-        guard let core = core else { return }
-        listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
-            self?.bindAllEvents()
-            self?.onDidChangeActiveContainer()
-        }
-        guard let container = core.activeContainer else { return }
+        guard let container = container else { return }
         listenTo(container, event: .didChangePlayback) { [weak self] _ in
             self?.bindAllEvents()
             self?.onDidChangePlayback()
@@ -23,7 +18,5 @@ open class ActiveCorePlugin: CorePlugin {
     open func bindEvents() { }
 
     open func onDidChangePlayback() { }
-
-    open func onDidChangeActiveContainer() { }
 
 }

--- a/Sources/Clappr/Classes/Plugin/Container/SimpleContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SimpleContainerPlugin.swift
@@ -1,4 +1,4 @@
-open class SimpleContainerPlugin : ContainerPlugin {
+open class SimpleContainerPlugin: ContainerPlugin {
 
     @objc public required init(context: UIObject) {
         super.init(context: context)
@@ -15,7 +15,9 @@ open class SimpleContainerPlugin : ContainerPlugin {
         }
     }
 
-    open func bindEvents() { }
+    open func bindEvents() {
+        NSException(name: NSExceptionName(rawValue: "MissingBindEvents"), reason: "SimpleContainerPlugins should always override bindEvents with its own binds: \(pluginName) does not implement.", userInfo: nil).raise()
+    }
 
     open func onDidChangePlayback() { }
 

--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -15,20 +15,11 @@ open class SpinnerPlugin: UIContainerPlugin {
         spinningWheel = UIActivityIndicatorView(style: .whiteLarge)
         view.addSubview(spinningWheel)
         view.isUserInteractionEnabled = false
-        bindDidChangePlayback()
         view.accessibilityIdentifier = "SpinnerPlugin"
     }
 
-    private func bindDidChangePlayback() {
-        if let container = self.container {
-            listenTo(container, eventName: Event.didChangePlayback.rawValue) { [weak self] (info: EventUserInfo) in self?.didChangePlayback(info) }
-        }
-    }
-
-    private func didChangePlayback(_: EventUserInfo) {
-        stopListening()
+    override open func bindEvents() {
         bindPlaybackEvents()
-        bindDidChangePlayback()
     }
 
     open override func render() {

--- a/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
@@ -1,4 +1,4 @@
-open class UIContainerPlugin: ActiveContainerPlugin, UIPlugin {
+open class UIContainerPlugin: SimpleContainerPlugin, UIPlugin {
     var uiObject = UIObject()
 
     public var view: UIView {

--- a/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/UIContainerPlugin.swift
@@ -1,4 +1,4 @@
-open class UIContainerPlugin: ContainerPlugin, UIPlugin {
+open class UIContainerPlugin: ActiveContainerPlugin, UIPlugin {
     var uiObject = UIObject()
 
     public var view: UIView {

--- a/Sources/Clappr/Classes/Plugin/Core/ActiveCorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/ActiveCorePlugin.swift
@@ -1,0 +1,29 @@
+open class ActiveCorePlugin: CorePlugin {
+
+    @objc public required init(context: UIObject) {
+        super.init(context: context)
+        bindAllEvents()
+    }
+
+    func bindAllEvents() {
+        stopListening()
+        bindEvents()
+        guard let core = core else { return }
+        listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
+            self?.bindAllEvents()
+            self?.onDidChangePlayback()
+        }
+        guard let container = core.activeContainer else { return }
+        listenTo(container, event: .didChangePlayback) { [weak self] _ in
+            self?.bindAllEvents()
+            self?.onDidChangePlayback()
+        }
+    }
+
+    open func bindEvents() { }
+
+    open func onDidChangePlayback() { }
+
+    open func onDidChangeActiveContainer() { }
+
+}

--- a/Sources/Clappr/Classes/Plugin/Core/ActiveCorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/ActiveCorePlugin.swift
@@ -11,7 +11,7 @@ open class ActiveCorePlugin: CorePlugin {
         guard let core = core else { return }
         listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
             self?.bindAllEvents()
-            self?.onDidChangePlayback()
+            self?.onDidChangeActiveContainer()
         }
         guard let container = core.activeContainer else { return }
         listenTo(container, event: .didChangePlayback) { [weak self] _ in

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -30,13 +30,12 @@ open class CorePlugin: BaseObject, Plugin {
             self?.bindAllEvents()
             self?.onDidChangePlayback()
         }
-
-
     }
 
     open func bindEvents() { }
 
     open func onDidChangePlayback() { }
+
     open func onDidChangeActiveContainer() { }
 
     open func destroy() {

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -19,7 +19,7 @@ open class CorePlugin: BaseObject, Plugin {
 
     func bindAllEvents() {
         stopListening()
-
+        bindEvents()
         guard let core = core else { return }
         listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
             self?.bindAllEvents()
@@ -31,7 +31,7 @@ open class CorePlugin: BaseObject, Plugin {
             self?.onDidChangePlayback()
         }
 
-        bindEvents()
+
     }
 
     open func bindEvents() { }

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -14,29 +14,7 @@ open class CorePlugin: BaseObject, Plugin {
         } else {
             NSException(name: NSExceptionName(rawValue: "WrongContextType"), reason: "Core Plugins should always be initialized with a Core context", userInfo: nil).raise()
         }
-        bindAllEvents()
     }
-
-    func bindAllEvents() {
-        stopListening()
-        bindEvents()
-        guard let core = core else { return }
-        listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
-            self?.bindAllEvents()
-            self?.onDidChangePlayback()
-        }
-        guard let container = core.activeContainer else { return }
-        listenTo(container, event: .didChangePlayback) { [weak self] _ in
-            self?.bindAllEvents()
-            self?.onDidChangePlayback()
-        }
-    }
-
-    open func bindEvents() { }
-
-    open func onDidChangePlayback() { }
-
-    open func onDidChangeActiveContainer() { }
 
     open func destroy() {
         Logger.logDebug("destroying", scope: "CorePlugin")

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -14,8 +14,31 @@ open class CorePlugin: BaseObject, Plugin {
         } else {
             NSException(name: NSExceptionName(rawValue: "WrongContextType"), reason: "Core Plugins should always be initialized with a Core context", userInfo: nil).raise()
         }
+        bindAllEvents()
     }
-    
+
+    func bindAllEvents() {
+        stopListening()
+
+        guard let core = core else { return }
+        listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
+            self?.bindAllEvents()
+            self?.onDidChangePlayback()
+        }
+        guard let container = core.activeContainer else { return }
+        listenTo(container, event: .didChangePlayback) { [weak self] _ in
+            self?.bindAllEvents()
+            self?.onDidChangePlayback()
+        }
+
+        bindEvents()
+    }
+
+    open func bindEvents() { }
+
+    open func onDidChangePlayback() { }
+    open func onDidChangeActiveContainer() { }
+
     open func destroy() {
         Logger.logDebug("destroying", scope: "CorePlugin")
         Logger.logDebug("destroying listeners", scope: "CorePlugin")

--- a/Sources/Clappr/Classes/Plugin/Core/SimpleCorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/SimpleCorePlugin.swift
@@ -20,7 +20,9 @@ open class SimpleCorePlugin: CorePlugin {
         }
     }
 
-    open func bindEvents() { }
+    open func bindEvents() {
+        NSException(name: NSExceptionName(rawValue: "MissingBindEvents"), reason: "SimpleCorePlugins should always override bindEvents with its own binds: \(pluginName) does not implement.", userInfo: nil).raise()
+    }
 
     open func onDidChangePlayback() { }
 

--- a/Sources/Clappr/Classes/Plugin/Core/SimpleCorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/SimpleCorePlugin.swift
@@ -1,4 +1,4 @@
-open class ActiveContainerPlugin : ContainerPlugin {
+open class SimpleCorePlugin: CorePlugin {
 
     @objc public required init(context: UIObject) {
         super.init(context: context)
@@ -8,7 +8,12 @@ open class ActiveContainerPlugin : ContainerPlugin {
     func bindAllEvents() {
         stopListening()
         bindEvents()
-        guard let container = container else { return }
+        guard let core = core else { return }
+        listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
+            self?.bindAllEvents()
+            self?.onDidChangeActiveContainer()
+        }
+        guard let container = core.activeContainer else { return }
         listenTo(container, event: .didChangePlayback) { [weak self] _ in
             self?.bindAllEvents()
             self?.onDidChangePlayback()
@@ -18,5 +23,7 @@ open class ActiveContainerPlugin : ContainerPlugin {
     open func bindEvents() { }
 
     open func onDidChangePlayback() { }
+
+    open func onDidChangeActiveContainer() { }
 
 }

--- a/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
@@ -1,4 +1,4 @@
-open class UICorePlugin: ActiveCorePlugin, UIPlugin {
+open class UICorePlugin: SimpleCorePlugin, UIPlugin {
     var uiObject = UIObject()
     
     public var view: UIView {

--- a/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/UICorePlugin.swift
@@ -1,4 +1,4 @@
-open class UICorePlugin: CorePlugin, UIPlugin {
+open class UICorePlugin: ActiveCorePlugin, UIPlugin {
     var uiObject = UIObject()
     
     public var view: UIView {

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -17,17 +17,14 @@ public class QuickSeekPlugin: UICorePlugin {
     required init(context: UIObject) {
         super.init(context: context)
         animatonHandler = QuickSeekAnimation(core)
-        bindEvents()
     }
     
-    private func bindEvents() {
-        stopListening()
+    override public func bindEvents() {
         bindCoreEvents()
     }
     
     private func bindCoreEvents() {
         guard let core = core else { return }
-        listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in self?.bindEvents() }
         listenTo(core, eventName: Event.didShowModal.rawValue) { [weak self] _ in self?.removeGesture() }
         listenTo(core, eventName: Event.didHideModal.rawValue) { [weak self] _ in self?.addGesture() }
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -10,7 +10,6 @@ open class PosterPlugin: UIContainerPlugin {
         super.init(context: context)
         view.translatesAutoresizingMaskIntoConstraints = false
         poster.contentMode = .scaleAspectFit
-        bindContainerEvents()
     }
 
     open override func render() {
@@ -63,6 +62,11 @@ open class PosterPlugin: UIContainerPlugin {
         view.addConstraint(yCenterConstraint)
     }
 
+    override open func bindEvents() {
+        bindContainerEvents()
+        bindPlaybackEvents()
+    }
+
     private func bindPlaybackEvents() {
         if let playback = container?.playback {
             listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.playbackStarted() }
@@ -73,7 +77,6 @@ open class PosterPlugin: UIContainerPlugin {
 
     private func bindContainerEvents() {
         guard let container = container else { return }
-        listenTo(container, eventName: Event.didChangePlayback.rawValue) { [weak self] _ in self?.didChangePlayback() }
         listenTo(container, eventName: Event.requestPosterUpdate.rawValue) { [weak self] info in self?.updatePoster(info) }
         listenTo(container, eventName: Event.didUpdateOptions.rawValue) { [weak self] _ in self?.updatePoster(container.options) }
     }
@@ -82,10 +85,7 @@ open class PosterPlugin: UIContainerPlugin {
         return container?.playback?.pluginName == "NoOp"
     }
 
-    private func didChangePlayback() {
-        stopListening()
-        bindPlaybackEvents()
-        bindContainerEvents()
+    override open func onDidChangePlayback() {
         if isNoOpPlayback {
             view.isHidden = true
         }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/FullscreenButton.swift
@@ -36,13 +36,7 @@ open class FullscreenButton: MediaControlPlugin {
         return .right
     }
     
-    required public init(context: UIObject) {
-        super.init(context: context)
-        bindEvents()
-    }
-    
-    private func bindEvents() {
-        stopListening()
+    override open func bindEvents() {
         bindCoreEvents()
     }
     

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -35,12 +35,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     required public init(context: UIObject) {
         super.init(context: context)
         alwaysVisible = (core?.options[kMediaControlAlwaysVisible] as? Bool) ?? false
-        bindEvents()
     }
 
-    private func bindEvents() {
-        stopListening()
-
+    override open func bindEvents() {
         bindCoreEvents()
         bindContainerEvents()
         bindPlaybackEvents()
@@ -48,10 +45,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     open func bindCoreEvents() {
         if let core = self.core {
-
-            listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in
-                self?.bindEvents()
-            }
 
             listenTo(core, eventName: Event.didEnterFullscreen.rawValue) { [weak self] _ in
                 if self?.hideControlsTimer?.isValid ?? false {
@@ -82,8 +75,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     private func bindContainerEvents() {
         if let container = activeContainer {
-            listenTo(container,
-                     eventName: Event.didChangePlayback.rawValue) { [weak self] _ in self?.bindEvents() }
             listenTo(container,
                      eventName: Event.enableMediaControl.rawValue) { [weak self] _ in self?.show() }
             listenTo(container,

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -32,30 +32,8 @@ open class PlayButton: MediaControlPlugin {
         }
     }
 
-    required public init(context: UIObject) {
-        super.init(context: context)
-        bindEvents()
-    }
-
-    private func bindEvents() {
-        stopListening()
-
-        bindCoreEvents()
-        bindContainerEvents()
+    override open func bindEvents() {
         bindPlaybackEvents()
-    }
-
-    open func bindCoreEvents() {
-        if let core = core {
-            listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in self?.bindEvents() }
-        }
-    }
-
-    open func bindContainerEvents() {
-        if let container = activeContainer {
-            listenTo(container,
-                     eventName: Event.didChangePlayback.rawValue) { [weak self] (_: EventUserInfo) in self?.bindEvents() }
-        }
     }
 
     func bindPlaybackEvents() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Seekbar.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Seekbar.swift
@@ -23,16 +23,7 @@ class Seekbar: MediaControlPlugin {
 
     private var isOfflinePlayback: Bool = false
 
-    required init(context: UIObject) {
-        super.init(context: context)
-        bindEvents()
-    }
-
-    private func bindEvents() {
-        stopListening()
-
-        bindCoreEvents()
-        bindContainerEvents()
+    override public func bindEvents() {
         bindPlaybackEvents()
         bindOfflinePlaybackEvents()
     }
@@ -43,18 +34,6 @@ class Seekbar: MediaControlPlugin {
 
     fileprivate var activePlayback: Playback? {
         return core?.activePlayback
-    }
-
-    private func bindCoreEvents() {
-        guard let core = core else { return }
-        listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] _ in self?.bindEvents() }
-    }
-
-    private func bindContainerEvents() {
-        if let container = activeContainer {
-            listenTo(container,
-                     eventName: Event.didChangePlayback.rawValue) { [weak self] (_: EventUserInfo) in self?.bindEvents() }
-        }
     }
 
     fileprivate func setSeekbarViewLive() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/TimeIndicator.swift
@@ -65,22 +65,9 @@ open class TimeIndicator: MediaControlPlugin {
         return core?.activePlayback
     }
 
-    required public init(context: UIObject) {
-        super.init(context: context)
-        bindEvents()
-    }
-
-    private func bindEvents() {
-        stopListening()
-        bindContainerEvents()
+    override open func bindEvents() {
         bindPlaybackEvents()
         bindCoreEvents()
-    }
-
-    open func bindContainerEvents() {
-        if let container = activeContainer {
-            listenTo(container, eventName: Event.didChangePlayback.rawValue) { [weak self] (_: EventUserInfo) in self?.bindEvents() }
-        }
     }
 
     private func bindPlaybackEvents() {
@@ -94,7 +81,6 @@ open class TimeIndicator: MediaControlPlugin {
         if let core = self.core {
             listenTo(core, eventName: Event.didEnterFullscreen.rawValue) { [weak self] _ in self?.updateLayoutConstants() }
             listenTo(core, eventName: Event.didExitFullscreen.rawValue) { [weak self] _ in self?.updateLayoutConstants() }
-            listenTo(core, eventName: Event.didChangeActiveContainer.rawValue) { [weak self] (_: EventUserInfo) in self?.bindEvents() }
         }
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugins/Container/UIContainerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Container/UIContainerPluginTests.swift
@@ -49,8 +49,12 @@ class UIContainerPluginTests: QuickSpec {
         override class var name: String {
             return "StubContainerPlugin"
         }
+
+        override func bindEvents() { }
     }
 
     class NoNameContainerPlugin: UIContainerPlugin {
+
+        override func bindEvents() { }
     }
 }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlPluginTests.swift
@@ -10,7 +10,7 @@ class MediaControlPluginTests: QuickSpec {
 
         beforeEach {
             core = CoreStub()
-            mediaControlPlugin = MediaControlPlugin(context: core)
+            mediaControlPlugin = StubMediaControlPlugin(context: core)
         }
 
         describe("MediaControlPlugin") {
@@ -50,4 +50,12 @@ class MediaControlPluginTests: QuickSpec {
             }
         }
     }
+}
+
+class StubMediaControlPlugin: MediaControlPlugin {
+    override class var name: String {
+        return "StubMediaControlPlugin"
+    }
+    
+    override func bindEvents() { }
 }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -511,7 +511,9 @@ class MediaControlPluginMock: MediaControlPlugin {
     open override var position: MediaControlPosition {
         return MediaControlPluginMock._position
     }
-    
+
+    override func bindEvents() { }
+
     override func render() {
         MediaControlPluginMock.didCallRender = true
 
@@ -541,6 +543,7 @@ class TimeIndicatorPluginMock: TimeIndicator {
     open override var position: MediaControlPosition {
         return .right
     }
+
 }
 
 class FirstPlugin: MediaControlPlugin {
@@ -554,6 +557,8 @@ class FirstPlugin: MediaControlPlugin {
             view.addSubview(button)
         }
     }
+
+    override func bindEvents() { }
 
     override open func render() {
         button = UIButton(type: .custom)
@@ -579,6 +584,8 @@ class SecondPlugin: MediaControlPlugin {
             view.addSubview(button)
         }
     }
+
+    override func bindEvents() { }
 
     override open func render() {
         button = UIButton(type: .custom)

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -404,6 +404,8 @@ class ContainerTests: QuickSpec {
             return "AnotherFakeContainerPlugin"
         }
 
+        override func bindEvents() { }
+        
         override func render() {
             AnotherFakeContainerPlugin.didCallRender = true
 

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -15,6 +15,8 @@ class CoreTests: QuickSpec {
             override class var name: String {
                 return "FakeCorePLugin"
             }
+
+            override func bindEvents() {  }
         }
 
         let options = [kSourceUrl: "http//test.com"]
@@ -754,6 +756,7 @@ class UICorePluginMock: UICorePlugin {
         }
     }
 
+    override func bindEvents() {  }
 
     override func destroy() {
         UICorePluginMock.didCallDestroy = true
@@ -776,6 +779,7 @@ class CorePluginMock: CorePlugin {
     override class var name: String {
         return "CorePluginMock"
     }
+
 }
 
 #if os(iOS)

--- a/Tests/Clappr_Tests/LoaderTests.swift
+++ b/Tests/Clappr_Tests/LoaderTests.swift
@@ -97,18 +97,24 @@ class LoaderTests: QuickSpec {
         override class var name: String {
             return "uicontainer"
         }
+
+        override func bindEvents() { }
     }
 
     class StubUICorePlugin: UICorePlugin {
         override class var name: String {
             return "uicore"
         }
+
+        override func bindEvents() { }
     }
 
     class StubSpinnerPlugin: UIContainerPlugin {
         override class var name: String {
             return "spinner"
         }
+
+        override func bindEvents() { }
     }
     
     class StubCorePlugin: CorePlugin {

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -350,5 +350,7 @@ class PlayerTests: QuickSpec {
         override class var name: String {
             return "FakeContainerPlugin"
         }
+
+        override func bindEvents() { }
     }
 }

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -331,11 +331,9 @@ class PlayerTests: QuickSpec {
 
         required init(context: UIObject) {
             super.init(context: context)
-            bindEvents()
         }
 
-        private func bindEvents() {
-            stopListening()
+        override public func bindEvents() {
             bindPlaybackEvents()
         }
 

--- a/Tests/Clappr_Tests/UICorePluginTests.swift
+++ b/Tests/Clappr_Tests/UICorePluginTests.swift
@@ -49,8 +49,12 @@ class UICorePluginTests: QuickSpec {
         override class var name: String {
             return "StubCorePlugin"
         }
+
+        override func bindEvents() { }
     }
 
     class NoNameCorePlugin: UICorePlugin {
+
+        override func bindEvents() { }
     }
 }


### PR DESCRIPTION
# Goal

The objective of this refactor is push the `bindEvents` up in the hierarchy of plugins so that plugins don't forget to `stopListening` or to re-`bindEvents` when `didChangeActiveContainer` and `didChangeActivePlayback` are triggered.

The main changes are in `ContainerPlugin.swift` and `CorePlugin.swift`. All other changes are so that plugins comply with the new structure.


A secondary benefit is that many plugins now don't need to override the required constructor when the only thing it used to do was to bind events.

# How to test
1. Run `make test`
2. Test the basic functionality in the example app.