### PR TITLE
Refactors AvFoundationPlayback to use newer kvo syntax

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -7,7 +7,6 @@ open class AVFoundationPlayback: Playback {
     ]
 
     private var kvoBufferingContext = 0
-    private var kvoPlayerRateContext = 0
 
     private(set) var seekToTimeWhenReadyToPlay: TimeInterval?
     
@@ -269,14 +268,13 @@ open class AVFoundationPlayback: Playback {
             player.observe(\.currentItem?.loadedTimeRanges, options: .new, changeHandler: handleLoadedTimeRangesEvent),
             player.observe(\.currentItem?.seekableTimeRanges, options: .new, changeHandler: handleSeekableTimeRangesEvent),
             player.observe(\.isExternalPlaybackActive, options: .new, changeHandler: handleExternalPlaybackActiveEvent),
+            player.observe(\.rate, options: .new, changeHandler: handlePlayerRateChanged),
         ]
 
         player.addObserver(self, forKeyPath: "currentItem.playbackLikelyToKeepUp",
                             options: .new, context: &kvoBufferingContext)
         player.addObserver(self, forKeyPath: "currentItem.playbackBufferEmpty",
                             options: .new, context: &kvoBufferingContext)
-        player.addObserver(self, forKeyPath: "rate",
-                            options: .new, context: &kvoPlayerRateContext)
 
         NotificationCenter.default.addObserver(
             self,
@@ -452,8 +450,6 @@ open class AVFoundationPlayback: Playback {
         switch context {
         case &kvoBufferingContext:
             handleBufferingEvent(keyPath)
-        case &kvoPlayerRateContext:
-            handlePlayerRateChanged()
         default:
             break
         }
@@ -601,7 +597,6 @@ open class AVFoundationPlayback: Playback {
         guard let player = player, player.observationInfo != nil else { return }
         player.removeObserver(self, forKeyPath: "currentItem.playbackLikelyToKeepUp")
         player.removeObserver(self, forKeyPath: "currentItem.playbackBufferEmpty")
-        player.removeObserver(self, forKeyPath: "rate")
         if let timeObserver = timeObserver {
             player.removeTimeObserver(timeObserver)
         }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -10,7 +10,7 @@ open class AVFoundationPlayback: Playback {
     
     private var selectedCharacteristics: [AVMediaCharacteristic] = []
 
-    @objc dynamic internal var player: AVPlayer?
+    @objc dynamic var player: AVPlayer?
     @objc dynamic private var playerLooper: AVPlayerLooper? {
         didSet {
             loopObserver = observe(\.playerLooper?.loopCount) { [weak self] _, _ in

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -266,30 +266,31 @@ open class AVFoundationPlayback: Playback {
     #endif
 
     @objc internal func addObservers() {
+        guard let player = player else { return }
         self.observers += [
             view.observe(\UIView.bounds, options: .new, changeHandler: maximizePlayer),
         ]
 
-        player?.addObserver(self, forKeyPath: "currentItem.status",
+        player.addObserver(self, forKeyPath: "currentItem.status",
                             options: .new, context: &kvoStatusDidChangeContext)
-        player?.addObserver(self, forKeyPath: "currentItem.loadedTimeRanges",
+        player.addObserver(self, forKeyPath: "currentItem.loadedTimeRanges",
                             options: .new, context: &kvoLoadedTimeRangesContext)
-        player?.addObserver(self, forKeyPath: "currentItem.seekableTimeRanges",
+        player.addObserver(self, forKeyPath: "currentItem.seekableTimeRanges",
                             options: .new, context: &kvoSeekableTimeRangesContext)
-        player?.addObserver(self, forKeyPath: "currentItem.playbackLikelyToKeepUp",
+        player.addObserver(self, forKeyPath: "currentItem.playbackLikelyToKeepUp",
                             options: .new, context: &kvoBufferingContext)
-        player?.addObserver(self, forKeyPath: "currentItem.playbackBufferEmpty",
+        player.addObserver(self, forKeyPath: "currentItem.playbackBufferEmpty",
                             options: .new, context: &kvoBufferingContext)
-        player?.addObserver(self, forKeyPath: "externalPlaybackActive",
+        player.addObserver(self, forKeyPath: "externalPlaybackActive",
                             options: .new, context: &kvoExternalPlaybackActiveContext)
-        player?.addObserver(self, forKeyPath: "rate",
+        player.addObserver(self, forKeyPath: "rate",
                             options: .new, context: &kvoPlayerRateContext)
 
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(AVFoundationPlayback.playbackDidEnd),
             name: NSNotification.Name.AVPlayerItemDidPlayToEndTime,
-            object: player?.currentItem)
+            object: player.currentItem)
     }
 
     private func maximizePlayer(view: UIView, changes: NSKeyValueObservedChange<CGRect>) {


### PR DESCRIPTION
# Goal
Use newer syntax when adding key-value observer to player properties.

# How to test
Everything is pretty much covered by unit tests. So just `make test`
