### PR TITLE
Player load core

### DIFF
--- a/Sources/Clappr/Classes/Base/Factories/ContainerFactory.swift
+++ b/Sources/Clappr/Classes/Base/Factories/ContainerFactory.swift
@@ -8,10 +8,6 @@ struct ContainerFactory {
             container.addPlugin(plugin.init(context: container))
         }
 
-        if let source = options[kSourceUrl] as? String {
-            container.load(source)
-        }
-
         return container
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -81,15 +81,15 @@ open class Player: BaseObject {
              Event.didSelectAudio.rawValue, Event.didUpdateBitrate.rawValue])
 
         setCore(with: options)
-
+        bindCoreEvents()
         bindPlaybackEvents()
+
+        core?.load()
     }
     
     private func setCore(with options: Options) {
         core?.stopListening()
         core = CoreFactory.create(with: options)
-        bindCoreEvents()
-        core?.load()
     }
 
     private func bindCoreEvents() {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -89,6 +89,7 @@ open class Player: BaseObject {
         core?.stopListening()
         core = CoreFactory.create(with: options)
         bindCoreEvents()
+        core?.load()
     }
 
     private func bindCoreEvents() {

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -122,7 +122,10 @@ open class Player: AVPlayerViewController {
 
         setCore(with: options)
 
+        bindCoreEvents()
         bindPlaybackEvents()
+        
+        core?.load()
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -131,8 +134,6 @@ open class Player: AVPlayerViewController {
 
     private func setCore(with options: Options) {
         core = CoreFactory.create(with: options)
-        bindCoreEvents()
-        core?.load()
     }
 
     private func bindCoreEvents() {

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -132,6 +132,7 @@ open class Player: AVPlayerViewController {
     private func setCore(with options: Options) {
         core = CoreFactory.create(with: options)
         bindCoreEvents()
+        core?.load()
     }
 
     private func bindCoreEvents() {

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/ContainerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/ContainerTests.swift
@@ -110,21 +110,6 @@ class ContainerTests: QuickSpec {
                         }
                     }
                 }
-
-                context("when resource is empty") {
-
-                    beforeEach {
-                        container = ContainerFactory.create(with: [:])
-                    }
-
-                    it("set playback as subview") {
-                        expect(container.playback?.view.superview).to(beNil())
-                    }
-
-                    it("set playback to front of container") {
-                        expect(container.view.subviews.first).to(beNil())
-                    }
-                }
             }
 
             describe("#render") {

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/ContainerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/ContainerTests.swift
@@ -14,7 +14,7 @@ class ContainerTests: QuickSpec {
                     it("creates a container with invalid playback") {
                         container = ContainerFactory.create(with: Resource.invalid)
 
-                        container.load(Source.invalid.rawValue)
+                        container.load(Source.invalid)
 
                         expect(container.playback?.pluginName) == "NoOp"
                     }
@@ -25,7 +25,7 @@ class ContainerTests: QuickSpec {
                         Loader.shared.register(playbacks: [AVFoundationPlayback.self])
                         container = ContainerFactory.create(with: Resource.valid)
 
-                        container.load(Source.valid.rawValue)
+                        container.load(Source.valid)
 
                         expect(container.playback?.pluginName) == "AVPlayback"
                     }
@@ -34,7 +34,7 @@ class ContainerTests: QuickSpec {
                 context("when resource is not empty") {
                     beforeEach {
                         container = ContainerFactory.create(with: Resource.valid)
-                        container.load(Source.valid.rawValue)
+                        container.load(Source.valid)
                     }
 
                     context("and add container plugins from loader") {
@@ -42,7 +42,7 @@ class ContainerTests: QuickSpec {
                             Loader.shared.register(plugins: [FakeContainerPlugin.self, AnotherFakeContainerPlugin.self])
                             container = ContainerFactory.create(with: [:])
 
-                            container.load(Source.valid.rawValue)
+                            container.load(Source.valid)
 
                             expect(container.hasPlugin(FakeContainerPlugin.name)).to(beTrue())
                             expect(container.hasPlugin(AnotherFakeContainerPlugin.name)).to(beTrue())
@@ -222,14 +222,14 @@ class ContainerTests: QuickSpec {
                     }
 
                     it("loads a valid playback") {
-                        container.load(Source.valid.rawValue)
+                        container.load(Source.valid)
 
                         expect(container.playback?.pluginName) == "AVPlayback"
                         expect(container.playback?.view.superview) == container.view
                     }
 
                     it("load a source with mime type") {
-                        container.load(Source.valid.rawValue, mimeType: "video/mp4")
+                        container.load(Source.valid, mimeType: "video/mp4")
 
                         expect(container.playback?.pluginName) == "AVPlayback"
                         expect(container.playback?.view.superview) == container.view
@@ -239,18 +239,18 @@ class ContainerTests: QuickSpec {
                 context("when pass a invalid resource") {
                     beforeEach {
                         container = ContainerFactory.create(with: [:])
-                        container.load(Source.invalid.rawValue)
+                        container.load(Source.invalid)
                     }
 
                     it("set playback as a 'noop' playback") {
-                        container.load(Source.invalid.rawValue)
+                        container.load(Source.invalid)
 
                         expect(container.playback?.pluginName) == NoOpPlayback.name
                         expect(container.playback?.view.superview) == container.view
                     }
 
                     it("set playback as a 'noop' playback with mimetype") {
-                        container.load(Source.valid.rawValue, mimeType: "video/mp4")
+                        container.load(Source.valid, mimeType: "video/mp4")
 
                         expect(container.playback?.pluginName) == "AVPlayback"
                         expect(container.playback?.view.superview) == container.view
@@ -274,20 +274,20 @@ class ContainerTests: QuickSpec {
                     Loader.shared.resetPlugins()
                     Loader.shared.register(playbacks: [StubPlayback.self])
                     container = ContainerFactory.create(with: Resource.valid)
-                    container.load(Source.valid.rawValue)
+                    container.load(Source.valid)
                 }
 
                 it("reset startAt after first play event") {
 
                     let options = [kSourceUrl: "someUrl", kStartAt: 15.0] as Options
                     let container = ContainerFactory.create(with: options)
-                    container.load(Source.invalid.rawValue)
+                    container.load(Source.invalid)
 
                     expect(container.options[kStartAt] as? TimeInterval) == 15.0
                     expect(container.playback?.startAt) == 15.0
 
                     container.playback?.play()
-                    container.load(Source.valid.rawValue)
+                    container.load(Source.valid)
 
                     expect(container.options[kStartAt] as? TimeInterval) == 0.0
                     expect(container.playback?.startAt) == 0.0
@@ -418,7 +418,7 @@ struct Resource {
     static let invalid = [kSourceUrl: Source.invalid]
 }
 
-enum Source: String {
-    case valid = "http://clappr.com/video.mp4"
-    case invalid = "invalid"
+struct Source {
+    static let valid = "http://clappr.com/video.mp4"
+    static let invalid = "invalid"
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/ContainerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/ContainerTests.swift
@@ -10,35 +10,28 @@ class ContainerTests: QuickSpec {
             var container: Container!
 
             describe("#Init") {
-
                 context("with a invalid resource") {
-
-                    beforeEach {
-                        container = ContainerFactory.create(with: Resource.invalid)
-                        container.load(Source.invalid.rawValue)
-                        Loader.shared.resetPlugins()
-                    }
-
                     it("creates a container with invalid playback") {
+                        container = ContainerFactory.create(with: Resource.invalid)
+
+                        container.load(Source.invalid.rawValue)
+
                         expect(container.playback?.pluginName) == "NoOp"
                     }
                 }
 
                 context("with a valid resource") {
-
-                    beforeEach {
+                    it("creates a container with valid playback") {
                         Loader.shared.register(playbacks: [AVFoundationPlayback.self])
                         container = ContainerFactory.create(with: Resource.valid)
-                        container.load(Source.valid.rawValue)
-                    }
 
-                    it("creates a container with valid playback") {
+                        container.load(Source.valid.rawValue)
+
                         expect(container.playback?.pluginName) == "AVPlayback"
                     }
                 }
 
                 context("when resource is not empty") {
-
                     beforeEach {
                         container = ContainerFactory.create(with: Resource.valid)
                         container.load(Source.valid.rawValue)
@@ -167,6 +160,7 @@ class ContainerTests: QuickSpec {
 
                 it("destroy playback") {
                     container.destroy()
+
                     expect(container.playback?.view.superview).to(beNil())
                 }
 
@@ -338,12 +332,10 @@ class ContainerTests: QuickSpec {
                 }
 
                 context("when stores a value on sharedData") {
-                    beforeEach {
+                    it("retrieves stored value") {
                         container = ContainerFactory.create(with: Resource.valid)
                         container.sharedData["testKey"] = "testValue"
-                    }
 
-                    it("retrieves stored value") {
                         expect(container.sharedData["testKey"] as? String) == "testValue"
                     }
                 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
@@ -98,7 +98,7 @@ class PosterPluginTests: QuickSpec {
                         expect(posterPlugin.view.isHidden).toEventually(beFalse())
                     }
 
-                    it("isNoOpPlayback is true") {
+                    it("isNoOpPlayback is false") {
                         expect(posterPlugin.isNoOpPlayback).to(beFalse())
                     }
                 }
@@ -110,7 +110,6 @@ class PosterPluginTests: QuickSpec {
                 beforeEach {
                     core = CoreFactory.create(with: options)
                     core.load()
-                    core.render()
                     posterPlugin = self.getPosterPlugin(core.activeContainer)
                 }
 
@@ -134,6 +133,6 @@ class PosterPluginTests: QuickSpec {
     }
 
     private func getPosterPlugin(_ container: Container?) -> PosterPlugin {
-        return container?.plugins.first(where: { $0.pluginName == PosterPlugin.name }) as! PosterPlugin
+        return container?.plugins.first { $0.pluginName == PosterPlugin.name } as! PosterPlugin
     }
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
@@ -104,6 +104,7 @@ class PosterPluginTests: QuickSpec {
 
                 beforeEach {
                     container = ContainerFactory.create(with: options)
+                    container.load(options[kSourceUrl]!)
                     container.render()
                     posterPlugin = self.getPosterPlugin(container)
                 }

--- a/Tests/Clappr_tvOS_Tests/PlayerTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlayerTests.swift
@@ -23,14 +23,10 @@ class PlayerTests: QuickSpec {
             it("is an instance of AVPlayerViewController") {
                 expect(player).to(beAKindOf(AVPlayerViewController.self))
             }
-            
-            it("loads source on core when initializing") {
-                let player = Player(options: options)
-                
-                if let core = player.core {
-                    expect(core.activeContainer).toNot(beNil())
-                } else {
-                    fail("player.core is nil")
+
+            describe("#init") {
+                it("loads source on core when initializing") {
+                    expect(player.core?.activeContainer).toNot(beNil())
                 }
             }
             


### PR DESCRIPTION
## Goal

Fix the event `willLoadSource` to trigger on player init.

## How to test

Put a breakpoint to get the `Player.init` and check if `core.load` is called and ensure that `willLoadSource` is triggered.