### PR TITLE
Create didChangeScreenOrientation and didDoubleTouchMediaControl events 

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		C990DAA52194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
 		C990DAA62194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
 		C9B6D6E7216FDD5400588896 /* FullscreenButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B6D6E6216FDD5400588896 /* FullscreenButton.swift */; };
+		C9B8414922E0F454009DE097 /* OrientationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B8414822E0F454009DE097 /* OrientationObserver.swift */; };
 		C9EDF8482162C98D00789E2F /* MediaControlPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EDF8472162C98D00789E2F /* MediaControlPluginTests.swift */; };
 		C9EDF84A2162CCB700789E2F /* MediaControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EDF8492162CCB700789E2F /* MediaControlTests.swift */; };
 		C9EDF84D2162CEF500789E2F /* UIViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EDF84C2162CEF500789E2F /* UIViewControllerMock.swift */; };
@@ -277,7 +278,6 @@
 		CD57FCF122949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* SimpleContainerPlugin.swift */; };
 		CD57FCF222949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCF022949BB300AB24CF /* SimpleContainerPlugin.swift */; };
 		CD57FCF322949BBB00AB24CF /* SimpleCorePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD57FCEE22949B0F00AB24CF /* SimpleCorePlugin.swift */; };
-		CDCECC42228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCECC41228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift */; };
 		E7BEEB59217506C100B8F7FA /* TimeIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEEB58217506C100B8F7FA /* TimeIndicator.swift */; };
 		E7BEEB5C21751EE600B8F7FA /* TimeIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BEEB5A21751D9600B8F7FA /* TimeIndicatorTests.swift */; };
 		E7C6E891219225B900A74149 /* SeekbarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C6E88F2192239500A74149 /* SeekbarViewTests.swift */; };
@@ -546,6 +546,7 @@
 		C98C014B2166B50E009DFE0A /* FullscreenButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenButtonTests.swift; sourceTree = "<group>"; };
 		C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackStateMachineEventsTests.swift; sourceTree = "<group>"; };
 		C9B6D6E6216FDD5400588896 /* FullscreenButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullscreenButton.swift; sourceTree = "<group>"; };
+		C9B8414822E0F454009DE097 /* OrientationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationObserver.swift; sourceTree = "<group>"; };
 		C9EDF8472162C98D00789E2F /* MediaControlPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlPluginTests.swift; sourceTree = "<group>"; };
 		C9EDF8492162CCB700789E2F /* MediaControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlTests.swift; sourceTree = "<group>"; };
 		C9EDF84C2162CEF500789E2F /* UIViewControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerMock.swift; sourceTree = "<group>"; };
@@ -561,7 +562,6 @@
 		CD10D93C22C28D4C0096B035 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		CD57FCEE22949B0F00AB24CF /* SimpleCorePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCorePlugin.swift; sourceTree = "<group>"; };
 		CD57FCF022949BB300AB24CF /* SimpleContainerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleContainerPlugin.swift; sourceTree = "<group>"; };
-		CDCECC41228F28CB0012FD33 /* DecoratedPressAVPlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoratedPressAVPlayerViewController.swift; sourceTree = "<group>"; };
 		D105480873032552EC2B57ED /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		D8810057D2C05E1F7A2759D7 /* Clappr.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = Clappr.podspec; sourceTree = "<group>"; };
 		E7BEEB58217506C100B8F7FA /* TimeIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIndicator.swift; sourceTree = "<group>"; };
@@ -1079,6 +1079,7 @@
 			children = (
 				9E26CFF02016148400AE92B7 /* FullScreen */,
 				96D362961D41339400CCB866 /* Player.swift */,
+				C9B8414822E0F454009DE097 /* OrientationObserver.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -2010,6 +2011,7 @@
 				57F1354921836EE000111BC6 /* Array+appendOrReplace.swift in Sources */,
 				96D362E81D41339400CCB866 /* BorderView.swift in Sources */,
 				96D362DC1D41339400CCB866 /* MediaOptionFactory.swift in Sources */,
+				C9B8414922E0F454009DE097 /* OrientationObserver.swift in Sources */,
 				96D362E01D41339400CCB866 /* PosterPlugin.swift in Sources */,
 				96D362CD1D41339400CCB866 /* Playback.swift in Sources */,
 				96D362D91D41339400CCB866 /* UIView+Ext.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -32,9 +32,7 @@ open class Container: UIObject {
     }
 
     private var boundsObservation: NSKeyValueObservation?
-    #if os(iOS)
-    private var previousDeviceOrientation: UIDeviceOrientation = UIDevice.current.orientation
-    #endif
+
     public init(options: Options = [:]) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
         self.options = options
@@ -73,9 +71,6 @@ open class Container: UIObject {
         renderPlayback()
 
         observeWhenViewChangeBounds()
-        #if os(iOS)
-        addOrientationObserver()
-        #endif
     }
 
     fileprivate func renderPlayback() {
@@ -123,32 +118,6 @@ open class Container: UIObject {
         }
     }
 
-    #if os(iOS)
-    private func addOrientationObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(orientationDidChange),
-            name: UIDevice.orientationDidChangeNotification,
-            object: nil)
-    }
-
-    private func removeOrientationObserver() {
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIDevice.orientationDidChangeNotification,
-            object: nil)
-    }
-
-    @objc func orientationDidChange() {
-        let currentOrientation = UIDevice.current.orientation
-        guard currentOrientation != previousDeviceOrientation else { return }
-
-        let description = currentOrientation.isPortrait ? "portrait" : "landscape"
-        trigger(.didChangeScreenOrientation, userInfo: ["orientation": description])
-        previousDeviceOrientation = currentOrientation
-    }
-    #endif
-
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Container")
 
@@ -172,9 +141,6 @@ open class Container: UIObject {
         view.removeFromSuperview()
 
         boundsObservation?.invalidate()
-        #if os(iOS)
-        removeOrientationObserver()
-        #endif
         trigger(Event.didDestroy.rawValue)
         Logger.logDebug("destroying listeners", scope: "Container")
         stopListening()

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -71,6 +71,9 @@ open class Container: UIObject {
         renderPlayback()
 
         observeWhenViewChangeBounds()
+        #if os(iOS)
+        addOrientationObserver()
+        #endif
     }
 
     fileprivate func renderPlayback() {
@@ -118,6 +121,29 @@ open class Container: UIObject {
         }
     }
 
+    #if os(iOS)
+    private func addOrientationObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(orientationDidChange),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil)
+    }
+
+    private func removeOrientationObserver() {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil)
+    }
+
+    @objc func orientationDidChange() {
+        let orientation = UIDevice.current.orientation.isPortrait ? "portrait" : "landscape"
+
+        trigger(.didChangeScreenOrientation, userInfo: ["orientation": orientation])
+    }
+    #endif
+
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Container")
 
@@ -141,7 +167,9 @@ open class Container: UIObject {
         view.removeFromSuperview()
 
         boundsObservation?.invalidate()
-
+        #if os(iOS)
+        removeOrientationObserver()
+        #endif
         trigger(Event.didDestroy.rawValue)
         Logger.logDebug("destroying listeners", scope: "Container")
         stopListening()

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -32,7 +32,9 @@ open class Container: UIObject {
     }
 
     private var boundsObservation: NSKeyValueObservation?
-
+    #if os(iOS)
+    private var previousDeviceOrientation: UIDeviceOrientation = UIDevice.current.orientation
+    #endif
     public init(options: Options = [:]) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
         self.options = options
@@ -138,9 +140,12 @@ open class Container: UIObject {
     }
 
     @objc func orientationDidChange() {
-        let orientation = UIDevice.current.orientation.isPortrait ? "portrait" : "landscape"
+        let currentOrientation = UIDevice.current.orientation
+        guard currentOrientation != previousDeviceOrientation else { return }
 
-        trigger(.didChangeScreenOrientation, userInfo: ["orientation": orientation])
+        let description = currentOrientation.isPortrait ? "portrait" : "landscape"
+        trigger(.didChangeScreenOrientation, userInfo: ["orientation": description])
+        previousDeviceOrientation = currentOrientation
     }
     #endif
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -20,7 +20,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     lazy var fullscreenHandler: FullscreenStateHandler? = {
         return self.optionsUnboxer.fullscreenControledByApp ? FullscreenByApp(core: self) : FullscreenByPlayer(core: self) as FullscreenStateHandler
     }()
-    private var previousDeviceOrientation: UIDeviceOrientation = UIDevice.current.orientation
+    private var orientationObserver: OrientationObserver?
     #endif
 
     lazy var optionsUnboxer: OptionsUnboxer = OptionsUnboxer(options: self.options)
@@ -62,7 +62,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         view.backgroundColor = .black
 
         addTapGestures()
-        
         bindEventListeners()
         
         Loader.shared.corePlugins.forEach { plugin in
@@ -95,7 +94,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         #if os(iOS)
         listenTo(self, eventName: InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler?.enterInFullscreen() }
         listenTo(self, eventName: InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler?.exitFullscreen() }
-        addOrientationObserver()
+        orientationObserver = OrientationObserver(core: self)
         #endif
     }
 
@@ -192,32 +191,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         #endif
     }
 
-    #if os(iOS)
-    private func addOrientationObserver() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(orientationDidChange),
-            name: UIDevice.orientationDidChangeNotification,
-            object: nil)
-    }
-
-    private func removeOrientationObserver() {
-        NotificationCenter.default.removeObserver(
-            self,
-            name: UIDevice.orientationDidChangeNotification,
-            object: nil)
-    }
-
-    @objc func orientationDidChange() {
-        let currentOrientation = UIDevice.current.orientation
-        guard currentOrientation != previousDeviceOrientation else { return }
-
-        let description = currentOrientation.isPortrait ? "portrait" : "landscape"
-        trigger(.didChangeScreenOrientation, userInfo: ["orientation": description])
-        previousDeviceOrientation = currentOrientation
-    }
-    #endif
-
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Core")
 
@@ -247,7 +220,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         fullscreenHandler?.destroy()
         fullscreenHandler = nil
         fullscreenController = nil
-        removeOrientationObserver()
+        orientationObserver = nil
         #endif
         view.removeFromSuperview()
 

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -57,4 +57,5 @@ public enum Event: String, CaseIterable {
     case didResize = "Clappr:didResize"
     case didAttachView = "Clappr:didAttachView"
     case didChangeScreenOrientation = "Clappr:didChangeScreenOrientation"
+    case didDoubleTouchMediaControl = "Clappr:didDoubleTouchMediaControl"
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -56,4 +56,5 @@ public enum Event: String, CaseIterable {
     case willHideModal = "Clappr:willHideModal"
     case didResize = "Clappr:didResize"
     case didAttachView = "Clappr:didAttachView"
+    case didChangeScreenOrientation = "Clappr:didChangeScreenOrientation"
 }

--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -4,5 +4,5 @@ public enum InternalEvent: String {
     case didTappedCore = "Clappr:didTappedCore"
     case willBeginScrubbing = "Clappr:willBeginScrubbing"
     case didFinishScrubbing = "Clappr:didFinishScrubbing"
-    case didTapQuickSeek = "Clappr:didTapQuickSeek"
+    case didQuickSeek = "Clappr:didQuickSeek"
 }

--- a/Sources/Clappr_iOS/Classes/Base/OrientationObserver.swift
+++ b/Sources/Clappr_iOS/Classes/Base/OrientationObserver.swift
@@ -1,0 +1,27 @@
+class OrientationObserver {
+    weak var core: Core?
+    private var previousDeviceOrientation: UIDeviceOrientation = UIDevice.current.orientation
+
+    init(core: Core) {
+        self.core = core
+
+        addOrientationObserver()
+    }
+
+    private func addOrientationObserver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(orientationDidChange),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil)
+    }
+
+    @objc private func orientationDidChange() {
+        let currentOrientation = UIDevice.current.orientation
+        guard currentOrientation != previousDeviceOrientation else { return }
+
+        let description = currentOrientation.isPortrait ? "portrait" : "landscape"
+        core?.trigger(.didChangeScreenOrientation, userInfo: ["orientation": description])
+        previousDeviceOrientation = currentOrientation
+    }
+}

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 public class QuickSeekPlugin: UICorePlugin {
-    let seekDuration = 10.0
+    private let seekDuration = 10.0
     var doubleTapGesture: UITapGestureRecognizer!
 
     open class override var name: String {

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -65,6 +65,7 @@ public class QuickSeekPlugin: UICorePlugin {
         playback.seek(playback.position - 10)
         guard playback.position - 10 > 0.0 else { return }
         animatonHandler?.animateBackward()
+        core?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "left"])
     }
     
     private func seekForward(_ playback: Playback) {
@@ -73,6 +74,7 @@ public class QuickSeekPlugin: UICorePlugin {
         playback.seek(playback.position + 10)
         guard playback.position + 10 < playback.duration else { return }
         animatonHandler?.animateForward()
+        core?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "right"])
     }
     
     private func impactFeedback() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 public class QuickSeekPlugin: UICorePlugin {
-    
+    let seekDuration = 10.0
     var doubleTapGesture: UITapGestureRecognizer!
 
     open class override var name: String {
@@ -49,12 +49,13 @@ public class QuickSeekPlugin: UICorePlugin {
         guard let activePlayback = core?.activePlayback,
             let container = core?.activeContainer,
             let coreViewWidth = core?.view.frame.width else { return }
-        
-        container.trigger(InternalEvent.didTapQuickSeek.rawValue)
+
         let didTapLeftSide = xPosition < coreViewWidth / 2
         if didTapLeftSide {
+            container.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "left"])
             seekBackward(activePlayback)
         } else {
+            container.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "right"])
             seekForward(activePlayback)
         }
     }
@@ -62,19 +63,19 @@ public class QuickSeekPlugin: UICorePlugin {
     private func seekBackward(_ playback: Playback) {
         guard playback.playbackType == .vod || playback.isDvrAvailable else { return }
         impactFeedback()
-        playback.seek(playback.position - 10)
-        guard playback.position - 10 > 0.0 else { return }
+        playback.seek(playback.position - seekDuration)
+        guard playback.position - seekDuration > 0.0 else { return }
         animatonHandler?.animateBackward()
-        core?.activeContainer?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "left"])
+        core?.activeContainer?.trigger(InternalEvent.didQuickSeek.rawValue, userInfo: ["duration": -seekDuration])
     }
     
     private func seekForward(_ playback: Playback) {
         guard playback.playbackType == .vod || playback.isDvrAvailable && playback.isDvrInUse else { return }
         impactFeedback()
-        playback.seek(playback.position + 10)
-        guard playback.position + 10 < playback.duration else { return }
+        playback.seek(playback.position + seekDuration)
+        guard playback.position + seekDuration < playback.duration else { return }
         animatonHandler?.animateForward()
-        core?.activeContainer?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "right"])
+        core?.activeContainer?.trigger(InternalEvent.didQuickSeek.rawValue, userInfo: ["duration": seekDuration])
     }
     
     private func impactFeedback() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -65,7 +65,7 @@ public class QuickSeekPlugin: UICorePlugin {
         playback.seek(playback.position - 10)
         guard playback.position - 10 > 0.0 else { return }
         animatonHandler?.animateBackward()
-        core?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "left"])
+        core?.activeContainer?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "left"])
     }
     
     private func seekForward(_ playback: Playback) {
@@ -74,7 +74,7 @@ public class QuickSeekPlugin: UICorePlugin {
         playback.seek(playback.position + 10)
         guard playback.position + 10 < playback.duration else { return }
         animatonHandler?.animateForward()
-        core?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "right"])
+        core?.activeContainer?.trigger(.didDoubleTouchMediaControl, userInfo: ["position": "right"])
     }
     
     private func impactFeedback() {

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/QuickSeekCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/QuickSeekCorePluginTests.swift
@@ -46,8 +46,21 @@ class QuickSeekCorePluginTests: QuickSpec {
                         expect(core.playbackMock?.didCallSeek).to(beTrue())
                         expect(core.playbackMock?.didCallSeekWithValue).to(equal(10))
                     }
+
+                    it("triggers didDoubleTouchMediaControl event") {
+                        var eventArguments: EventUserInfo = [:]
+                        core.playbackMock?.set(position: 20.0)
+
+                        core.on(Event.didDoubleTouchMediaControl.rawValue) { userInfo in
+                            eventArguments = userInfo
+                        }
+
+                        quickSeekPlugin.quickSeek(xPosition: 0)
+
+                        expect(eventArguments?["position"] as? String).to(equal("left"))
+                    }
                 }
-                
+
                 context("and its position is higher than half of the view (right)") {
                     it("seeks forward 10 seconds") {
                         core.playbackMock?.set(position: 20.0)
@@ -57,6 +70,19 @@ class QuickSeekCorePluginTests: QuickSpec {
                         expect(eventTrigger).toEventually(beTrue())
                         expect(core.playbackMock?.didCallSeek).to(beTrue())
                         expect(core.playbackMock?.didCallSeekWithValue).to(equal(30))
+                    }
+
+                    it("triggers didDoubleTouchMediaControl event") {
+                        var eventArguments: EventUserInfo = [:]
+                        core.playbackMock?.set(position: 20.0)
+
+                        core.on(Event.didDoubleTouchMediaControl.rawValue) { userInfo in
+                            eventArguments = userInfo
+                        }
+
+                        quickSeekPlugin.quickSeek(xPosition: 100)
+
+                        expect(eventArguments?["position"] as? String).to(equal("right"))
                     }
                 }
                 

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/QuickSeekCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/QuickSeekCorePluginTests.swift
@@ -10,7 +10,8 @@ class QuickSeekCorePluginTests: QuickSpec {
             var quickSeekPlugin: QuickSeekCorePlugin!
             var core: CoreStub!
             var eventTrigger = false
-            
+            var eventParams: EventUserInfo = [:]
+
             beforeEach {
                 core = CoreStub()
                 core.playbackMock?.videoDuration = 60.0
@@ -18,8 +19,9 @@ class QuickSeekCorePluginTests: QuickSpec {
                 core.addPlugin(quickSeekPlugin)
                 core.view.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                 quickSeekPlugin.render()
-                core._container?.on(InternalEvent.didTapQuickSeek.rawValue) { _ in
+                core._container?.on(InternalEvent.didQuickSeek.rawValue) { userInfo in
                     eventTrigger = true
+                    eventParams = userInfo
                 }
             }
             
@@ -43,6 +45,7 @@ class QuickSeekCorePluginTests: QuickSpec {
                         quickSeekPlugin.quickSeek(xPosition: 0)
                         
                         expect(eventTrigger).toEventually(beTrue())
+                        expect(eventParams?["duration"] as? Double).to(equal(-10.0))
                         expect(core.playbackMock?.didCallSeek).to(beTrue())
                         expect(core.playbackMock?.didCallSeekWithValue).to(equal(10))
                     }
@@ -51,7 +54,7 @@ class QuickSeekCorePluginTests: QuickSpec {
                         var eventArguments: EventUserInfo = [:]
                         core.playbackMock?.set(position: 20.0)
 
-                        core.on(Event.didDoubleTouchMediaControl.rawValue) { userInfo in
+                        core.activeContainer?.on(Event.didDoubleTouchMediaControl.rawValue) { userInfo in
                             eventArguments = userInfo
                         }
 
@@ -68,6 +71,7 @@ class QuickSeekCorePluginTests: QuickSpec {
                         quickSeekPlugin.quickSeek(xPosition: 100)
 
                         expect(eventTrigger).toEventually(beTrue())
+                        expect(eventParams?["duration"] as? Double).to(equal(10.0))
                         expect(core.playbackMock?.didCallSeek).to(beTrue())
                         expect(core.playbackMock?.didCallSeekWithValue).to(equal(30))
                     }
@@ -76,7 +80,7 @@ class QuickSeekCorePluginTests: QuickSpec {
                         var eventArguments: EventUserInfo = [:]
                         core.playbackMock?.set(position: 20.0)
 
-                        core.on(Event.didDoubleTouchMediaControl.rawValue) { userInfo in
+                        core.activeContainer?.on(Event.didDoubleTouchMediaControl.rawValue) { userInfo in
                             eventArguments = userInfo
                         }
 


### PR DESCRIPTION
## 🏁 Goal:
- To trigger a `didChangeScreenOrientation` event every orientation change.
- To trigger a `didDoubleTouchMediaControl` event every consecutive double tap on screen.

## ✅ How to test `didChangeScreenOrientation`:
1. On `ViewController.swift#52` add this piece of code:
```swift
player.on(Event.didChangeScreenOrientation) { _ in
    print("on didChangeScreenOrientation")
}
```
2. On `Player.swift#100` add the event to trigger on player layer:
```swift
core?.activeContainer?.on(Event.didChangeScreenOrientation.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.didChangeScreenOrientation.rawValue, userInfo: info) }
```
3. Check the console log and ensure that `on didChangeScreenOrientation` was printed

## ✅ How to test `didDoubleTouchMediaControl`:
1. On `ViewController.swift#52` add this piece of code:
```swift
player.on(Event.didDoubleTouchMediaControl) { _ in
    print("on didDoubleTouchMediaControl")
}
```
2. On `Player.swift#100` add the event to trigger on player layer:
```swift
core?.activeContainer?.on(Event.didDoubleTouchMediaControl.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.didDoubleTouchMediaControl.rawValue, userInfo: info) }
```
3. Check the console log and ensure that `on on didChangeScreenOrientation with params -> Optional([AnyHashable("position"): "right"])` and `on didChangeScreenOrientation with params -> Optional([AnyHashable("position"): "left"])` was printed with `right` and `left` according to tap screen position