### PR TITLE
Fix events of click in subview of drawer plugin

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -28,8 +28,8 @@ open class BottomDrawerPlugin: DrawerPlugin {
     required public init(context: UIObject) {
         super.init(context: context)
 
-        addTapGesture()
-        addDragGesture()
+        addGesture(UITapGestureRecognizer(target: self, action: #selector(didTapView)))
+        addGesture(UIPanGestureRecognizer(target: self, action: #selector(onDragView)))
     }
 
     override open func render() {
@@ -64,16 +64,9 @@ open class BottomDrawerPlugin: DrawerPlugin {
         view.setVerticalPoint(to: hiddenHeight, duration: duration)
     }
 
-    private func addTapGesture() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
-    }
-
-    private func addDragGesture() {
-        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(onDragView))
-        panGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(panGesture)
+    private func addGesture(_ gesture: UIGestureRecognizer) {
+        gesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(gesture)
     }
 
     @objc private func didTapView() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -65,15 +65,15 @@ open class BottomDrawerPlugin: DrawerPlugin {
     }
 
     private func addTapGesture() {
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
-        gesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(gesture)
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
     }
 
     private func addDragGesture() {
-        let gesture = UIPanGestureRecognizer(target: self, action: #selector(onDragView))
-        gesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(gesture)
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(onDragView))
+        panGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(panGesture)
     }
 
     @objc private func didTapView() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -66,11 +66,13 @@ open class BottomDrawerPlugin: DrawerPlugin {
 
     private func addTapGesture() {
         let gesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        gesture.cancelsTouchesInView = false
         view.addGestureRecognizer(gesture)
     }
 
     private func addDragGesture() {
         let gesture = UIPanGestureRecognizer(target: self, action: #selector(onDragView))
+        gesture.cancelsTouchesInView = false
         view.addGestureRecognizer(gesture)
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -24,7 +24,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     private var alwaysVisible = false
     private var currentlyShowing = false
     private var currentlyHiding = false
-    private var showOnDrawerHide = true
 
     required public init(context: UIObject) {
         super.init(context: context)
@@ -73,13 +72,11 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
             listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in
                 self?.hide()
-                self?.showOnDrawerHide = false
             }
 
             listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in
                 self?.keepVisible()
                 self?.listenToOnce(playback, eventName: Event.playing.rawValue) { [weak self] _ in
-                    self?.showOnDrawerHide = true
                     self?.show { [weak self] in
                         self?.disappearAfterSomeTime()
                     }
@@ -128,11 +125,12 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         }
 
         listenTo(context, event: .didHideDrawerPlugin) { [weak self] _ in
-            guard self?.showOnDrawerHide == true else { return }
+            let statesToShow: [PlaybackState] = [.playing, .paused]
+
+            guard let state = self?.activePlayback?.state, statesToShow.contains(state) else { return }
             self?.show()
         }
     }
-
 
     func show(animated: Bool = false, completion: (() -> Void)? = nil) {
         if currentlyShowing {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
@@ -330,6 +330,8 @@ class MediaControlTests: QuickSpec {
                     it("shows Media Control when the video is not ended") {
                         var didCallShow = false
 
+                        coreStub.playbackMock?.set(state: .playing)
+
                         coreStub.trigger(.didShowDrawerPlugin)
                         coreStub.trigger(.didHideDrawerPlugin)
 


### PR DESCRIPTION
## 🏁  Goal: 
When we have subviews in a plugin of type BottomDrawerPlugin the events of click dont work because of the gestures recognizers. We just set the `cancelsTouchesInView` to false to make this work. And make minor changes in `MediaControl` removing the flag `showOnDrawerHide`and validating if the media control can show when drawer hides by the `PlaybackState`.

## ✅  How to test:
1 - Add this code on BottomDrawerPlugin.swift#127 

```swift
class CustomBottomDrawerPlugin: BottomDrawerPlugin {
    open class override var name: String {
        return "CustomBottomDrawerPlugin"
    }

    override var placeholder: CGFloat {
        return 32.0
    }

    override func render() {
        super.render()
        let button = UIButton()
        button.backgroundColor = .gray
        button.setTitle("Click me", for: .normal)
        button.addTarget(self, action: #selector(cliked), for: .touchUpInside)
        view.addSubviewMatchingConstraints(button)
    }

     @objc func cliked() {
          print("Yes, clicked")
    }
}
```
2 - Add `CustomBottomDrawerPlugin.self` on Player.swift#208

3 - Interact with the view by tap and drag gesture.
4 - Interact with the button by clicking and see the print.
5 - Run the test suite
