### PR TITLE
Asset available event

### DIFF
--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -59,4 +59,5 @@ public enum Event: String, CaseIterable {
     case didChangeScreenOrientation = "Clappr:didChangeScreenOrientation"
     case didDoubleTouchMediaControl = "Clappr:didDoubleTouchMediaControl"
     case didUpdateBitrate = "Clappr:didUpdateBitrate"
+    case assetReady = "Clappr:assetReady"
 }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -250,8 +250,13 @@ open class AVFoundationPlayback: Playback {
         setupMaxResolution(for: playerLayer!.frame.size)
 
         asset.wait(for: .characteristics, then: selectDefaultMediaOptionIfNeeded)
-        asset.wait(for: .duration, then: seekToStartAtIfNeeded)
+        asset.wait(for: .duration, then: durationAvailable)
         addObservers()
+    }
+
+    private func durationAvailable() {
+        trigger(.assetReady)
+        seekToStartAtIfNeeded()
     }
 
     private func seekToStartAtIfNeeded() {

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -12,7 +12,8 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                 .didUpdateBuffer, .didUpdatePosition,
                 .seekableUpdate, .didFindAudio,
                 .didFindSubtitle, .didChangeDvrAvailability,
-                .didUpdateDuration, .didUpdateBitrate
+                .didUpdateDuration, .didUpdateBitrate,
+                .assetReady
             ]
 
             beforeEach {

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -1509,6 +1509,24 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
             }
 
+            describe("#setupPlayer") {
+                context("when asset is available") {
+                    it("triggers event assetAvailable") {
+                        let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
+                        let playback = AVFoundationPlayback(options: options)
+                        var didTriggerAssetReady = false
+
+                        playback.on(Event.assetReady.rawValue) { _ in
+                            didTriggerAssetReady = true
+                        }
+
+                        playback.play()
+
+                        expect(didTriggerAssetReady).toEventually(beTrue())
+                    }
+                }
+            }
+
             #if os(tvOS)
             describe("#loadMetadata") {
                 func getPlayback(with source: String) -> AVFoundationPlayback {


### PR DESCRIPTION
## Goal

Trigger `assetAvailable` event when `AVURLAsset` is ready. 

## How to test

1.  Add this code on ViewController.swift
```swift
player.on(Event.assetReady) { _ in
    print("on assetReady")
}
```

2. Add `Event.assetReady.rawValue` on `Player.swift#81`  