### PR TITLE
Trigger didStop from NoOpPlayback to prevent race conditions while video is being loaded

### DIFF
--- a/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
+++ b/Sources/Clappr/Classes/Playback/NoOpPlayback.swift
@@ -26,6 +26,10 @@ open class NoOpPlayback: Playback {
         view.addSubviewMatchingConstraints(errorLabel)
     }
 
+    open override func stop() {
+        trigger(.didStop)
+    }
+
     fileprivate func setupLabel() {
         errorLabel.translatesAutoresizingMaskIntoConstraints = false
         errorLabel.text = labelText()

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -147,30 +147,6 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
                     }
                 }
-
-                context("when play and stop") {
-                    it("triggers events following the state machine pattern") {
-                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
-                        let playback = AVFoundationPlayback(options: options)
-                        let expectedEvents: [Event] = [
-                            .ready, .willPause, .didPause,
-                            .willPlay, .stalling, .willStop, .didStop
-                        ]
-                        var triggeredEvents: [Event] = []
-                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
-                            playback.on(event.rawValue) { _ in
-                                triggeredEvents.append(event)
-                            }
-                        }
-                        playback.render()
-                        
-                        playback.play()
-                        playback.stop()
-                        playback.destroy()
-
-                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
-                    }
-                }
             }
 
             describe("#state machine error events") {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -147,6 +147,30 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
                     }
                 }
+
+                context("when play and stop") {
+                    it("triggers events following the state machine pattern") {
+                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
+                        let playback = AVFoundationPlayback(options: options)
+                        let expectedEvents: [Event] = [
+                            .ready, .willPause, .didPause,
+                            .willPlay, .stalling, .willStop, .didStop
+                        ]
+                        var triggeredEvents: [Event] = []
+                        for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {
+                            playback.on(event.rawValue) { _ in
+                                triggeredEvents.append(event)
+                            }
+                        }
+                        playback.render()
+                        
+                        playback.play()
+                        playback.stop()
+                        playback.destroy()
+
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 5)
+                    }
+                }
             }
 
             describe("#state machine error events") {

--- a/Tests/Clappr_Tests/NoOpPlaybackTests.swift
+++ b/Tests/Clappr_Tests/NoOpPlaybackTests.swift
@@ -13,13 +13,23 @@ class NoOpPlaybackTests: QuickSpec {
                 it("doesn't trigger ready event") {
                     let playback = NoOpPlayback(options: [:])
                     var didCallEvent = false
-                    playback.on(Event.ready.rawValue) { _ in
-                        didCallEvent = true
-                    }
+                    playback.on(Event.ready.rawValue) { _ in didCallEvent = true }
 
                     playback.render()
 
-                    expect(didCallEvent) == false
+                    expect(didCallEvent).to(beFalse())
+                }
+            }
+
+            describe("#stop") {
+                it("triggers didStop event") {
+                    let playback = NoOpPlayback(options: [:])
+                    var didCallEvent = false
+                    playback.on(Event.didStop.rawValue) { _ in didCallEvent = true }
+
+                    playback.stop()
+
+                    expect(didCallEvent).to(beTrue())
                 }
             }
         }


### PR DESCRIPTION
### 🏁 Goal:
To make sure we trigger didStop on NoOpPlayback
This will prevent a weird behavior where user can stop the player while in between NoOpPlayback and AVFoundationPlayback

### ✅ How to test:
1. Run the tests and make sure they pass. There's no way to simulate the behavior on the sample app