### PR TITLE
Create didAttachView event

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -96,6 +96,12 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         parentView?.addSubviewMatchingConstraints(view)
     }
 
+    open func attach(to parentView: UIView, controller: UIViewController) {
+        self.parentController = controller
+        self.parentView = parentView
+        trigger(Event.didAttachView)
+    }
+
     open override func render() {
         containers.forEach(renderContainer)
         addToContainer()

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -55,4 +55,5 @@ public enum Event: String, CaseIterable {
     case willShowModal = "Clappr:willShowModal"
     case willHideModal = "Clappr:willHideModal"
     case didResize = "Clappr:didResize"
+    case didAttachView = "Clappr:didAttachView"
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -108,8 +108,7 @@ open class Player: BaseObject {
     }
     
     @objc open func attachTo(_ view: UIView, controller: UIViewController) {
-        core?.parentController = controller
-        core?.parentView = view
+        core?.attach(to: view, controller: controller)
         core?.render()
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -9,9 +9,7 @@ open class Player: UIViewController {
     private let baseObject = BaseObject()
 
     override open func viewDidLoad() {
-        core?.parentView = view
-
-        if isMediaControlEnabled != false {
+        if isMediaControlEnabled {
             viewController = DecoratedPressAVPlayerViewController(player: self)
             core?.parentView = viewController?.contentOverlayView
             core?.parentController = self
@@ -20,7 +18,11 @@ open class Player: UIViewController {
             viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             view.addSubview(viewController.view)
             viewController.didMove(toParent: self)
+        } else {
+            core?.parentView = view
         }
+
+        core?.trigger(.didAttachView)
 
         NotificationCenter.default.addObserver(self, selector: #selector(Player.willEnterForeground), name:
             UIApplication.willEnterForegroundNotification, object: nil)

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -76,6 +76,25 @@ class CoreTests: QuickSpec {
                 #endif
             }
 
+            describe("On view ready") {
+                context("when a parentView is set") {
+                    it("triggers a core ready event") {
+                        let core = CoreFactory.create(with: [:])
+                        let parentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+                        let parentViewController = UIViewController()
+
+                        var didTriggerEvent = false
+                        core.listenTo(core, eventName: Event.didAttachView.rawValue) { _ in
+                            didTriggerEvent = true
+                        }
+
+                        core.attach(to: parentView, controller: parentViewController)
+
+                        expect(didTriggerEvent).to(beTrue())
+                    }
+                }
+            }
+
             #if os(iOS)
             describe("Fullscreen") {
                 var options: Options!

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -269,7 +269,24 @@ class PlayerTests: QuickSpec {
                 }
             }
 
-            describe("#lifecycle") {
+            describe("#attachTo") {
+                fit("triggers didAttachView") {
+                    let player = Player(options: [:])
+                    let view = UIView(frame: .zero)
+                    let controller = UIViewController()
+
+                    var didTriggerEvent = false
+                    player.listenTo(player.core!, eventName: Event.didAttachView.rawValue) { _ in
+                        didTriggerEvent = true
+                    }
+
+                    player.attachTo(view, controller: controller)
+
+                    expect(didTriggerEvent).to(beTrue())
+                }
+            }
+
+            describe("lifecycle") {
                 it("triggers events of destruction correctly") {
                     var triggeredEvents = [String]()
                     player = Player(options: options)

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -270,7 +270,7 @@ class PlayerTests: QuickSpec {
             }
 
             describe("#attachTo") {
-                fit("triggers didAttachView") {
+                it("triggers didAttachView") {
                     let player = Player(options: [:])
                     let view = UIView(frame: .zero)
                     let controller = UIViewController()

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -49,6 +49,21 @@ class PlayerTests: QuickSpec {
                     expect(player.core!.options["foo"] as? String).to(equal("bar"))
                 }
             }
+
+            describe("attachTo") {
+                it("triggers didAttachView") {
+                    let player = Player(options: [:])
+
+                    var didTriggerEvent = false
+                    player.listenTo(player.core!, eventName: Event.didAttachView.rawValue) { _ in
+                        didTriggerEvent = true
+                    }
+
+                    player.viewDidLoad()
+
+                    expect(didTriggerEvent).to(beTrue())
+                }
+            }
             
             it("Should listen to didSelectSubtitle event") {
                 var callbackWasCalled = false


### PR DESCRIPTION
## 🏁 Goal:
- To trigger a `didAttachView` event every time we attach a parentView to it through `attachTo` method.
## ✅ How to test:
1. On Player.swift, Create a dummy CorePlugin at the bottom of the file: 
```swift
class AttachPlugin: SimpleCorePlugin {

    override class var name: String {
        return "AttachPlugin"
    }

    override open func bindEvents() {
        guard let core = core else { return }
        listenTo(core, event: Event.didAttachView) { _ in
            print("Event.didAttachView").   <---- Breakpoint here! 😄 
        }
    }
}
```
2. Place a breakpoint on the `print` line of this plugin
3. Run the example project
4. Make sure the app stops at that line
