### PR TITLE
Bottom drawer plugin

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -160,6 +160,8 @@
 		57AB0E882253CAB70096BCA4 /* PassthroughView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AB0E872253CAB70096BCA4 /* PassthroughView.swift */; };
 		57F1354921836EE000111BC6 /* Array+appendOrReplace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F1354821836EE000111BC6 /* Array+appendOrReplace.swift */; };
 		7B51DF0C230B58A800C2B045 /* MediaControlElementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B51DF0B230B58A800C2B045 /* MediaControlElementTests.swift */; };
+		7B5EBDEA23297D4E00B2FBBC /* BottomDrawerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5EBDE923297D4E00B2FBBC /* BottomDrawerPluginTests.swift */; };
+		7B5EBDEC23297EFE00B2FBBC /* BottomDrawerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5EBDEB23297EFE00B2FBBC /* BottomDrawerPlugin.swift */; };
 		7BCD8EE023073A8900FBE5A2 /* SimpleContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCD8EDF23073A8900FBE5A2 /* SimpleContainerPluginTests.swift */; };
 		7BCD8EE123073A8900FBE5A2 /* SimpleContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BCD8EDF23073A8900FBE5A2 /* SimpleContainerPluginTests.swift */; };
 		96036D671CBD89500022CCCA /* PlaybackFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */; };
@@ -467,6 +469,8 @@
 		607FACE51AFB9204008FA782 /* Clappr_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Clappr_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7B51DF0B230B58A800C2B045 /* MediaControlElementTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaControlElementTests.swift; sourceTree = "<group>"; };
+		7B5EBDE923297D4E00B2FBBC /* BottomDrawerPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomDrawerPluginTests.swift; sourceTree = "<group>"; };
+		7B5EBDEB23297EFE00B2FBBC /* BottomDrawerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomDrawerPlugin.swift; sourceTree = "<group>"; };
 		7BCD8EDF23073A8900FBE5A2 /* SimpleContainerPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleContainerPluginTests.swift; sourceTree = "<group>"; };
 		8F3389F0416A5259ADD1C31F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaybackFactoryTests.swift; sourceTree = "<group>"; };
@@ -769,6 +773,7 @@
 		48F1E96F232296CC00EAD6A1 /* Drawer */ = {
 			isa = PBXGroup;
 			children = (
+				7B5EBDE923297D4E00B2FBBC /* BottomDrawerPluginTests.swift */,
 				48F1E970232296F600EAD6A1 /* DrawerPluginTests.swift */,
 			);
 			path = Drawer;
@@ -778,6 +783,7 @@
 			isa = PBXGroup;
 			children = (
 				48F1E97323229FDC00EAD6A1 /* DrawerPlugin.swift */,
+				7B5EBDEB23297EFE00B2FBBC /* BottomDrawerPlugin.swift */,
 			);
 			path = Drawer;
 			sourceTree = "<group>";
@@ -2104,6 +2110,7 @@
 				57937C5A1FB0DD2C000A239E /* AVURLAssetWithCookiesTests.swift in Sources */,
 				9E1613FC2051CD89006E95F2 /* HTTPStub.swift in Sources */,
 				969703A61BEA8C7500B7F282 /* BaseObjectTests.swift in Sources */,
+				7B5EBDEA23297D4E00B2FBBC /* BottomDrawerPluginTests.swift in Sources */,
 				487747D5220B5BFB000167CE /* QuickSeekMediaControlPluginTests.swift in Sources */,
 				C9EDF84A2162CCB700789E2F /* MediaControlTests.swift in Sources */,
 				E7C6E891219225B900A74149 /* SeekbarViewTests.swift in Sources */,
@@ -2156,6 +2163,7 @@
 				AB25CC2822EB7D0500AD4759 /* AVFoundationPlayback+LogEvent.swift in Sources */,
 				9E26CFF42016149600AE92B7 /* FullscreenController.swift in Sources */,
 				96D362E71D41339400CCB866 /* Plugin.swift in Sources */,
+				7B5EBDEC23297EFE00B2FBBC /* BottomDrawerPlugin.swift in Sources */,
 				96D362D81D41339400CCB866 /* PluginType.swift in Sources */,
 				96D362C91D41339400CCB866 /* Loader.swift in Sources */,
 				968E5BD91D6CBFA50092F372 /* Logger.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -270,6 +270,7 @@
 		C94D8CEE221B1E5400C7855D /* ContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94D8CEC221B1DDD00C7855D /* ContainerPluginTests.swift */; };
 		C94D8CF0221B22C300C7855D /* ContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94D8CEF221B22C300C7855D /* ContainerPlugin.swift */; };
 		C94D8CF1221B22C300C7855D /* ContainerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94D8CEF221B22C300C7855D /* ContainerPlugin.swift */; };
+		C957E82A2332C45B001F0612 /* PanGesture+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957E8292332C45B001F0612 /* PanGesture+Ext.swift */; };
 		C98C014C2166B50E009DFE0A /* FullscreenButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98C014B2166B50E009DFE0A /* FullscreenButtonTests.swift */; };
 		C990DAA52194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
 		C990DAA62194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
@@ -568,6 +569,7 @@
 		C93212462212013700F0C47B /* UIImageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageViewTests.swift; sourceTree = "<group>"; };
 		C94D8CEC221B1DDD00C7855D /* ContainerPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerPluginTests.swift; sourceTree = "<group>"; };
 		C94D8CEF221B22C300C7855D /* ContainerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerPlugin.swift; sourceTree = "<group>"; };
+		C957E8292332C45B001F0612 /* PanGesture+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PanGesture+Ext.swift"; sourceTree = "<group>"; };
 		C98C014B2166B50E009DFE0A /* FullscreenButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenButtonTests.swift; sourceTree = "<group>"; };
 		C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackStateMachineEventsTests.swift; sourceTree = "<group>"; };
 		C9B6D6E6216FDD5400588896 /* FullscreenButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullscreenButton.swift; sourceTree = "<group>"; };
@@ -990,6 +992,7 @@
 				48EC491F22A1908300DC7A2D /* AVPlayerItem+Ext.swift */,
 				AB25CC2722EB7D0500AD4759 /* AVFoundationPlayback+LogEvent.swift */,
 				AB25CC2A22EB7DE500AD4759 /* AVFoundationPlayback+DVR.swift */,
+				C957E8292332C45B001F0612 /* PanGesture+Ext.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2136,6 +2139,7 @@
 				96D362D91D41339400CCB866 /* UIView+Ext.swift in Sources */,
 				96D362DD1D41339400CCB866 /* PlaybackFactory.swift in Sources */,
 				AB163506215AB97800635233 /* MediaControlElement.swift in Sources */,
+				C957E82A2332C45B001F0612 /* PanGesture+Ext.swift in Sources */,
 				96D362E61D41339400CCB866 /* EventProtocol.swift in Sources */,
 				CD57FCF122949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */,
 				48B9F9AD230D82C200CD07D5 /* OverlayPlugin.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -113,6 +113,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         containers.forEach(renderContainer)
         addToContainer()
         parentView?.bringSubviewToFront(overlayView)
+        overlayView.clipsToBounds = true
     }
 
     #if os(tvOS)

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -109,7 +109,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
 
     open override func render() {
-        parentView?.addSubviewMatchingConstraints(overlayView)
+        view.addSubviewMatchingConstraints(overlayView)
         containers.forEach(renderContainer)
         addToContainer()
         parentView?.bringSubviewToFront(overlayView)
@@ -140,6 +140,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         plugins
             .compactMap { $0 as? OverlayPlugin }
             .forEach(render)
+        view.bringSubviewToFront(overlayView)
     }
     #endif
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -125,6 +125,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     private func renderCorePlugins() {
         plugins
             .filter { $0.isNotMediaControlElement }
+            .filter { $0.isNotOverlayPlugin}
             .forEach(render)
     }
 
@@ -254,6 +255,10 @@ fileprivate extension Plugin {
     #if os(iOS)
     var isNotMediaControlElement: Bool {
         return !(self is MediaControl.Element)
+    }
+
+    var isNotOverlayPlugin: Bool {
+        return !(self is OverlayPlugin)
     }
     #endif
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -112,7 +112,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         view.addSubviewMatchingConstraints(overlayView)
         containers.forEach(renderContainer)
         addToContainer()
-        parentView?.bringSubviewToFront(overlayView)
+        view.bringSubviewToFront(overlayView)
         overlayView.clipsToBounds = true
     }
 

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -67,5 +67,4 @@ public enum Event: String, CaseIterable {
     case hideDrawerPlugin = "Clappr:hideDrawerPlugin"
     case willHideDrawerPlugin = "Clappr:willHideDrawerPlugin"
     case didHideDrawerPlugin = "Clappr:didHideDrawerPlugin"
-    case didDragDrawer = "Clappr:didDragDrawer"
 }

--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -67,4 +67,5 @@ public enum Event: String, CaseIterable {
     case hideDrawerPlugin = "Clappr:hideDrawerPlugin"
     case willHideDrawerPlugin = "Clappr:willHideDrawerPlugin"
     case didHideDrawerPlugin = "Clappr:didHideDrawerPlugin"
+    case didDragDrawer = "Clappr:didDragDrawer"
 }

--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -5,4 +5,5 @@ public enum InternalEvent: String {
     case willBeginScrubbing = "Clappr:willBeginScrubbing"
     case didFinishScrubbing = "Clappr:didFinishScrubbing"
     case didQuickSeek = "Clappr:didQuickSeek"
+    case didDragDrawer = "Clappr:didDragDrawer"
 }

--- a/Sources/Clappr/Classes/Extension/PanGesture+Ext.swift
+++ b/Sources/Clappr/Classes/Extension/PanGesture+Ext.swift
@@ -1,0 +1,10 @@
+extension UIPanGestureRecognizer {
+    var translation: CGPoint {
+        return translation(in: view)
+    }
+
+    var newYCoordinate: CGFloat {
+        guard let view = view else { return .zero }
+        return view.center.y + translation.y
+    }
+}

--- a/Sources/Clappr/Classes/Extension/UIView+Ext.swift
+++ b/Sources/Clappr/Classes/Extension/UIView+Ext.swift
@@ -76,4 +76,10 @@ extension UIView {
         layer.cornerRadius = radius
         clipsToBounds = true
     }
+
+    func setVerticalPoint(to point: CGFloat, duration: TimeInterval = 0) {
+        UIView.animate(withDuration: duration) {
+            self.frame.origin.y = point
+        }
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -1,7 +1,8 @@
 class BottomDrawerPlugin: DrawerPlugin {
+    required init(context: UIObject) {
+        super.init(context: context)
 
-    open class override var name: String {
-        return "BottomDrawerPlugin"
+        self.addTapGesture()
     }
 
     override var position: DrawerPlugin.Position {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -14,16 +14,19 @@ class BottomDrawerPlugin: DrawerPlugin {
 
     private var coreViewBounds: CGRect {
         guard let core = core else { return .zero }
-        return core.view.bounds
+        return core.view.frame
     }
 
     override func render() {
+        super.render()
+
         moveDown()
     }
 
     override func bindEvents() {
         guard let core = core else { return }
-        
+        super.bindEvents()
+
         listenTo(core, event: .showDrawerPlugin) { [weak self] _ in
             self?.moveUp()
         }
@@ -38,6 +41,6 @@ class BottomDrawerPlugin: DrawerPlugin {
     }
 
     private func setVerticalPoint(to point: CGFloat) {
-        view.bounds.origin.y = point
+        view.frame.origin.y = point
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -21,27 +21,46 @@ class BottomDrawerPlugin: DrawerPlugin {
     override func render() {
         super.render()
 
+        adjustSize()
         moveDown()
     }
 
-    override func bindEvents() {
-        guard let core = core else { return }
-        super.bindEvents()
+    override func onDrawerShow() {
+        moveUp()
+    }
 
-        listenTo(core, event: .showDrawerPlugin) { [weak self] _ in
-            self?.moveUp()
-        }
+    override func onDrawerHide() {
+        moveDown()
+    }
+
+    private func adjustSize() {
+        view.frame.size = size
     }
 
     private func moveUp() {
-        setVerticalPoint(to: size.height)
+        view.setVerticalPoint(to: size.height, duration: ClapprAnimationDuration.mediaControlShow)
     }
 
     private func moveDown() {
-        setVerticalPoint(to: coreViewBounds.height)
+        let point = coreViewBounds.height - placeholder
+        view.setVerticalPoint(to: point, duration: ClapprAnimationDuration.mediaControlHide)
     }
 
-    private func setVerticalPoint(to point: CGFloat) {
-        view.frame.origin.y = point
+    private func addTapGesture() {
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        view.addGestureRecognizer(gesture)
+    }
+
+    @objc private func didTapView() {
+        showDrawerPlugin()
+        hideMediaControl()
+    }
+
+    private func showDrawerPlugin() {
+        core?.trigger(.showDrawerPlugin)
+    }
+
+    private func hideMediaControl() {
+        activeContainer?.trigger(.disableMediaControl)
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -97,12 +97,12 @@ class BottomDrawerPlugin: DrawerPlugin {
         let updatedY = gestureView.frame.origin.y
 
         switch gesture.state {
-            case .began, .changed:
-                handleGestureChange(for: newYCoordinate, within: gestureView)
-            case .ended, .failed:
-                handleGestureEnded(for: updatedY)
-            default:
-                Logger.logInfo("unhandled gesture state")
+        case .began, .changed:
+            handleGestureChange(for: newYCoordinate, within: gestureView)
+        case .ended, .failed:
+            handleGestureEnded(for: updatedY)
+        default:
+            Logger.logInfo("unhandled gesture state")
         }
 
         gesture.setTranslation(.zero, in: view)
@@ -113,7 +113,7 @@ class BottomDrawerPlugin: DrawerPlugin {
             view.center.y = newYCoordinate
             view.alpha = 1
             let portionShown = initialCenterY - newYCoordinate
-            let alpha = hiddenHeight / portionShown * 0.2
+            let alpha = hiddenHeight / portionShown * 0.08
             core?.trigger(.didDragDrawer, userInfo: ["alpha": alpha])
         }
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -68,20 +68,14 @@ open class BottomDrawerPlugin: DrawerPlugin {
 
     @objc private func didTapView() {
         showDrawerPlugin()
-        hideMediaControl()
     }
 
     private func showDrawerPlugin() {
         core?.trigger(.showDrawerPlugin)
     }
 
-    private func hideMediaControl() {
-        activeContainer?.trigger(.disableMediaControl)
-    }
-
     private func hideDrawerPlugin() {
         core?.trigger(.hideDrawerPlugin)
-        activeContainer?.trigger(.enableMediaControl)
     }
 
     @objc private func onDragView(_ gesture: UIPanGestureRecognizer) {
@@ -109,7 +103,7 @@ open class BottomDrawerPlugin: DrawerPlugin {
             view.center.y = gesture.newYCoordinate
             view.alpha = 1
 
-            core?.trigger(.didDragDrawer, userInfo: ["alpha": alpha])
+            core?.trigger(InternalEvent.didDragDrawer.rawValue, userInfo: ["alpha": alpha])
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -85,17 +85,13 @@ class BottomDrawerPlugin: DrawerPlugin {
     }
 
     @objc private func onDragView(_ gesture: UIPanGestureRecognizer) {
-        guard let gestureView = gesture.view else { return }
-
-        let translation = gesture.translation(in: gestureView)
-        let newYCoordinate = gestureView.center.y + translation.y
-        let updatedY = gestureView.frame.origin.y
+        guard let view = gesture.view else { return }
 
         switch gesture.state {
         case .began, .changed:
-            handleGestureChange(for: newYCoordinate, within: gestureView)
+            handleGestureChange(with: gesture)
         case .ended, .failed:
-            handleGestureEnded(for: updatedY)
+            handleGestureEnded(for: view.frame.origin.y)
         default:
             Logger.logInfo("unhandled gesture state")
         }
@@ -103,12 +99,16 @@ class BottomDrawerPlugin: DrawerPlugin {
         gesture.setTranslation(.zero, in: view)
     }
 
-    private func handleGestureChange(for newYCoordinate: CGFloat, within view: UIView) {
-        if canDrag(with: newYCoordinate) {
-            view.center.y = newYCoordinate
-            view.alpha = 1
-            let portionShown = initialCenterY - newYCoordinate
+    private func handleGestureChange(with gesture: UIPanGestureRecognizer) {
+        guard let view = gesture.view else { return }
+
+        if canDrag(with: gesture.newYCoordinate) {
+            let portionShown = initialCenterY - gesture.newYCoordinate
             let alpha = hiddenHeight / portionShown * 0.08
+
+            view.center.y = gesture.newYCoordinate
+            view.alpha = 1
+
             core?.trigger(.didDragDrawer, userInfo: ["alpha": alpha])
         }
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -98,12 +98,12 @@ open class BottomDrawerPlugin: DrawerPlugin {
 
         if canDrag(with: gesture.newYCoordinate) {
             let portionShown = initialCenterY - gesture.newYCoordinate
-            let alpha = hiddenHeight / portionShown * 0.08
+            let alphaToSet = hiddenHeight / portionShown * 0.08
 
             view.center.y = gesture.newYCoordinate
             view.alpha = 1
 
-            core?.trigger(InternalEvent.didDragDrawer.rawValue, userInfo: ["alpha": alpha])
+            core?.trigger(InternalEvent.didDragDrawer.rawValue, userInfo: ["alphaToSet": alphaToSet])
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -1,11 +1,11 @@
-class BottomDrawerPlugin: DrawerPlugin {
+open class BottomDrawerPlugin: DrawerPlugin {
     private var initialCenterY: CGFloat = .zero
 
-    override var position: DrawerPlugin.Position {
+    override open var position: DrawerPlugin.Position {
         return .bottom
     }
 
-    override var size: CGSize {
+    override open var size: CGSize {
         return CGSize(width: coreViewFrame.width, height: coreViewFrame.height/2)
     }
 
@@ -17,14 +17,14 @@ class BottomDrawerPlugin: DrawerPlugin {
         return coreViewFrame.height - placeholder
     }
 
-    required init(context: UIObject) {
+    required public init(context: UIObject) {
         super.init(context: context)
 
         addTapGesture()
         addDragGesture()
     }
 
-    override func render() {
+    override open func render() {
         super.render()
 
         adjustSize()
@@ -40,11 +40,11 @@ class BottomDrawerPlugin: DrawerPlugin {
         initialCenterY = view.center.y
     }
 
-    override func onDrawerShow() {
+    override open func onDrawerShow() {
         moveUp()
     }
 
-    override func onDrawerHide() {
+    override open func onDrawerHide() {
         moveDown()
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -9,7 +9,35 @@ class BottomDrawerPlugin: DrawerPlugin {
     }
 
     override var size: CGSize {
-        guard let core = self.core else { return .zero }
-        return CGSize(width: core.view.bounds.width, height: core.view.bounds.height/2)
+        return CGSize(width: coreViewBounds.width, height: coreViewBounds.height/2)
+    }
+
+    private var coreViewBounds: CGRect {
+        guard let core = core else { return .zero }
+        return core.view.bounds
+    }
+
+    override func render() {
+        moveDown()
+    }
+
+    override func bindEvents() {
+        guard let core = core else { return }
+        
+        listenTo(core, event: .showDrawerPlugin) { [weak self] _ in
+            self?.moveUp()
+        }
+    }
+
+    private func moveUp() {
+        setVerticalPoint(to: size.height)
+    }
+
+    private func moveDown() {
+        setVerticalPoint(to: coreViewBounds.height)
+    }
+
+    private func setVerticalPoint(to point: CGFloat) {
+        view.bounds.origin.y = point
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -1,26 +1,21 @@
 class BottomDrawerPlugin: DrawerPlugin {
+    private var initialCenterY: CGFloat = .zero
+
     override var position: DrawerPlugin.Position {
         return .bottom
     }
 
     override var size: CGSize {
-        return CGSize(width: coreViewBounds.width, height: coreViewBounds.height/2)
-    }
-
-    private var coreViewBounds: CGRect {
-        guard let core = core else { return .zero }
-        return core.view.frame
+        return CGSize(width: coreViewFrame.width, height: coreViewFrame.height/2)
     }
 
     private var minYToShow: CGFloat {
-        return coreViewBounds.height * 0.75
+        return coreViewFrame.height * 0.75
     }
 
     private var hiddenHeight: CGFloat {
-        return coreViewBounds.height - placeholder
+        return coreViewFrame.height - placeholder
     }
-
-    private var initialCenterY: CGFloat = .zero
 
     required init(context: UIObject) {
         super.init(context: context)
@@ -33,16 +28,8 @@ class BottomDrawerPlugin: DrawerPlugin {
         super.render()
 
         adjustSize()
-        moveDown()
+        moveDown(with: .zero)
         adjustInitialPosition()
-    }
-
-    override func onDrawerShow() {
-        moveUp()
-    }
-
-    override func onDrawerHide() {
-        moveDown()
     }
 
     private func adjustSize() {
@@ -53,12 +40,20 @@ class BottomDrawerPlugin: DrawerPlugin {
         initialCenterY = view.center.y
     }
 
+    override func onDrawerShow() {
+        moveUp()
+    }
+
+    override func onDrawerHide() {
+        moveDown()
+    }
+
     private func moveUp() {
         view.setVerticalPoint(to: size.height, duration: ClapprAnimationDuration.mediaControlShow)
     }
 
-    private func moveDown() {
-        view.setVerticalPoint(to: hiddenHeight, duration: ClapprAnimationDuration.mediaControlHide)
+    private func moveDown(with duration: TimeInterval = ClapprAnimationDuration.mediaControlHide) {
+        view.setVerticalPoint(to: hiddenHeight, duration: duration)
     }
 
     private func addTapGesture() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -1,12 +1,20 @@
 open class BottomDrawerPlugin: DrawerPlugin {
     private var initialCenterY: CGFloat = .zero
 
+    private var maxHeight: CGFloat {
+        return coreViewFrame.height/2
+    }
+
+    open var height: CGFloat {
+        return maxHeight
+    }
+
     override open var position: DrawerPlugin.Position {
         return .bottom
     }
 
-    override open var size: CGSize {
-        return CGSize(width: coreViewFrame.width, height: coreViewFrame.height/2)
+    override var size: CGSize {
+        return CGSize(width: coreViewFrame.width, height: min(maxHeight, height))
     }
 
     private var minYToShow: CGFloat {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -1,0 +1,15 @@
+class BottomDrawerPlugin: DrawerPlugin {
+
+    open class override var name: String {
+        return "BottomDrawerPlugin"
+    }
+
+    override var position: DrawerPlugin.Position {
+        return .bottom
+    }
+
+    override var size: CGSize {
+        guard let core = self.core else { return .zero }
+        return CGSize(width: core.view.bounds.width, height: core.view.bounds.height/2)
+    }
+}

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -33,20 +33,29 @@ open class DrawerPlugin: OverlayPlugin {
     }
 
     open override func bindEvents() {
-        bindMediaControlEvents()
-        bindDrawerEvents()
-    }
-
-    private func bindMediaControlEvents() {
         guard let core = core else { return }
 
-        listenTo(core, event: .willShowMediaControl) { [weak self] _ in
+        bindCoreEvents(context: core)
+        bindMediaControlEvents(context: core)
+        bindDrawerEvents(context: core)
+    }
+
+    private func bindCoreEvents(context: UIObject) {
+        listenTo(context, eventName: InternalEvent.didTappedCore.rawValue) { [weak self] _ in
+            guard self?.isClosed == false else { return }
+
+            context.trigger(.hideDrawerPlugin)
+        }
+    }
+
+    private func bindMediaControlEvents(context: UIObject) {
+        listenTo(context, event: .willShowMediaControl) { [weak self] _ in
             UIView.animate(withDuration: ClapprAnimationDuration.mediaControlShow) {
                 self?.view.alpha = 1
             }
         }
 
-        listenTo(core, event: .willHideMediaControl) { [weak self] _ in
+        listenTo(context, event: .willHideMediaControl) { [weak self] _ in
             guard self?.isClosed == true else { return }
             UIView.animate(withDuration: ClapprAnimationDuration.mediaControlHide) {
                 self?.view.alpha = 0
@@ -54,15 +63,15 @@ open class DrawerPlugin: OverlayPlugin {
         }
     }
 
-    private func bindDrawerEvents() {
-        guard let core = core else { return }
-
-        listenTo(core, event: .showDrawerPlugin) { [weak self] _ in
+    private func bindDrawerEvents(context: UIObject) {
+        listenTo(context, event: .showDrawerPlugin) { [weak self] _ in
             self?.toggleIsClosed(to: false)
+            self?.onDrawerShow()
         }
 
-        listenTo(core, event: .hideDrawerPlugin) { [weak self] _ in
+        listenTo(context, event: .hideDrawerPlugin) { [weak self] _ in
             self?.toggleIsClosed(to: true)
+            self?.onDrawerHide()
         }
     }
 
@@ -73,6 +82,14 @@ open class DrawerPlugin: OverlayPlugin {
 
     override open func render() {
         requestPaddingIfNeeded()
+    }
+
+    open func onDrawerShow() {
+        Logger.logWarn("You have to override onDrawerShow function")
+    }
+
+    open func onDrawerHide() {
+        Logger.logWarn("You have to override onDrawerHide function")
     }
 
     private func requestPaddingIfNeeded() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -16,6 +16,11 @@ open class DrawerPlugin: OverlayPlugin {
         return .zero
     }
 
+    open var coreViewFrame: CGRect {
+        guard let core = core else { return .zero }
+        return core.view.frame
+    }
+
     private(set) var isClosed: Bool = true {
         willSet {
             let event: Event = newValue ? .willHideDrawerPlugin : .willShowDrawerPlugin

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -41,10 +41,18 @@ open class DrawerPlugin: OverlayPlugin {
     }
 
     private func bindCoreEvents(context: UIObject) {
+        let eventsToRender: [Event] = [.didEnterFullscreen, .didExitFullscreen, .didChangeScreenOrientation]
+
         listenTo(context, eventName: InternalEvent.didTappedCore.rawValue) { [weak self] _ in
             guard self?.isClosed == false else { return }
 
             context.trigger(.hideDrawerPlugin)
+        }
+
+        eventsToRender.forEach {
+            listenTo(context, event: $0) { [weak self] _ in
+                self?.render()
+            }
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -43,18 +43,13 @@ open class DrawerPlugin: OverlayPlugin {
         bindCoreEvents(context: core)
         bindMediaControlEvents(context: core)
         bindDrawerEvents(context: core)
+        bindPlaybackEvents(context: core)
     }
 
     private func bindCoreEvents(context: UIObject) {
         let eventsToRender: [Event] = [.didEnterFullscreen, .didExitFullscreen, .didChangeScreenOrientation]
 
         listenTo(context, eventName: InternalEvent.didTappedCore.rawValue) { [weak self] _ in
-            guard self?.isClosed == false else { return }
-
-            context.trigger(.hideDrawerPlugin)
-        }
-
-        listenTo(context, event: .didComplete) { [weak self] _ in
             guard self?.isClosed == false else { return }
 
             context.trigger(.hideDrawerPlugin)
@@ -92,6 +87,17 @@ open class DrawerPlugin: OverlayPlugin {
             self?.toggleIsClosed(to: true)
             self?.onDrawerHide()
         }
+    }
+
+    private func bindPlaybackEvents(context: UIObject?) {
+        guard let core = context as? Core, let activePlayback = core.activePlayback else { return }
+
+        listenTo(activePlayback, event: .didComplete) { [weak self] _ in
+            guard self?.isClosed == false else { return }
+
+            self?.onDrawerHide()
+        }
+
     }
 
     private func toggleIsClosed(to newValue: Bool) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -8,7 +8,7 @@ open class DrawerPlugin: OverlayPlugin {
         return .undefined
     }
 
-    open var size: CGSize {
+    var size: CGSize {
         return .zero
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -43,7 +43,6 @@ open class DrawerPlugin: OverlayPlugin {
         bindCoreEvents(context: core)
         bindMediaControlEvents(context: core)
         bindDrawerEvents(context: core)
-        bindPlaybackEvents(context: core)
     }
 
     private func bindCoreEvents(context: UIObject) {
@@ -87,17 +86,6 @@ open class DrawerPlugin: OverlayPlugin {
             self?.toggleIsClosed(to: true)
             self?.onDrawerHide()
         }
-    }
-
-    private func bindPlaybackEvents(context: UIObject?) {
-        guard let core = context as? Core, let activePlayback = core.activePlayback else { return }
-
-        listenTo(activePlayback, event: .didComplete) { [weak self] _ in
-            guard self?.isClosed == false else { return }
-
-            self?.onDrawerHide()
-        }
-
     }
 
     private func toggleIsClosed(to newValue: Bool) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -1,6 +1,7 @@
 open class DrawerPlugin: OverlayPlugin {
     public enum Position {
         case undefined
+        case bottom
     }
 
     open var position: DrawerPlugin.Position {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -53,7 +53,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         listenScrubbingEvents()
 
         listenTo(core, eventName: InternalEvent.didDragDrawer.rawValue) { [weak self] info in
-            guard let alpha = info?["alpha"] as? CGFloat else { return }
+            guard let alpha = info?["alphaToSet"] as? CGFloat else { return }
             self?.view.alpha = alpha
         }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -52,7 +52,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
         listenScrubbingEvents()
 
-        listenTo(core, event: .didDragDrawer) { [weak self] info in
+        listenTo(core, eventName: InternalEvent.didDragDrawer.rawValue) { [weak self] info in
             guard let alpha = info?["alpha"] as? CGFloat else { return }
             self?.view.alpha = alpha
         }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -51,6 +51,19 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         }
 
         listenScrubbingEvents()
+
+        listenTo(core, event: .didDragDrawer) { [weak self] info in
+            guard let alpha = info?["alpha"] as? CGFloat else { return }
+            self?.view.alpha = alpha
+        }
+
+        listenTo(core, event: .didShowDrawerPlugin) { [weak self] _ in
+            self?.hide()
+        }
+
+        listenTo(core, event: .didHideDrawerPlugin) { [weak self] _ in
+            self?.show()
+        }
     }
 
     private func bindContainerEvents() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -24,6 +24,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     private var alwaysVisible = false
     private var currentlyShowing = false
     private var currentlyHiding = false
+    private var showOnDrawerHide = true
 
     required public init(context: UIObject) {
         super.init(context: context)
@@ -62,6 +63,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         }
 
         listenTo(core, event: .didHideDrawerPlugin) { [weak self] _ in
+            guard self?.showOnDrawerHide == true else { return }
             self?.show()
         }
     }
@@ -83,11 +85,13 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
             listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in
                 self?.hide()
+                self?.showOnDrawerHide = false
             }
 
             listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in
                 self?.keepVisible()
                 self?.listenToOnce(playback, eventName: Event.playing.rawValue) { [weak self] _ in
+                    self?.showOnDrawerHide = true
                     self?.show { [weak self] in
                         self?.disappearAfterSomeTime()
                     }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -723,6 +723,7 @@ class CoreTests: QuickSpec {
                 }
 
                 it("renders MediaControlElements after CorePlugins") {
+                    UICorePluginMock.crashOnRender = false
                     let core = Core()
                     let mediaControl = MediaControl(context: core)
                     let element = MediaControlElementMock(context: core)
@@ -779,7 +780,7 @@ class CoreTests: QuickSpec {
 
                     core.render()
 
-                    expect(core.view.subviews.count).to(equal(2))
+                    expect(core.view.subviews.count).to(equal(3))
                     expect(core.view.subviews.first?.accessibilityIdentifier).to(equal("Container"))
                     expect(core.view.subviews[1].accessibilityIdentifier).to(beNil())
                 }
@@ -805,7 +806,7 @@ class CoreTests: QuickSpec {
 
                     core.render()
 
-                    expect(core.parentView?.subviews.last).to(beAKindOf(PassthroughView.self))
+                    expect(core.view.subviews.last).to(beAKindOf(PassthroughView.self))
                 }
             }
         }
@@ -839,7 +840,6 @@ class UICorePluginMock: UICorePlugin {
     override class var name: String {
         return "UICorePluginMock"
     }
-    
 
     override func render() {
         UICorePluginMock.didCallRender = true

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -39,8 +39,8 @@ class BottomDrawerPluginTests: QuickSpec {
 
                     plugin.render()
 
-                    expect(plugin.view.bounds.origin.y).to(equal(100))
-                    expect(plugin.view.bounds.origin.x).to(equal(.zero))
+                    expect(plugin.view.frame.origin.y).to(equal(100))
+                    expect(plugin.view.frame.origin.x).to(equal(.zero))
                 }
             }
 
@@ -53,8 +53,8 @@ class BottomDrawerPluginTests: QuickSpec {
                     plugin.render()
                     core.trigger(.showDrawerPlugin)
 
-                    expect(plugin.view.bounds.origin.y).to(equal(plugin.size.height))
-                    expect(plugin.view.bounds.origin.x).to(equal(.zero))
+                    expect(plugin.view.frame.origin.y).to(equal(plugin.size.height))
+                    expect(plugin.view.frame.origin.x).to(equal(.zero))
                 }
             }
         }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -28,32 +28,67 @@ class BottomDrawerPluginTests: QuickSpec {
             }
 
             context("#render") {
-                it("has origin x on zero and y equal to parentView height") {
-                    let core = CoreStub()
-                    let plugin = BottomDrawerPlugin(context: core)
-                    core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
+                var core: CoreStub!
+                var plugin: BottomDrawerPlugin!
 
+                beforeEach {
+                    core = CoreStub()
+                    plugin = BottomDrawerPlugin(context: core)
+                    core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
+                }
+
+                it("has origin x on zero and y equal to parentView height") {
                     plugin.render()
 
-                    expect(plugin.view.frame.origin.y).to(equal(100))
-                    expect(plugin.view.frame.origin.x).to(equal(.zero))
+                    expect(plugin.view.frame.origin).to(equal(CGPoint(x: .zero, y: 100)))
+                }
+
+                it("has a view frame size equals to his size") {
+                    plugin.render()
+
+                    expect(plugin.view.frame.size).to(equal(CGSize(width: 320, height: 50)))
                 }
             }
 
-            context("when the showDrawerPlugin event is triggered") {
-                it("up the drawer to his height") {
-                    let core = CoreStub()
-                    let plugin = BottomDrawerPlugin(context: core)
+            describe("#events") {
+                var core: CoreStub!
+                var plugin: BottomDrawerPlugin!
+
+                beforeEach {
+                    core = CoreStub()
+                    plugin = BottomDrawerPlugin(context: core)
                     core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
-
                     plugin.render()
-                    core.trigger(.showDrawerPlugin)
+                }
 
-                    expect(plugin.view.frame.origin.y).to(equal(plugin.size.height))
-                    expect(plugin.view.frame.origin.x).to(equal(.zero))
+                context("when the showDrawerPlugin event is triggered") {
+                    it("push up the drawer to half of core height") {
+                        core.trigger(.showDrawerPlugin)
+
+                        expect(plugin.view.frame.origin).to(equal(CGPoint(x: .zero, y: 50)))
+                    }
+                }
+
+                context("when the hideDrawer event is triggered") {
+                    it("push down the drawer to core height") {
+                        core.trigger(.hideDrawerPlugin)
+
+                        expect(plugin.view.frame.origin).to(equal(CGPoint(x: .zero, y: 100)))
+                    }
+                }
+
+                context("when the didTappedCore event is triggered") {
+                    it("calls hideDrawer event") {
+                        var didCallHideDrawer = false
+                        core.on(Event.hideDrawerPlugin.rawValue) { _ in didCallHideDrawer.toggle() }
+                        core.trigger(.showDrawerPlugin)
+
+                        core.trigger(InternalEvent.didTappedCore.rawValue)
+
+                        expect(didCallHideDrawer).to(beTrue())
+                    }
                 }
             }
         }
     }
 }
-

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -8,27 +8,53 @@ class BottomDrawerPluginTests: QuickSpec {
     override func spec() {
         describe(".BottomDrawerPlugin") {
             context("#init") {
-                it("has a name") {
-                    let core = CoreStub()
-                    let plugin = BottomDrawerPlugin(context: core)
+                var core: CoreStub!
+                var plugin: BottomDrawerPlugin!
 
+                beforeEach {
+                    core = CoreStub()
+                    plugin = BottomDrawerPlugin(context: core)
+                }
+
+                it("has a name") {
                     expect(plugin.pluginName).to(equal("BottomDrawerPlugin"))
                 }
 
                 it("has bottom as position") {
-                    let core = CoreStub()
-                    let plugin = BottomDrawerPlugin(context: core)
-
                     expect(plugin.position).to(equal(.bottom))
                 }
 
                 it("has size with the same width and the half of the height from parentView") {
-                    let core = CoreStub()
-                    let plugin = BottomDrawerPlugin(context: core)
-
                     core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
 
                     expect(plugin.size).to(equal(CGSize(width: 320, height: 50)))
+                }
+            }
+
+            context("#render") {
+                it("has origin x on zero and y equal to parentView height") {
+                    let core = CoreStub()
+                    let plugin = BottomDrawerPlugin(context: core)
+                    core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
+
+                    plugin.render()
+
+                    expect(plugin.view.bounds.origin.y).to(equal(100))
+                    expect(plugin.view.bounds.origin.x).to(equal(.zero))
+                }
+            }
+
+            context("when the showDrawerPlugin event is triggered") {
+                it("up the drawer to his height") {
+                    let core = CoreStub()
+                    let plugin = BottomDrawerPlugin(context: core)
+                    core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
+
+                    plugin.render()
+                    core.trigger(.showDrawerPlugin)
+
+                    expect(plugin.view.bounds.origin.y).to(equal(plugin.size.height))
+                    expect(plugin.view.bounds.origin.x).to(equal(.zero))
                 }
             }
         }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -102,13 +102,11 @@ class BottomDrawerPluginTests: QuickSpec {
 
                 context("when the didComplete event is triggered") {
                     it("calls hideDrawer event") {
-                        var didCallHideDrawer = false
-                        core.on(Event.hideDrawerPlugin.rawValue) { _ in didCallHideDrawer.toggle() }
                         core.trigger(.showDrawerPlugin)
 
-                        core.trigger(.didComplete)
+                        core.activePlayback?.trigger(.didComplete)
 
-                        expect(didCallHideDrawer).to(beTrue())
+                        expect(plugin.view.frame.origin).to(equal(CGPoint(x: .zero, y: 100)))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -16,10 +16,6 @@ class BottomDrawerPluginTests: QuickSpec {
                     plugin = BottomDrawerPlugin(context: core)
                 }
 
-                it("has a name") {
-                    expect(plugin.pluginName).to(equal("BottomDrawerPlugin"))
-                }
-
                 it("has bottom as position") {
                     expect(plugin.position).to(equal(.bottom))
                 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -50,7 +50,7 @@ class BottomDrawerPluginTests: QuickSpec {
                 }
 
                 context("when plugin request a height greater then the limit") {
-                    it("uses the height limit insted") {
+                    it("uses the height limit instead") {
                         core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
                         let pluginMock = BottomDrawerPluginMock(context: core)
 
@@ -85,18 +85,6 @@ class BottomDrawerPluginTests: QuickSpec {
                         core.trigger(.hideDrawerPlugin)
 
                         expect(plugin.view.frame.origin).to(equal(CGPoint(x: .zero, y: 100)))
-                    }
-                }
-
-                context("when the didTappedCore event is triggered") {
-                    it("calls hideDrawer event") {
-                        var didCallHideDrawer = false
-                        core.on(Event.hideDrawerPlugin.rawValue) { _ in didCallHideDrawer.toggle() }
-                        core.trigger(.showDrawerPlugin)
-
-                        core.trigger(InternalEvent.didTappedCore.rawValue)
-
-                        expect(didCallHideDrawer).to(beTrue())
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -99,16 +99,6 @@ class BottomDrawerPluginTests: QuickSpec {
                         expect(didCallHideDrawer).to(beTrue())
                     }
                 }
-
-                context("when the didComplete event is triggered") {
-                    it("calls hideDrawer event") {
-                        core.trigger(.showDrawerPlugin)
-
-                        core.activePlayback?.trigger(.didComplete)
-
-                        expect(plugin.view.frame.origin).to(equal(CGPoint(x: .zero, y: 100)))
-                    }
-                }
             }
         }
     }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -1,0 +1,37 @@
+import Quick
+import Nimble
+
+@testable import Clappr
+
+class BottomDrawerPluginTests: QuickSpec {
+
+    override func spec() {
+        describe(".BottomDrawerPlugin") {
+            context("#init") {
+                it("has a name") {
+                    let core = CoreStub()
+                    let plugin = BottomDrawerPlugin(context: core)
+
+                    expect(plugin.pluginName).to(equal("BottomDrawerPlugin"))
+                }
+
+                it("has bottom as position") {
+                    let core = CoreStub()
+                    let plugin = BottomDrawerPlugin(context: core)
+
+                    expect(plugin.position).to(equal(.bottom))
+                }
+
+                it("has size with the same width and the half of the height from parentView") {
+                    let core = CoreStub()
+                    let plugin = BottomDrawerPlugin(context: core)
+
+                    core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
+
+                    expect(plugin.size).to(equal(CGSize(width: 320, height: 50)))
+                }
+            }
+        }
+    }
+}
+

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -27,7 +27,7 @@ class BottomDrawerPluginTests: QuickSpec {
                 }
             }
 
-            context("#render") {
+            describe("#render") {
                 var core: CoreStub!
                 var plugin: BottomDrawerPlugin!
 
@@ -47,6 +47,17 @@ class BottomDrawerPluginTests: QuickSpec {
                     plugin.render()
 
                     expect(plugin.view.frame.size).to(equal(CGSize(width: 320, height: 50)))
+                }
+
+                context("when plugin request a height greater then the limit") {
+                    it("uses the height limit insted") {
+                        core.view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 100))
+                        let pluginMock = BottomDrawerPluginMock(context: core)
+
+                        pluginMock.render()
+
+                        expect(pluginMock.view.frame.size).to(equal(CGSize(width: 320, height: 50)))
+                    }
                 }
             }
 
@@ -102,5 +113,12 @@ class BottomDrawerPluginTests: QuickSpec {
                 }
             }
         }
+    }
+}
+
+class BottomDrawerPluginMock: BottomDrawerPlugin {
+
+    override var height: CGFloat {
+        return 1000
     }
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/DrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/DrawerPluginTests.swift
@@ -164,6 +164,39 @@ class DrawerPluginTests: QuickSpec {
                         expect(didCallRequestPadding).to(beFalse())
                     }
                 }
+
+                context("when enter on fullscreen") {
+                    it("calls render") {
+                        let core = CoreStub()
+                        let plugin = MockDrawerPlugin(context: core)
+
+                        core.trigger(.didEnterFullscreen)
+
+                        expect(plugin.didCallRender).to(beTrue())
+                    }
+                }
+
+                context("when exit fullscreen") {
+                    it("calls render") {
+                        let core = CoreStub()
+                        let plugin = MockDrawerPlugin(context: core)
+
+                        core.trigger(.didExitFullscreen)
+
+                        expect(plugin.didCallRender).to(beTrue())
+                    }
+                }
+
+                context("when changes the orientation") {
+                    it("calls render") {
+                        let core = CoreStub()
+                        let plugin = MockDrawerPlugin(context: core)
+
+                        core.trigger(.didChangeScreenOrientation)
+
+                        expect(plugin.didCallRender).to(beTrue())
+                    }
+                }
             }
         }
     }
@@ -171,7 +204,14 @@ class DrawerPluginTests: QuickSpec {
 
 class MockDrawerPlugin: DrawerPlugin {
     var _placeholder: CGFloat = .zero
+    var didCallRender = false
+
     override var placeholder: CGFloat {
         return _placeholder
+    }
+
+    override func render() {
+        super.render()
+        didCallRender = true
     }
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/DrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/DrawerPluginTests.swift
@@ -126,6 +126,18 @@ class DrawerPluginTests: QuickSpec {
                         }
                     }
                 }
+
+                context("when the didTappedCore event is triggered") {
+                    it("calls hideDrawer event") {
+                        var didCallHideDrawer = false
+                        core.on(Event.hideDrawerPlugin.rawValue) { _ in didCallHideDrawer.toggle() }
+                        core.trigger(.showDrawerPlugin)
+
+                        core.trigger(InternalEvent.didTappedCore.rawValue)
+
+                        expect(didCallHideDrawer).to(beTrue())
+                    }
+                }
             }
 
             describe("rendering") {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
@@ -314,6 +314,31 @@ class MediaControlTests: QuickSpec {
                     }
                 }
 
+                context("when the drawer events are triggered") {
+                    it("dont show Media Control when the video ended") {
+                        var didCallShow = false
+
+                        coreStub.trigger(.didShowDrawerPlugin)
+                        coreStub.activePlayback?.trigger(.didComplete)
+                        coreStub.trigger(.didHideDrawerPlugin)
+
+                        mediaControl.show() { didCallShow = true }
+
+                        expect(didCallShow).to(beFalse())
+                    }
+
+                    it("shows Media Control when the video is not ended") {
+                        var didCallShow = false
+
+                        coreStub.trigger(.didShowDrawerPlugin)
+                        coreStub.trigger(.didHideDrawerPlugin)
+
+                        mediaControl.show() { didCallShow = true }
+
+                        expect(didCallShow).to(beTrue())
+                    }
+                }
+
                 func mediaControlHidden() {
                     coreStub.activePlayback?.trigger(Event.didComplete)
                 }


### PR DESCRIPTION
## Goal

We are introducing the BottomDrawerPlugin structure, that allows customizing `DrawerPlugin` with a bottom behavior. With this, it's possible to create a plugin from the bottom screen.

![Simulator Screen Shot - iPhone 8 - 2019-09-18 at 18 01 29](https://user-images.githubusercontent.com/28604291/65185646-604d0a80-da3e-11e9-8577-a4a6ba63a2b0.png)

## How to test

1 - Add this code on BottomDrawerPlugin.swift#127 

```swift
class CustomBottomDrawerPlugin: BottomDrawerPlugin {
    open class override var name: String {
        return "CustomBottomDrawerPlugin"
    }

    override var placeholder: CGFloat {
        return 32.0
    }

    override func render() {
        super.render()

        view.backgroundColor = .red
    }
}
```
2 - Add `CustomBottomDrawerPlugin.self` on Player.swift#208

3 - Interact with the red view by tap and drag gesture
