### PR TITLE
Change way to trigger willPause event in tvOS

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -370,7 +370,7 @@ open class AVFoundationPlayback: Playback {
 
     private func handlePlayerRateChanged(_ player: AVPlayer, _ changes: NSKeyValueObservedChange<Float>) {
         guard playerStatus != .unknown else { return }
-        if changes.isPrior && player.rate == 1 && state == .playing {
+        if changes.isPrior && player.rate != 0.0 && state == .playing {
             triggerWillPause()
         } else if !changes.isPrior && player.rate == 0 && state != .idle {
             updateState(.paused)
@@ -556,7 +556,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     private func timeUpdated(_ time: CMTime) {
-        if player?.rate == 1.0 {
+        if player?.rate != 0.0 {
             updateState(.playing)
             trigger(.didUpdatePosition, userInfo: ["position": CMTimeGetSeconds(time)])
         }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -361,13 +361,17 @@ open class AVFoundationPlayback: Playback {
         }
     }
     
+    private func triggerWillPause() {
+        if canTriggerWillPause {
+            canTriggerWillPause = false
+            trigger(.willPause)
+        }
+    }
+
     private func handlePlayerRateChanged(player: AVPlayer, changes: NSKeyValueObservedChange<Float>) {
         guard playerStatus != .unknown else { return }
         if changes.isPrior && player.rate == 1 && state == .playing {
-            if canTriggerWillPause {
-                canTriggerWillPause = false
-                trigger(.willPause)
-            }
+            triggerWillPause()
         } else if !changes.isPrior && player.rate == 0 && state != .idle {
             updateState(.paused)
         }
@@ -389,10 +393,7 @@ open class AVFoundationPlayback: Playback {
 
     open override func pause() {
         guard canPause else { return }
-        if canTriggerWillPause {
-            canTriggerWillPause = false
-            trigger(.willPause)
-        }
+        triggerWillPause()
         player?.pause()
         updateState(.paused)
     }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -269,6 +269,7 @@ open class AVFoundationPlayback: Playback {
             player.observe(\.currentItem?.isPlaybackLikelyToKeepUp) { [weak self] player, _ in self?.handlePlaybackLikelyToKeepUp(player) },
             player.observe(\.currentItem?.isPlaybackBufferEmpty) { [weak self] player, _ in self?.handlePlaybackBufferEmpty(player) },
             player.observe(\.isExternalPlaybackActive) { [weak self] player, _ in self?.updateAirplayStatus(from: player) },
+            player.observe(\.timeControlStatus) { [weak self] player, _ in self?.triggerStallingIfNeeded(player) },
             player.observe(\.rate, options: .prior) { [weak self] player, changes in self?.handlePlayerRateChanged(player, changes) },
         ]
 
@@ -374,6 +375,12 @@ open class AVFoundationPlayback: Playback {
             triggerWillPause()
         } else if !changes.isPrior && player.rate == 0 && state != .idle {
             updateState(.paused)
+        }
+    }
+
+    private func triggerStallingIfNeeded(_ player: AVPlayer) {
+        if player.timeControlStatus == .waitingToPlayAtSpecifiedRate {
+            updateState(.stalling)
         }
     }
 

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -302,11 +302,7 @@ extension Player {
         if presses.containsAny(pressTypes: [.select, .playPause]) && isPaused {
             activePlayback?.trigger(.willPlay)
         }
-
-        if presses.containsAny(pressTypes: [.select, .playPause]) && isPlaying {
-            activePlayback?.trigger(.willPause)
-        }
-
+        
         super.pressesBegan(presses, with: event)
     }
 }

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -39,7 +39,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                         let expectedEvents: [Event] = [
                             .ready, .willPlay, .stalling, .willPlay, .playing,
                             .willPause, .didPause, .willSeek, .didSeek,
-                            .willPlay, .playing, .willStop, .didStop
+                            .willPlay, .stalling, .willPlay, .playing, .willStop, .didStop
                         ]
                         var triggeredEvents: [Event] = []
                         for event in Set(Event.allCases).subtracting(Set(unwantedEvents)) {

--- a/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -47,23 +47,26 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                                 triggeredEvents.append(event)
                             }
                         }
-                        playback.render()
 
-                        #if os(iOS)
-                        playback.play()
-                        #endif
-                        playback.once(Event.playing.rawValue) { _ in
-                            playback.pause()
-                            playback.seek(2)
-                        }
                         playback.once(Event.didSeek.rawValue) { _ in
                             playback.play()
-
+                            
                             playback.once(Event.playing.rawValue) { _ in
                                 playback.stop()
                             }
                         }
+                        
+                        playback.once(Event.playing.rawValue) { _ in
+                            playback.pause()
+                            playback.seek(2)
+                        }
 
+                        playback.render()
+                        
+                        #if os(iOS)
+                        playback.play()
+                        #endif
+                        
                         expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 15)
                     }
                 }


### PR DESCRIPTION
### Goal
Willpause event was being triggered in `Player` for tvOS, but it was not working on a real device.

We had to change where the event is triggered. The event is being triggered in `AVFoundationPlayback`. 

### How to test
Run tvOS sample and check if `on willPause` is printed when the video is paused.