### PR TITLE
Add sharedData to core

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -239,8 +239,6 @@
 		AB163517215ACA0C00635233 /* MediaControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB163514215ACA0C00635233 /* MediaControl.swift */; };
 		AB24DCD62152ED0E002D4660 /* AvailableMediaOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAFEBA52152C25B007BA497 /* AvailableMediaOptions.swift */; };
 		ABAFEBA62152C25B007BA497 /* AvailableMediaOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAFEBA52152C25B007BA497 /* AvailableMediaOptions.swift */; };
-		ABE7D3EE212C36200049773A /* SharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE7D3ED212C36200049773A /* SharedData.swift */; };
-		ABE7D3EF212C36200049773A /* SharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABE7D3ED212C36200049773A /* SharedData.swift */; };
 		B46D05AA1DB7DE4B0004B23F /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B46D05A71DB7DBD60004B23F /* Quick.framework */; };
 		B46D05AB1DB7DE570004B23F /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B46D05A51DB7DBC50004B23F /* Nimble.framework */; };
 		C905869322132046009D2FA0 /* poster.png in Resources */ = {isa = PBXBuildFile; fileRef = C905869222132046009D2FA0 /* poster.png */; };
@@ -533,7 +531,6 @@
 		AB16350B215AC9FC00635233 /* MediaControlView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MediaControlView.xib; sourceTree = "<group>"; };
 		AB163514215ACA0C00635233 /* MediaControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaControl.swift; sourceTree = "<group>"; };
 		ABAFEBA52152C25B007BA497 /* AvailableMediaOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableMediaOptions.swift; sourceTree = "<group>"; };
-		ABE7D3ED212C36200049773A /* SharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedData.swift; sourceTree = "<group>"; };
 		B46D05A51DB7DBC50004B23F /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		B46D05A71DB7DBD60004B23F /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		C905869222132046009D2FA0 /* poster.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = poster.png; sourceTree = "<group>"; };
@@ -932,7 +929,6 @@
 				96D3628D1D41339400CCB866 /* Container.swift */,
 				96D362911D41339400CCB866 /* Loader.swift */,
 				96D362931D41339400CCB866 /* MediaOption.swift */,
-				ABE7D3ED212C36200049773A /* SharedData.swift */,
 				ABAFEBA52152C25B007BA497 /* AvailableMediaOptions.swift */,
 				96D362951D41339400CCB866 /* Playback.swift */,
 			);
@@ -1885,7 +1881,6 @@
 				32FC971B20B7257800ABA0C2 /* AVURLAssetWithCookiesBuilder.swift in Sources */,
 				32E401C41FF42335001C2096 /* UIView+Ext.swift in Sources */,
 				325111452134827F001FEEBA /* Options.swift in Sources */,
-				ABE7D3EF212C36200049773A /* SharedData.swift in Sources */,
 				576786C02188A4B40046508C /* Array+appendOrReplace.swift in Sources */,
 				32DA34191FFBCFC400484C90 /* Container.swift in Sources */,
 				FBD47AB021AD6856003265AF /* ContainerFactory.swift in Sources */,
@@ -2067,7 +2062,6 @@
 				57AB0E882253CAB70096BCA4 /* PassthroughView.swift in Sources */,
 				96D362CB1D41339400CCB866 /* MediaOption.swift in Sources */,
 				C9EDF8582163A9A900789E2F /* UIColor+ClapprAdditions.swift in Sources */,
-				ABE7D3EE212C36200049773A /* SharedData.swift in Sources */,
 				4856322B220B4C9C0096CDAE /* QuickSeekMediaControlPlugin.swift in Sources */,
 				96E7D2741E786FEE0056F358 /* InternalEvent.swift in Sources */,
 				96D362CF1D41339400CCB866 /* UIObject.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -39,9 +39,7 @@ open class Container: UIObject {
 
         super.init()
 
-        self.sharedData.container = self
         view.backgroundColor = .clear
-
         view.accessibilityIdentifier = "Container"
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -1,6 +1,7 @@
 open class Core: UIObject, UIGestureRecognizerDelegate {
 
     @objc public let environment = Environment()
+    @objc open var sharedData = SharedData()
 
     @objc open var options: Options {
         didSet {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -1,3 +1,5 @@
+public typealias SharedData = [String: Any]
+
 open class Core: UIObject, UIGestureRecognizerDelegate {
 
     @objc public let environment = Environment()

--- a/Sources/Clappr/Classes/Base/SharedData.swift
+++ b/Sources/Clappr/Classes/Base/SharedData.swift
@@ -2,5 +2,4 @@ import Foundation
 
 @objc open class SharedData: NSObject {
     @objc public var storeDictionary = [String: Any]()
-    @objc public weak var container: Container?
 }

--- a/Sources/Clappr/Classes/Base/SharedData.swift
+++ b/Sources/Clappr/Classes/Base/SharedData.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-@objc open class SharedData: NSObject {
-    @objc public var storeDictionary = [String: Any]()
-}

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -341,11 +341,11 @@ class ContainerTests: QuickSpec {
 
                     beforeEach {
                         container = ContainerFactory.create(with: Resource.valid)
-                        container.sharedData.storeDictionary["testKey"] = "testValue"
+                        container.sharedData["testKey"] = "testValue"
                     }
 
                     it("retrieves stored value") {
-                        expect(container.sharedData.storeDictionary["testKey"] as? String) == "testValue"
+                        expect(container.sharedData["testKey"] as? String) == "testValue"
                     }
                 }
             }

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -337,8 +337,15 @@ class ContainerTests: QuickSpec {
             }
 
             describe("Container sharedData") {
-                context("when stores a value on sharedData") {
+                context("on a brand new instance") {
+                    it("starts empty") {
+                        container = ContainerFactory.create(with: Resource.valid)
 
+                        expect(container.sharedData).to(beEmpty())
+                    }
+                }
+
+                context("when stores a value on sharedData") {
                     beforeEach {
                         container = ContainerFactory.create(with: Resource.valid)
                         container.sharedData["testKey"] = "testValue"

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -96,8 +96,15 @@ class CoreTests: QuickSpec {
             }
 
             describe("Core sharedData") {
-                context("when stores a value on sharedData") {
+                context("on a brand new instance") {
+                    it("starts empty") {
+                        core = CoreFactory.create(with: [:])
 
+                        expect(core.sharedData).to(beEmpty())
+                    }
+                }
+
+                context("when stores a value on sharedData") {
                     beforeEach {
                         core = CoreFactory.create(with: [:])
                         core.sharedData["testKey"] = "testValue"

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -95,6 +95,20 @@ class CoreTests: QuickSpec {
                 }
             }
 
+            describe("Core sharedData") {
+                context("when stores a value on sharedData") {
+
+                    beforeEach {
+                        core = CoreFactory.create(with: [:])
+                        core.sharedData.storeDictionary["testKey"] = "testValue"
+                    }
+
+                    it("retrieves stored value") {
+                        expect(core.sharedData.storeDictionary["testKey"] as? String) == "testValue"
+                    }
+                }
+            }
+
             #if os(iOS)
             describe("Fullscreen") {
                 var options: Options!

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -100,11 +100,11 @@ class CoreTests: QuickSpec {
 
                     beforeEach {
                         core = CoreFactory.create(with: [:])
-                        core.sharedData.storeDictionary["testKey"] = "testValue"
+                        core.sharedData["testKey"] = "testValue"
                     }
 
                     it("retrieves stored value") {
-                        expect(core.sharedData.storeDictionary["testKey"] as? String) == "testValue"
+                        expect(core.sharedData["testKey"] as? String) == "testValue"
                     }
                 }
             }


### PR DESCRIPTION
## 🏁 Goal:
- To add to Core the ability to store shared data across the player lifecycle

## ✅ How to test:
1. Store anything you want on `core.sharedData` and try to retrieve it
2. Run the tests (they execute the step 1).