### PR TITLE
Trigger willLoadSource from core when player.configure or load are called

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -176,6 +176,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     fileprivate func loadSourceIfNeeded() {
         if let source = options[kSourceUrl] as? String {
+            trigger(.willLoadSource)
             activeContainer?.load(source, mimeType: options[kMimeType] as? String)
         }
     }

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -6,7 +6,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         didSet {
             containers.forEach { $0.options = options }
             trigger(Event.didUpdateOptions)
-            loadSourceIfNeeded()
         }
     }
     @objc fileprivate(set) open var containers: [Container] = []
@@ -67,6 +66,13 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         
         Loader.shared.corePlugins.forEach { plugin in
             self.addPlugin(plugin.init(context: self))
+        }
+    }
+    
+    func load() {
+        if let source = options[kSourceUrl] as? String {
+            trigger(.willLoadSource)
+            activeContainer?.load(source, mimeType: options[kMimeType] as? String)
         }
     }
     
@@ -172,13 +178,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     fileprivate func renderContainer(_ container: Container) {
         view.addSubviewMatchingConstraints(container.view)
         container.render()
-    }
-
-    fileprivate func loadSourceIfNeeded() {
-        if let source = options[kSourceUrl] as? String {
-            trigger(.willLoadSource)
-            activeContainer?.load(source, mimeType: options[kMimeType] as? String)
-        }
     }
 
     open func addPlugin(_ plugin: Plugin) {

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -56,4 +56,5 @@ public enum Event: String, CaseIterable {
     case willHideModal = "Clappr:willHideModal"
     case didResize = "Clappr:didResize"
     case didAttachView = "Clappr:didAttachView"
+    case willConfigure = "Clappr:willConfigure"
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -29,6 +29,7 @@ public enum Event: String, CaseIterable {
     case didChangeDvrStatus = "Clappr:didChangeDvrStatus"
     case seekableUpdate = "Clappr:seekableUpdate"
     case didChangeDvrAvailability = "Clappr:didChangeDvrAvailability"
+    case willUpdateOptions = "Clappr:willUpdateOptions"
     case didUpdateOptions = "Clappr:didUpdateOptions"
     case willShowMediaControl = "Clappr:willShowMediaControl"
     case didShowMediaControl = "Clappr:didShowMediaControl"
@@ -56,5 +57,4 @@ public enum Event: String, CaseIterable {
     case willHideModal = "Clappr:willHideModal"
     case didResize = "Clappr:didResize"
     case didAttachView = "Clappr:didAttachView"
-    case willConfigure = "Clappr:willConfigure"
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -29,7 +29,6 @@ public enum Event: String, CaseIterable {
     case didChangeDvrStatus = "Clappr:didChangeDvrStatus"
     case seekableUpdate = "Clappr:seekableUpdate"
     case didChangeDvrAvailability = "Clappr:didChangeDvrAvailability"
-    case willUpdateOptions = "Clappr:willUpdateOptions"
     case didUpdateOptions = "Clappr:didUpdateOptions"
     case willShowMediaControl = "Clappr:willShowMediaControl"
     case didShowMediaControl = "Clappr:didShowMediaControl"

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -121,6 +121,7 @@ open class Player: BaseObject {
 
     open func configure(options: Options) {
         core?.options = options
+        core?.load()
     }
 
     open func play() {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -114,9 +114,9 @@ open class Player: BaseObject {
     }
 
     open func load(_ source: String, mimeType: String? = nil) {
-        core?.options[kSourceUrl] = source
-        core?.options[kMimeType] = mimeType
-        core?.load()
+        guard let core = core else { return }
+        let newOptions = core.options.merging([kSourceUrl: source, kMimeType: mimeType as Any], uniquingKeysWith: { _, second in second })
+        configure(options: newOptions)
         play()
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -119,7 +119,7 @@ open class Player: BaseObject {
     }
 
     open func configure(options: Options) {
-        core?.trigger(.willConfigure, userInfo: ["options": options])
+        core?.trigger(.willUpdateOptions, userInfo: ["options": options])
         core?.options = options
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -114,6 +114,7 @@ open class Player: BaseObject {
     }
 
     open func load(_ source: String, mimeType: String? = nil) {
+        core?.trigger(.willLoadSource)
         core?.activeContainer?.load(source, mimeType: mimeType)
         play()
     }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -120,7 +120,6 @@ open class Player: BaseObject {
     }
 
     open func configure(options: Options) {
-        core?.trigger(.willUpdateOptions, userInfo: ["options": options])
         core?.options = options
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -119,6 +119,7 @@ open class Player: BaseObject {
     }
 
     open func configure(options: Options) {
+        core?.trigger(.willConfigure, userInfo: ["options": options])
         core?.options = options
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -114,8 +114,9 @@ open class Player: BaseObject {
     }
 
     open func load(_ source: String, mimeType: String? = nil) {
-        core?.trigger(.willLoadSource)
-        core?.activeContainer?.load(source, mimeType: mimeType)
+        core?.options[kSourceUrl] = source
+        core?.options[kMimeType] = mimeType
+        core?.load()
         play()
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -148,7 +148,6 @@ open class Player: AVPlayerViewController {
     }
 
     open func configure(options: Options) {
-        core?.trigger(.willUpdateOptions, userInfo: ["options": options])
         core?.options = options
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -142,8 +142,9 @@ open class Player: AVPlayerViewController {
     }
 
     open func load(_ source: String, mimeType: String? = nil) {
-        core?.trigger(.willLoadSource)
-        activeContainer?.load(source, mimeType: mimeType)
+        core?.options[kSourceUrl] = source
+        core?.options[kMimeType] = mimeType
+        core?.load()
         play()
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -142,6 +142,7 @@ open class Player: AVPlayerViewController {
     }
 
     open func load(_ source: String, mimeType: String? = nil) {
+        core?.trigger(.willLoadSource)
         activeContainer?.load(source, mimeType: mimeType)
         play()
     }

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -147,6 +147,7 @@ open class Player: AVPlayerViewController {
     }
 
     open func configure(options: Options) {
+        core?.trigger(.willConfigure, userInfo: ["options": options])
         core?.options = options
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -142,9 +142,9 @@ open class Player: AVPlayerViewController {
     }
 
     open func load(_ source: String, mimeType: String? = nil) {
-        core?.options[kSourceUrl] = source
-        core?.options[kMimeType] = mimeType
-        core?.load()
+        guard let core = core else { return }
+        let newOptions = core.options.merging([kSourceUrl: source, kMimeType: mimeType as Any], uniquingKeysWith: { _, second in second })
+        configure(options: newOptions)
         play()
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -149,6 +149,7 @@ open class Player: AVPlayerViewController {
 
     open func configure(options: Options) {
         core?.options = options
+        core?.load()
     }
 
     open func play() {

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -147,7 +147,7 @@ open class Player: AVPlayerViewController {
     }
 
     open func configure(options: Options) {
-        core?.trigger(.willConfigure, userInfo: ["options": options])
+        core?.trigger(.willUpdateOptions, userInfo: ["options": options])
         core?.options = options
     }
 

--- a/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackTests.swift
@@ -83,7 +83,7 @@ class AVFoundationPlaybackTests: QuickSpec {
                             playback.play()
                             playback.seek(playback.duration)
 
-                            expect(didLoopTriggered).toEventually(beTrue(), timeout: 3)
+                            expect(didLoopTriggered).toEventually(beTrue(), timeout: 4)
                         }
                     }
 

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -283,19 +283,19 @@ class PlayerTests: QuickSpec {
                     expect(playerOptionValue).to(equal("bar"))
                 }
 
-                it("triggers willUpdateOptions with new options") {
-                    Loader.shared.resetPlugins()
-                    Player.register(playbacks: [SpecialStubPlayback.self, StubPlayback.self])
-                    player = Player(options: options)
+                it("triggers willLoadSource in core on load") {
+                    Loader.shared.resetPlaybacks()
+                    Player.register(playbacks: [SpecialStubPlayback.self])
+                    let player = Player(options: options)
+                    var willLoadSourceTriggered = false
 
-                    var newOptions: [String: String]?
-                    player.core!.on(Event.willUpdateOptions.rawValue) { userInfo in
-                        newOptions = userInfo?["options"] as? [String: String]
+                    player.core?.on(Event.willLoadSource.rawValue) { _ in
+                        willLoadSourceTriggered = true
                     }
 
-                    player.configure(options: ["foo": "bar"])
+                    player.load(PlayerTests.specialSource)
 
-                    expect(newOptions).to(equal(["foo": "bar"]))
+                    expect(willLoadSourceTriggered).to(beTrue())
                 }
             }
 

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -210,6 +210,21 @@ class PlayerTests: QuickSpec {
 
                         expect(player.activePlayback).to(beAKindOf(SpecialStubPlayback.self))
                     }
+
+                    it("triggers willLoadSource in core") {
+                        Loader.shared.resetPlaybacks()
+                        Player.register(playbacks: [SpecialStubPlayback.self])
+                        let player = Player(options: options)
+                        var willLoadSourceTriggered = false
+
+                        player.core?.on(Event.willLoadSource.rawValue) { _ in
+                            willLoadSourceTriggered = true
+                        }
+
+                        player.load(PlayerTests.specialSource)
+
+                        expect(willLoadSourceTriggered).to(beTrue())
+                    }
                 }
 
                 context("third party plugins") {

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -267,6 +267,21 @@ class PlayerTests: QuickSpec {
 
                     expect(playerOptionValue).to(equal("bar"))
                 }
+
+                it("triggers willConfigure with new options") {
+                    Loader.shared.resetPlugins()
+                    Player.register(playbacks: [SpecialStubPlayback.self, StubPlayback.self])
+                    player = Player(options: options)
+
+                    var newOptions: [String: String]?
+                    player.core!.on(Event.willConfigure.rawValue) { userInfo in
+                        newOptions = userInfo?["options"] as? [String: String]
+                    }
+
+                    player.configure(options: ["foo": "bar"])
+
+                    expect(newOptions).to(equal(["foo": "bar"]))
+                }
             }
 
             describe("#attachTo") {

--- a/Tests/Clappr_Tests/PlayerTests.swift
+++ b/Tests/Clappr_Tests/PlayerTests.swift
@@ -268,13 +268,13 @@ class PlayerTests: QuickSpec {
                     expect(playerOptionValue).to(equal("bar"))
                 }
 
-                it("triggers willConfigure with new options") {
+                it("triggers willUpdateOptions with new options") {
                     Loader.shared.resetPlugins()
                     Player.register(playbacks: [SpecialStubPlayback.self, StubPlayback.self])
                     player = Player(options: options)
 
                     var newOptions: [String: String]?
-                    player.core!.on(Event.willConfigure.rawValue) { userInfo in
+                    player.core!.on(Event.willUpdateOptions.rawValue) { userInfo in
                         newOptions = userInfo?["options"] as? [String: String]
                     }
 

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -51,6 +51,17 @@ class PlayerTests: QuickSpec {
                     
                     expect(player.core!.options["foo"] as? String).to(equal("bar"))
                 }
+
+                it("triggers willConfigure with new options") {
+                    var newOptions: [String: String]?
+                    player.core!.on(Event.willConfigure.rawValue) { userInfo in
+                        newOptions = userInfo?["options"] as? [String: String]
+                    }
+
+                    player.configure(options: ["foo": "bar"])
+
+                    expect(newOptions).to(equal(["foo": "bar"]))
+                }
             }
 
             describe("attachTo") {

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -52,9 +52,9 @@ class PlayerTests: QuickSpec {
                     expect(player.core!.options["foo"] as? String).to(equal("bar"))
                 }
 
-                it("triggers willConfigure with new options") {
+                it("triggers willUpdateOptions with new options") {
                     var newOptions: [String: String]?
-                    player.core!.on(Event.willConfigure.rawValue) { userInfo in
+                    player.core!.on(Event.willUpdateOptions.rawValue) { userInfo in
                         newOptions = userInfo?["options"] as? [String: String]
                     }
 

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -125,14 +125,17 @@ class PlayerTests: QuickSpec {
                 Player.register(playbacks: [SpecialStubPlayback.self])
                 let player = Player(options: options)
                 var willLoadSourceTriggered = false
+                var timesTriggered = 0
 
                 player.core?.on(Event.willLoadSource.rawValue) { _ in
                     willLoadSourceTriggered = true
+                    timesTriggered += 1
                 }
 
                 player.load(PlayerTests.specialSource)
 
                 expect(willLoadSourceTriggered).to(beTrue())
+                expect(timesTriggered).toEventually(equal(1))
             }
         }
     }

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -52,15 +52,17 @@ class PlayerTests: QuickSpec {
                     expect(player.core!.options["foo"] as? String).to(equal("bar"))
                 }
 
-                it("triggers willUpdateOptions with new options") {
-                    var newOptions: [String: String]?
-                    player.core!.on(Event.willUpdateOptions.rawValue) { userInfo in
-                        newOptions = userInfo?["options"] as? [String: String]
+                context("when source is passed in configure") {
+                    it("triggers willLoadSource in core") {
+                        var triggeredWillLoadSource = false
+                        player.core!.on(Event.willLoadSource.rawValue) { userInfo in
+                            triggeredWillLoadSource = true
+                        }
+
+                        player.configure(options: [kSourceUrl: "new source url"])
+
+                        expect(triggeredWillLoadSource).to(beTrue())
                     }
-
-                    player.configure(options: ["foo": "bar"])
-
-                    expect(newOptions).to(equal(["foo": "bar"]))
                 }
             }
 
@@ -117,7 +119,6 @@ class PlayerTests: QuickSpec {
 
                 expect(player.focusEnvironments.contains(where: { $0 is UIButton} )).to(beTrue())
             }
-
 
             it("triggers willLoadSource in core on load") {
                 Loader.shared.resetPlaybacks()

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -117,6 +117,22 @@ class PlayerTests: QuickSpec {
 
                 expect(player.focusEnvironments.contains(where: { $0 is UIButton} )).to(beTrue())
             }
+
+
+            it("triggers willLoadSource in core on load") {
+                Loader.shared.resetPlaybacks()
+                Player.register(playbacks: [SpecialStubPlayback.self])
+                let player = Player(options: options)
+                var willLoadSourceTriggered = false
+
+                player.core?.on(Event.willLoadSource.rawValue) { _ in
+                    willLoadSourceTriggered = true
+                }
+
+                player.load(PlayerTests.specialSource)
+
+                expect(willLoadSourceTriggered).to(beTrue())
+            }
         }
     }
     


### PR DESCRIPTION
# Goal

To trigger `.willLoadSOurce` from core whenever `player.configure` or player.load is called. This should let plugins prepare for fresh options if they need to.