### PR TITLE
Add view bounds size on didResize event param

### DIFF
--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -113,8 +113,8 @@ open class Container: UIObject {
     }
 
     private func observeWhenViewChangeBounds() {
-        boundsObservation = view.observe(\.bounds) { [weak self] (_, _) in
-            self?.trigger(Event.didResize)
+        boundsObservation = view.observe(\.bounds) { [weak self] (view, _) in
+            self?.trigger(Event.didResize, userInfo: ["size": view.bounds.size])
         }
     }
 

--- a/Tests/Clappr_Tests/ContainerTests.swift
+++ b/Tests/Clappr_Tests/ContainerTests.swift
@@ -353,18 +353,23 @@ class ContainerTests: QuickSpec {
             context("when resized") {
                 it("triggers didResize event") {
                     let container = Container()
+                    container.view.superview?.addSubviewMatchingConstraints(container.view)
                     container.render()
                     container.view.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
                     var didResizeTriggered = false
+                    var didResizeValue: CGSize? = .zero
 
-                    container.on(Event.didResize.rawValue) { _ in
+                    container.on(Event.didResize.rawValue) { userInfo in
                         didResizeTriggered = true
+                        didResizeValue = userInfo?["size"] as? CGSize
                     }
 
                     container.view.setWidthAndHeight(with: CGSize(width: 10, height: 10))
                     container.view.layoutIfNeeded()
 
                     expect(didResizeTriggered).toEventually(beTrue())
+                    expect(didResizeValue?.width).toEventually(equal(10))
+                    expect(didResizeValue?.height).toEventually(equal(10))
                 }
             }
         }


### PR DESCRIPTION
# Goal

 - Add view bound size on didResize event. 

# How to test 

- Run tests
- Listen the event didResize, put the player in fullscreen and ensure that userInfo event has the values from new view size.