### PR TITLE
Trigger didLoop event for every video loop

### DIFF
--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -16,6 +16,7 @@ public enum Event: String, CaseIterable {
     case didPause = "Clappr:didPause"
     case willStop = "Clappr:willStop"
     case didStop = "Clappr:didStop"
+    case didLoop = "Clappr:didLoop"
     case error = "Clappr:error"
     case didUpdateAirPlayStatus = "Clappr:didUpdateAirPlayStatus"
     case requestFullscreen = "Clappr:requestFullscreen"

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -32,7 +32,7 @@ open class AVFoundationPlayback: Playback {
     private var timeObserver: Any?
     private var asset: AVURLAsset?
     private var backgroundSessionBackup: AVAudioSession.Category?
-    private var loopObserver: NSKeyValueObservation?
+    private(set) var loopObserver: NSKeyValueObservation?
 
     var lastDvrAvailability: Bool?
     #if os(tvOS)

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -18,14 +18,21 @@ open class AVFoundationPlayback: Playback {
     
     private var selectedCharacteristics: [AVMediaCharacteristic] = []
 
-    @objc internal dynamic var player: AVPlayer?
+    @objc dynamic internal var player: AVPlayer?
+    @objc dynamic private var playerLooper: AVPlayerLooper? {
+        didSet {
+            loopObserver = observe(\.playerLooper?.loopCount) { [weak self] _, _ in
+                self?.trigger(.didLoop)
+            }
+        }
+    }
     private var playerLayer: AVPlayerLayer?
-    private var playerLooper: AVPlayerLooper?
     private var playerStatus: AVPlayerItem.Status = .unknown
     private var isStopped = false
     private var timeObserver: Any?
     private var asset: AVURLAsset?
     private var backgroundSessionBackup: AVAudioSession.Category?
+    private var loopObserver: NSKeyValueObservation?
 
     var lastDvrAvailability: Bool?
     #if os(tvOS)
@@ -614,6 +621,7 @@ open class AVFoundationPlayback: Playback {
             player.removeTimeObserver(timeObserver)
         }
         view.removeObserver(self, forKeyPath: "bounds")
+        loopObserver = nil
     }
 
     override open func destroy() {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -86,6 +86,18 @@ class AVFoundationPlaybackTests: QuickSpec {
                             expect(didLoopTriggered).toEventually(beTrue(), timeout: 3)
                         }
                     }
+
+                    context("on stop") {
+                        it("stops observing loopCount") {
+                            let options: Options = [kSourceUrl: "http://clappr.io/highline.mp4", kLoop: true]
+                            let playback = AVFoundationPlayback(options: options)
+
+                            playback.play()
+                            playback.stop()
+
+                            expect(playback.loopObserver).to(beNil())
+                        }
+                    }
                 }
             }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -68,6 +68,24 @@ class AVFoundationPlaybackTests: QuickSpec {
                         
                         expect(playback.player).to(beAKindOf(AVQueuePlayer.self))
                     }
+
+                    context("when video finishes") {
+                        it("triggers didLoop event") {
+                            let options: Options = [kSourceUrl: "http://clappr.io/highline.mp4", kLoop: true]
+                            let playback = AVFoundationPlayback(options: options)
+
+                            var didLoopTriggered = false
+
+                            playback.on(Event.didLoop.rawValue) { _ in
+                                didLoopTriggered = true
+                            }
+
+                            playback.play()
+                            playback.seek(playback.duration)
+
+                            expect(didLoopTriggered).toEventually(beTrue(), timeout: 3)
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## 🏁 Goal
- To trigger a `didLoop` event on every video loop

## ✅ How to test
1. On `DashboardViewController.swift`, add a new option: `kLoop: true`
2. On AVFoundationPlayback.swift, place a breakpoint on line 25, within the observer scope
3. Play the video and drag the scrubber to the end of the video
4. You should see the code stopping on your breakpoint
5. You can repeat steps 3 and 4 just to make sure it is always triggering the `didLoop` event.