### PR TITLE
Full Screen Events triggered twice

### DIFF
--- a/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
+++ b/Sources/Clappr_iOS/Classes/Base/FullScreen/FullScreenStateHandler.swift
@@ -49,7 +49,6 @@ struct FullscreenByPlayer: FullscreenStateHandler {
         core.parentController?.present(fullscreenController, animated: false) {
             fullscreenController.view.addSubviewMatchingConstraints(self.core.view)
             self.core.trigger(Event.didEnterFullscreen.rawValue)
-            self.core.trigger(InternalEvent.userRequestEnterInFullscreen.rawValue)
         }
     }
 
@@ -59,7 +58,6 @@ struct FullscreenByPlayer: FullscreenStateHandler {
         core.isFullscreen = false
         handleExit()
         core.trigger(Event.didExitFullscreen.rawValue)
-        core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
     }
 
     private func handleExit() {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -72,7 +72,6 @@ open class Player: BaseObject {
              Event.playing.rawValue, Event.didComplete.rawValue,
              Event.didPause.rawValue, Event.stalling.rawValue,
              Event.didStop.rawValue, Event.didUpdateBuffer.rawValue,
-             Event.requestFullscreen.rawValue, Event.exitFullscreen.rawValue,
              Event.willPlay.rawValue, Event.didUpdatePosition.rawValue,
              Event.willPause.rawValue, Event.willStop.rawValue,
              Event.willSeek.rawValue, Event.didUpdateAirPlayStatus.rawValue,

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -109,17 +109,13 @@ class CoreTests: QuickSpec {
                     it("start as fullscreen video when `kFullscreenByApp: false` and setFullscreen is called") {
                         options[kFullscreenByApp] = false
                         let player = Player(options: options)
-                        var callbackWasCalled = false
-                        player.on(.requestFullscreen) { _ in
-                            callbackWasCalled = true
-                        }
 
                         self.playerSetup(player: player)
 
                         player.setFullscreen(true)
 
-                        expect(callbackWasCalled).toEventually(beTrue())
                         expect(player.core!.parentView?.subviews.contains(core.view)).to(beFalse())
+                        expect(player.isFullscreen).to(beTrue())
                         expect(player.core!.isFullscreen).to(beTrue())
                     }
                 }
@@ -442,16 +438,11 @@ class CoreTests: QuickSpec {
 
                     it("start as fullscreen video when its false") {
                         let player = Player(options: [kFullscreenByApp: false] as Options)
-                        var callbackWasCalled = false
-                        player.on(.requestFullscreen) { _ in
-                            callbackWasCalled = true
-                        }
 
                         self.playerSetup(player: player)
 
                         player.setFullscreen(true)
 
-                        expect(callbackWasCalled).toEventually(beTrue())
                         expect(player.core!.parentView?.subviews.contains(core.view)).to(beFalse())
                         expect(player.core!.isFullscreen).to(beTrue())
                     }
@@ -461,16 +452,11 @@ class CoreTests: QuickSpec {
 
                     it("start as fullscreen video") {
                         let player = Player(options: [kFullscreenByApp: false] as Options)
-                        var callbackWasCalled = false
-                        player.on(.requestFullscreen) { _ in
-                            callbackWasCalled = true
-                        }
 
                         self.playerSetup(player: player)
 
                         player.setFullscreen(true)
 
-                        expect(callbackWasCalled).toEventually(beTrue())
                         expect(player.core!.parentView?.subviews.contains(core.view)).to(beFalse())
                         expect(player.core!.isFullscreen).to(beTrue())
                     }

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -178,23 +178,6 @@ class PlayerTests: QuickSpec {
                         expect(callbackWasCalled).to(beTrue())
                     }
 
-                    it("calls a callback function to handle requestFullscreen event") {
-                        player.on(.requestFullscreen) { _ in
-                            callbackWasCalled = true
-                        }
-                        playback.trigger(.requestFullscreen)
-
-                        expect(callbackWasCalled).to(beTrue())
-                    }
-
-                    it("calls a callback function to handle exitFullscreen event") {
-                        player.on(.exitFullscreen) { _ in
-                            callbackWasCalled = true
-                        }
-                        playback.trigger(.exitFullscreen)
-
-                        expect(callbackWasCalled).to(beTrue())
-                    }
                 }
 
                 context("core dependency") {


### PR DESCRIPTION
# Goal
Fix a problem where the `userRequest*FullScreen` events were being triggered twice when the option `kFullscreenByApp == false` or not set.

# How to test
1. Open the example app
2. Play the video
3. Put it in full screen mode and exit.
4. Check that the message `on requestFullscreen`/`on exitFullscreen` only appear once

try variations with the fullscreenByApp true and false, as well as starting the example app already in full screen.