### PR TITLE
MediaControl none panel bottom constraint

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Layout/MediaControlView.xib
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/Layout/MediaControlView.xib
@@ -111,10 +111,10 @@
                 <constraint firstItem="rxJ-bk-Ll1" firstAttribute="bottom" secondItem="78G-Xh-tuQ" secondAttribute="bottom" id="F4w-fC-1R5"/>
                 <constraint firstItem="rxJ-bk-Ll1" firstAttribute="top" secondItem="78G-Xh-tuQ" secondAttribute="top" id="I1w-LF-O8G"/>
                 <constraint firstItem="VEM-5Y-Fai" firstAttribute="trailing" secondItem="78G-Xh-tuQ" secondAttribute="trailing" id="ISV-ZS-bmD"/>
+                <constraint firstItem="7qX-Y6-Q33" firstAttribute="bottom" secondItem="VEM-5Y-Fai" secondAttribute="bottom" id="Kjx-6y-A1r"/>
                 <constraint firstItem="VEM-5Y-Fai" firstAttribute="leading" secondItem="78G-Xh-tuQ" secondAttribute="leading" id="Rla-rd-ZbW"/>
                 <constraint firstItem="7qX-Y6-Q33" firstAttribute="leading" secondItem="78G-Xh-tuQ" secondAttribute="leading" id="V7n-vp-Ty8"/>
                 <constraint firstItem="rxJ-bk-Ll1" firstAttribute="leading" secondItem="78G-Xh-tuQ" secondAttribute="leading" id="XAn-Ez-HXf"/>
-                <constraint firstItem="78G-Xh-tuQ" firstAttribute="bottom" secondItem="7qX-Y6-Q33" secondAttribute="bottom" id="XkV-9P-Evi"/>
                 <constraint firstItem="7qX-Y6-Q33" firstAttribute="top" secondItem="78G-Xh-tuQ" secondAttribute="top" id="Xxk-kb-VQN"/>
                 <constraint firstAttribute="bottom" secondItem="d79-k6-8Eh" secondAttribute="bottom" id="YHT-bZ-01n"/>
                 <constraint firstItem="rxJ-bk-Ll1" firstAttribute="trailing" secondItem="78G-Xh-tuQ" secondAttribute="trailing" id="foI-fv-LJa"/>

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -3,7 +3,6 @@ import Foundation
 open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     public var tapGesture: UITapGestureRecognizer?
-    private let paddingHeight: CGFloat = 32.0
 
     var mediaControlView: MediaControlView = .fromNib()
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -42,8 +42,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
         listenFullscreenEvents()
 
-        listenTo(core, event: .requestPadding) { [weak self] _ in
-            guard let padding = self?.paddingHeight else { return }
+        listenTo(core, event: .requestPadding) { [weak self] info in
+            guard let padding = info?["padding"] as? CGFloat else { return }
             self?.mediaControlView.bottomPadding.constant = padding
         }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
@@ -115,7 +115,7 @@ class MediaControlTests: QuickSpec {
                         let mediaControl = MediaControl(context: core)
                         mediaControl.render()
 
-                        core.trigger(.requestPadding)
+                        core.trigger(.requestPadding, userInfo: ["padding": CGFloat(32)])
 
                         expect(mediaControl.mediaControlView.bottomPadding?.constant).to(equal(32.0))
                     }


### PR DESCRIPTION
## 🏁 Goal:
- Now that we have a way to add a bottom placeholder to mediaControl, we want to apply this constraint to the `none` panel as well. This PR is simply changing the bottom constraint of this panel to use the StackView bottom constraint.

## ✅ How to test:
- Run the tests and nonthing should fail as this is a simple constraint replacement and a simple change on the way we pass the placeholder height