### PR TITLE
Release snapshot from a branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,9 @@ test: ## Run clappr-ios tests
 release: ## Release clappr-ios to cocoa pods
 	$(FASTLANE) release version:$(version)
 
+release_snapshot:
+	$(FASTLANE) release_snapshot version:$(version)
+
 lint: ## Run swiftlint
 	$(FASTLANE) lint
+

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -72,7 +72,7 @@ end
 desc "Release a new snapshot"
 lane :release_snapshot do |options|
   version = options[:version].to_s
-  UI.user_error!("You need to provide the new version number like: make release_snapshot version='X.X.X'") if version.strip.empty?
+  UI.user_error!("You need to provide the new version number like: make release_snapshot version='X.X.X'") if version.strip.empty? || !version.include?("snapshot")
 
   ensure_git_status_clean
 
@@ -92,6 +92,8 @@ lane :release_snapshot do |options|
   pod_push(
     allow_warnings: true
   )
+
+  reset_git_repo
 end
 
 desc "Release a new version of Clappr"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,6 +60,37 @@ lane :version_bump do |options|
   )
 end
 
+
+desc "Bump version in all necessary files"
+lane :bump do |options|
+  version = options[:version]
+  puts "Version from parameter: " + version
+
+  version_bump_podspec(path: ENV['podspec_file'], version_number: version)
+end
+
+desc "Release a new snapshot"
+lane :release_snapshot do |options|
+  ensure_git_status_clean
+
+  bump(options)
+
+  test
+
+  set_github_release(
+    repository_name: "clappr/clappr-ios",
+    api_token: ENV["GITHUB_TOKEN"],
+    name: "",
+    tag_name: options[:version],
+    description: "TODO: write release notes here",
+    is_prerelease: true
+  )
+
+  pod_push(
+    allow_warnings: true
+  )
+end
+
 desc "Release a new version of Clappr"
 lane :release do |options|
   UI.user_error!("You need to provide the new version number like: make release version=X.X.X") if options[:version].to_s.strip.empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,17 +71,20 @@ end
 
 desc "Release a new snapshot"
 lane :release_snapshot do |options|
+  version = options[:version].to_s
+  UI.user_error!("You need to provide the new version number like: make release_snapshot version='X.X.X'") if version.strip.empty?
+
   ensure_git_status_clean
 
-  bump(options)
-
   test
+
+  bump(options)
 
   set_github_release(
     repository_name: "clappr/clappr-ios",
     api_token: ENV["GITHUB_TOKEN"],
-    name: "",
-    tag_name: options[:version],
+    name: version,
+    tag_name: version,
     description: "TODO: write release notes here",
     is_prerelease: true
   )

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -30,6 +30,16 @@ Runs swiftlint producing an html report
 fastlane version_bump
 ```
 Bump version in Podspec and Info.plist
+### bump
+```
+fastlane bump
+```
+Bump version in all necessary files
+### release_snapshot
+```
+fastlane release_snapshot
+```
+Release a new snapshot
 ### release
 ```
 fastlane release


### PR DESCRIPTION
## 🏁 Goal
- Allow publishing snapshots from the current branch

## ✅ Test
- run `make release_snapshot version='0.11.46-snapshot'` and verify that it will create a `pre-release on github`
<img width="991" alt="Captura de Tela 2019-05-28 às 12 44 15" src="https://user-images.githubusercontent.com/997521/58494158-d7d2f300-814a-11e9-9a54-dfd344e3abd8.png">

- You can also try pod install Clappr with the `0.11.46-snapshot` version