### PR TITLE
Render plugins order

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -162,12 +162,14 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     fileprivate func addToContainer() {
         #if os(iOS)
-        renderCorePlugins()
-        renderMediaControlElements()
         if shouldEnterInFullScreen {
+            renderCorePlugins()
+            renderMediaControlElements()
             fullscreenHandler?.enterInFullscreen()
         } else {
             renderInContainerView()
+            renderCorePlugins()
+            renderMediaControlElements()
         }
         #else
         renderInContainerView()

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -516,10 +516,12 @@ class MediaControlElementMock: MediaControl.Element {
 
     override func render() {
         MediaControlElementMock.didCallRender = true
-
+        
         if MediaControlElementMock.crashOnRender {
             codeThatCrashes()
         }
+
+        trigger("render")
     }
     
     static func reset() {

--- a/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugins/Core/MediaControl/MediaControlTests.swift
@@ -516,7 +516,7 @@ class MediaControlElementMock: MediaControl.Element {
 
     override func render() {
         MediaControlElementMock.didCallRender = true
-        
+
         if MediaControlElementMock.crashOnRender {
             codeThatCrashes()
         }

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -703,7 +703,7 @@ class CoreTests: QuickSpec {
                     expect(plugin.view.superview).to(beNil())
                 }
 
-                it("render MediaControlElements after CorePlugins") {
+                it("renders MediaControlElements after CorePlugins") {
                     let core = Core()
                     let mediaControl = MediaControl(context: core)
                     let element = MediaControlElementMock(context: core)

--- a/Tests/Clappr_Tests/CoreTests.swift
+++ b/Tests/Clappr_Tests/CoreTests.swift
@@ -693,7 +693,7 @@ class CoreTests: QuickSpec {
                 }
                 
                 #if os(iOS)
-                it("doesnt add plugin as subview if it is a MediaControlPlugin") {
+                it("doesnt add plugin as subview if it is a MediaControlElement") {
                     let core = Core()
                     let plugin = MediaControlElementMock(context: core)
                     
@@ -702,8 +702,31 @@ class CoreTests: QuickSpec {
                     
                     expect(plugin.view.superview).to(beNil())
                 }
+
+                it("render MediaControlElements after CorePlugins") {
+                    let core = Core()
+                    let mediaControl = MediaControl(context: core)
+                    let element = MediaControlElementMock(context: core)
+                    let plugin = UICorePluginMock(context: core)
+
+                    var renderingOrder: [String] = []
+                    element.on("render") { _ in
+                        renderingOrder.append("element")
+                    }
+
+                    plugin.on("render") { _ in
+                        renderingOrder.append("plugin")
+                    }
+
+                    core.addPlugin(mediaControl)
+                    core.addPlugin(element)
+                    core.addPlugin(plugin)
+                    core.render()
+
+                    expect(renderingOrder).toEventually(equal(["plugin", "element"]))
+                }
                 
-                it("calls the mediacontrol to add the plugins into the panels") {
+                it("calls the mediacontrol to add the elements into the panels") {
                     let core = CoreFactory.create(with: [:])
                     let mediaControlMock = MediaControlMock(context: core)
                     let mediaControlPluginMock = MediaControlElementMock(context: core)
@@ -773,6 +796,7 @@ class UICorePluginMock: UICorePlugin {
     override class var name: String {
         return "UICorePluginMock"
     }
+    
 
     override func render() {
         UICorePluginMock.didCallRender = true
@@ -780,6 +804,8 @@ class UICorePluginMock: UICorePlugin {
         if UICorePluginMock.crashOnRender {
             codeThatCrashes()
         }
+
+        trigger("render")
     }
 
     override func bindEvents() {  }
@@ -805,7 +831,6 @@ class CorePluginMock: CorePlugin {
     override class var name: String {
         return "CorePluginMock"
     }
-
 }
 
 #if os(iOS)


### PR DESCRIPTION
## Goal:
- We found that the order of which the plugins are rendered, can cause an issue with positioning.
Therefore, we have to make sure we render the mediaControl Elements after everything is being positioned.

## How to test
- Run the test suite, because there's a test that was implemented just to make sure we don't invert the rendering order: `Core -> MediaControl`