### PR TITLE
Trigger core ready event after rendering containers

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -115,6 +115,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     open override func render() {
         containers.forEach(renderContainer)
         addToContainer()
+        trigger(.coreReady)
     }
 
     #if os(tvOS)

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -58,4 +58,5 @@ public enum Event: String, CaseIterable {
     case didAttachView = "Clappr:didAttachView"
     case didChangeScreenOrientation = "Clappr:didChangeScreenOrientation"
     case didDoubleTouchMediaControl = "Clappr:didDoubleTouchMediaControl"
+    case coreReady = "Clappr:coreReady"
 }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -691,6 +691,19 @@ class CoreTests: QuickSpec {
 
                     expect(plugin.view.superview).to(equal(core.view))
                 }
+
+                it("triggers core ready after rendering containers") {
+                    let core = Core()
+                    var didCallCoreReady = false
+
+                    core.listenTo(core, event: .coreReady) { _ in
+                        didCallCoreReady.toggle()
+                    }
+
+                    core.render()
+
+                    expect(didCallCoreReady).toEventually(beTrue())
+                }
                 
                 #if os(iOS)
                 it("doesnt add plugin as subview if it is a MediaControlPlugin") {


### PR DESCRIPTION
## 🏁  Goal:
1. In order to know when `core` is fully loaded (regardless of the playback state), we are conforming to the `Clappr web` approach that is to trigger a `CORE_READY` event right after containers are rendered.

## ✅  How to test:
1.  Create a dummy plugin that listens to .coreReady
2. Load the plugin in the plugins list
3. Launch the sample app
4. Notice that your plugin will listen to the core ready event right away

### Dummy plugin example:
```swift
class DummyPlugin: SimpleCorePlugin {
    open class override var name: String {
        return "DummyPlugin"
    }

    override func bindEvents() {
        listenTo(core!, event: .coreReady) { _ in
            print("I'm listening to coreReady event!")
        }
    }
}
```

Just add it to the player `builtInPlugins` list