### PR TITLE
Expose missing plugin name

### DIFF
--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -4,7 +4,7 @@ open class Playback: UIObject, NamedType {
     open class var type: PluginType { return .playback }
 
     @objc open class var name: String {
-        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Playback Plugins should always declare a name", userInfo: nil).raise()
+        NSException(name: NSExceptionName(rawValue: "MissingPlaybackName"), reason: "Playbacks should always declare a name. \(self) does not.", userInfo: nil).raise()
         return ""
     }
 

--- a/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/ContainerPlugin.swift
@@ -3,7 +3,7 @@ open class ContainerPlugin: BaseObject, Plugin {
     open class var type: PluginType { return .container }
 
     @objc open class var name: String {
-        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Container Plugins should always declare a name", userInfo: nil).raise()
+        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Container Plugins should always declare a name. \(self) does not.", userInfo: nil).raise()
         return ""
     }
     

--- a/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/CorePlugin.swift
@@ -3,7 +3,7 @@ open class CorePlugin: BaseObject, Plugin {
     open class var type: PluginType { return .core }
     
     @objc open class var name: String {
-        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "CorePlugin Plugins should always declare a name", userInfo: nil).raise()
+        NSException(name: NSExceptionName(rawValue: "MissingPluginName"), reason: "Core Plugins should always declare a name. \(self) does not.", userInfo: nil).raise()
         return ""
     }
     

--- a/Tests/Clappr_Tests/Classes/Plugins/Container/ContainerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Container/ContainerPluginTests.swift
@@ -33,7 +33,7 @@ class ContainerPluginTests: QuickSpec {
                     let container = ContainerStub()
                     let containerPlugin = ContainerPlugin(context: container)
                     let expectedExceptionName = "MissingPluginName"
-                    let expectedExceptionReason = "Container Plugins should always declare a name"
+                    let expectedExceptionReason = "Container Plugins should always declare a name. ContainerPlugin does not."
                     expect(containerPlugin.pluginName).to(raiseException(named: expectedExceptionName, reason: expectedExceptionReason))
                 }
             }
@@ -41,7 +41,7 @@ class ContainerPluginTests: QuickSpec {
             describe("#name") {
                 it("returns an exception") {
                     let expectedExceptionName = "MissingPluginName"
-                    let expectedExceptionReason = "Container Plugins should always declare a name"
+                    let expectedExceptionReason = "Container Plugins should always declare a name. ContainerPlugin does not."
                     
                     expect(ContainerPlugin.name).to(raiseException(named: expectedExceptionName, reason: expectedExceptionReason))
                 }

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/CorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/CorePluginTests.swift
@@ -33,7 +33,7 @@ class CorePluginTests: QuickSpec {
                     let core = CoreStub()
                     let corePlugin = CorePlugin(context: core)
                     let expectedExceptionName = "MissingPluginName"
-                    let expectedExceptionReason = "CorePlugin Plugins should always declare a name"
+                    let expectedExceptionReason = "Core Plugins should always declare a name. CorePlugin does not."
                     expect(corePlugin.pluginName).to(raiseException(named: expectedExceptionName, reason: expectedExceptionReason))
                 }
             }
@@ -41,7 +41,7 @@ class CorePluginTests: QuickSpec {
             describe("#name") {
                 it("returns an exception") {
                     let expectedExceptionName = "MissingPluginName"
-                    let expectedExceptionReason = "CorePlugin Plugins should always declare a name"
+                    let expectedExceptionReason = "Core Plugins should always declare a name. CorePlugin does not."
                     
                     expect(CorePlugin.name).to(raiseException(named: expectedExceptionName, reason: expectedExceptionReason))
                 }

--- a/Tests/Clappr_Tests/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/PlaybackTests.swift
@@ -13,6 +13,15 @@ class PlaybackTests: QuickSpec {
                 playback = StubPlayback(options: options as Options)
             }
 
+            describe("#name") {
+                it("throws an exception because it is an `abstract` class") {
+                    let expectedExceptionName = "MissingPlaybackName"
+                    let expectedExceptionReason = "Playbacks should always declare a name. Playback does not."
+
+                    expect(Playback.name).to(raiseException(named: expectedExceptionName, reason: expectedExceptionReason))
+                }
+            }
+
             it("set frame of Playback to CGRect.zero") {
                 expect(playback.view.frame) == CGRect.zero
             }

--- a/Tests/Clappr_Tests/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/PlaybackTests.swift
@@ -22,55 +22,55 @@ class PlaybackTests: QuickSpec {
                 }
             }
 
-            it("set frame of Playback to CGRect.zero") {
+            it("sets frame of Playback to CGRect.zero") {
                 expect(playback.view.frame) == CGRect.zero
             }
 
-            it("set backgroundColor to clear") {
+            it("sets backgroundColor to clear") {
                 expect(playback.view.backgroundColor).to(beNil())
             }
 
-            it("set isUserInteractionEnabled to false") {
+            it("sets isUserInteractionEnabled to false") {
                 expect(playback.view.isUserInteractionEnabled) == false
             }
 
-            it("have a play method") {
+            it("has a play method") {
                 let responds = playback.responds(to: #selector(Playback.play))
                 expect(responds).to(beTrue())
             }
 
-            it("have a pause method") {
+            it("has a pause method") {
                 let responds = playback.responds(to: #selector(Progress.pause))
                 expect(responds).to(beTrue())
             }
 
-            it("have a stop method") {
+            it("has a stop method") {
                 let responds = playback.responds(to: #selector(NetService.stop))
                 expect(responds).to(beTrue())
             }
 
-            it("have a seek method receiving a time") {
+            it("has a seek method receiving a time") {
                 let responds = playback.responds(to: #selector(Playback.seek(_:)))
                 expect(responds).to(beTrue())
             }
 
-            it("have a duration var with a default value 0") {
+            it("has a duration var with a default value 0") {
                 expect(playback.duration) == 0
             }
 
-            it("have a isPlaying var with a default value false") {
+            it("has a isPlaying var with a default value false") {
                 expect(playback.isPlaying).to(beFalse())
             }
 
-            it("have a type var with a default value Unknown") {
+            it("has a type var with a default value Unknown") {
                 expect(playback.playbackType).to(equal(PlaybackType.unknown))
             }
 
-            it("have a isHighDefinitionInUse var with a default value false") {
+            it("has a isHighDefinitionInUse var with a default value false") {
                 expect(playback.isHighDefinitionInUse).to(beFalse())
             }
 
-            it("removed from superview when destroy is called") {
+            it("is removed from superview when destroy is called") {
                 let container = UIView()
                 container.addSubview(playback.view)
 
@@ -79,7 +79,7 @@ class PlaybackTests: QuickSpec {
                 expect(playback.view.superview).to(beNil())
             }
 
-            it("stop listening events after destroy has been called") {
+            it("stops listening to events after destroy has been called") {
                 var callbackWasCalled = false
 
                 playback.on("some-event") { _ in
@@ -92,7 +92,7 @@ class PlaybackTests: QuickSpec {
                 expect(callbackWasCalled) == false
             }
 
-            it("have a class function to check if a source can be played with default value false") {
+            it("has a class function to check if a source can be played with default value false") {
                 let canPlay = Playback.canPlay([:])
                 expect(canPlay) == false
             }
@@ -103,7 +103,7 @@ class PlaybackTests: QuickSpec {
                     expect(playback.startAt) == 10.0
                 }
 
-                it("have startAt with 0 if no time is set on options") {
+                it("has startAt with 0 if no time is set on options") {
                     let playback = StubPlayback(options: [:])
                     expect(playback.startAt) == 0.0
                 }
@@ -120,12 +120,12 @@ class PlaybackTests: QuickSpec {
             }
 
             context("Playback source") {
-                it("have a source property with the url sent via options") {
+                it("has a source property with the url sent via options") {
                     let playback = StubPlayback(options: [kSourceUrl: "someUrl"])
                     expect(playback.source) == "someUrl"
                 }
 
-                it("have a source property with nil if no source is set") {
+                it("has a source property with nil if no source is set") {
                     let playback = StubPlayback(options: [:])
                     expect(playback.source).to(beNil())
                 }


### PR DESCRIPTION
# Goal
Whenever a new plugin extending `CorePlugin` or `ContainerPlugin` or a new playback extending `Playback` does not override the `open class var name: String`, the exception will now display the class name like so:

```
Core Plugins should always declare a name. MyNewPluginClass does not.
```

# How to test
Run `make test`