### PR TITLE
Propagates media control events on player

### DIFF
--- a/Example/Clappr/ViewController.swift
+++ b/Example/Clappr/ViewController.swift
@@ -39,6 +39,14 @@ class ViewController: UIViewController {
         player.on(Event.willSeek) { _ in print("on willSeek") }
 
         player.on(Event.didSeek) { _ in print("on didSeek") }
+        
+        player.on(Event.willShowMediaControl) { _ in print("on willShowMediaControl") }
+        
+        player.on(Event.didShowMediaControl) { _ in print("on didShowMediaControl") }
+        
+        player.on(Event.willHideMediaControl) { _ in print("on willHideMediaControl") }
+        
+        player.on(Event.didHideMediaControl) { _ in print("on didHideMediaControl") }
 
         player.on(Event.requestFullscreen) { _ in
             print("on requestFullscreen")

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -101,7 +101,7 @@ open class Player: BaseObject {
     }
     
     private func bindMediaControlEvents() {
-        let eventsToListen: [Event] = [.willShowMediaControl, .didShowMediaControl, .willHideMediaControl, .didHideMediaControl]
+        let eventsToListen = [Event.willShowMediaControl, .didShowMediaControl, .willHideMediaControl, .didHideMediaControl]
         
         eventsToListen.forEach { event in
             core?.on(event.rawValue) { [weak self] _ in self?.trigger(event.rawValue) }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -97,6 +97,15 @@ open class Player: BaseObject {
         core?.on(Event.didChangeActivePlayback.rawValue) { [weak self] _ in self?.bindPlaybackEvents() }
         core?.on(InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.requestFullscreen.rawValue, userInfo: info) }
         core?.on(InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.exitFullscreen.rawValue, userInfo: info) }
+        bindMediaControlEvents()
+    }
+    
+    private func bindMediaControlEvents() {
+        let eventsToListen: [Event] = [.willShowMediaControl, .didShowMediaControl, .willHideMediaControl, .didHideMediaControl]
+        
+        eventsToListen.forEach { event in
+            core?.on(event.rawValue) { [weak self] _ in self?.trigger(event.rawValue) }
+        }
     }
     
     open func presentFullscreenIn(_ controller: UIViewController) {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -82,6 +82,7 @@ open class Player: BaseObject {
 
         setCore(with: options)
         bindCoreEvents()
+        bindMediaControlEvents()
         bindPlaybackEvents()
 
         core?.load()
@@ -97,7 +98,6 @@ open class Player: BaseObject {
         core?.on(Event.didChangeActivePlayback.rawValue) { [weak self] _ in self?.bindPlaybackEvents() }
         core?.on(InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.requestFullscreen.rawValue, userInfo: info) }
         core?.on(InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.exitFullscreen.rawValue, userInfo: info) }
-        bindMediaControlEvents()
     }
     
     private func bindMediaControlEvents() {

--- a/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
@@ -187,6 +187,51 @@ class PlayerTests: QuickSpec {
                         expect(callbackWasCalled).to(beTrue())
                     }
                 }
+                
+                context("when listening to core events") {
+                    var callbackWasCalled = false
+                       
+                    beforeEach {
+                        player = Player(options: options)
+                        callbackWasCalled = false
+                    }
+                       
+                    it("calls a callback function to handle willShowMediaControl") {
+                        player.on(.willShowMediaControl) { _ in
+                            callbackWasCalled = true
+                        }
+                        player.core?.trigger(.willShowMediaControl)
+                        
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                    
+                    it("calls a callback function to handle didShowMediaControl") {
+                        player.on(.didShowMediaControl) { _ in
+                            callbackWasCalled = true
+                        }
+                        player.core?.trigger(.didShowMediaControl)
+                        
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                    
+                    it("calls a callback function to handle willHideMediaControl") {
+                        player.on(.willHideMediaControl) { _ in
+                            callbackWasCalled = true
+                        }
+                        player.core?.trigger(.willHideMediaControl)
+                        
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                    
+                    it("calls a callback function to handle didHideMediaControl") {
+                        player.on(.didHideMediaControl) { _ in
+                            callbackWasCalled = true
+                        }
+                        player.core?.trigger(.didHideMediaControl)
+                        
+                        expect(callbackWasCalled).to(beTrue())
+                    }
+                }
 
                 context("core dependency") {
                     it("is initialized") {


### PR DESCRIPTION
This PR fixes issue #319 
## 🏁  Goal: 
To propagate media control events on the player, so that external plugins and such can listen to the `willShowMediaControl`, `didShowMediaControl`, `willHideMediaControl` and `didHideMediaControl` events.

## ✅  How to test:
1 - Interact with the player and check if media control events are being printed on the console as they're triggered.
2 - Run tests.