### PR TITLE
Prevent quick-seek on overlay plugins

### DIFF
--- a/Sources/Clappr/Classes/Enum/Event.swift
+++ b/Sources/Clappr/Classes/Enum/Event.swift
@@ -67,4 +67,6 @@ public enum Event: String, CaseIterable {
     case hideDrawerPlugin = "Clappr:hideDrawerPlugin"
     case willHideDrawerPlugin = "Clappr:willHideDrawerPlugin"
     case didHideDrawerPlugin = "Clappr:didHideDrawerPlugin"
+    case didShowOverlayPlugin = "Clappr:didShowOverlayPlugin"
+    case didHideOverlayPlugin = "Clappr:didHideOverlayPlugin"
 }

--- a/Sources/Clappr/Classes/Plugin/Core/OverlayPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Core/OverlayPlugin.swift
@@ -6,4 +6,12 @@ open class OverlayPlugin: UICorePlugin {
     open var isModal: Bool {
         return false
     }
+
+    open func show() {
+        core?.trigger(.didShowOverlayPlugin)
+    }
+
+    open func hide() {
+        core?.trigger(.didHideOverlayPlugin)
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -21,10 +21,8 @@ public class QuickSeekPlugin: UICorePlugin {
     
     private func bindCoreEvents() {
         guard let core = core else { return }
-        listenTo(core, eventName: Event.didShowModal.rawValue) { [weak self] _ in self?.removeGesture() }
-        listenTo(core, eventName: Event.didHideModal.rawValue) { [weak self] _ in self?.addGesture() }
-        listenTo(core, eventName: Event.didShowDrawerPlugin.rawValue) { [weak self] _ in self?.removeGesture() }
-        listenTo(core, eventName: Event.didHideDrawerPlugin.rawValue) { [weak self] _ in self?.addGesture() }
+        listenTo(core, eventName: Event.didShowOverlayPlugin.rawValue) { [weak self] _ in self?.removeGesture() }
+        listenTo(core, eventName: Event.didHideOverlayPlugin.rawValue) { [weak self] _ in self?.addGesture() }
     }
     
     func removeGesture() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Base/QuickSeekPlugin.swift
@@ -23,6 +23,8 @@ public class QuickSeekPlugin: UICorePlugin {
         guard let core = core else { return }
         listenTo(core, eventName: Event.didShowModal.rawValue) { [weak self] _ in self?.removeGesture() }
         listenTo(core, eventName: Event.didHideModal.rawValue) { [weak self] _ in self?.addGesture() }
+        listenTo(core, eventName: Event.didShowDrawerPlugin.rawValue) { [weak self] _ in self?.removeGesture() }
+        listenTo(core, eventName: Event.didHideDrawerPlugin.rawValue) { [weak self] _ in self?.addGesture() }
     }
     
     func removeGesture() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -29,6 +29,7 @@ open class DrawerPlugin: OverlayPlugin {
         didSet {
             let event: Event = isClosed ? .didHideDrawerPlugin : .didShowDrawerPlugin
             core?.trigger(event)
+            isClosed ? hide() : show()
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -27,9 +27,13 @@ open class DrawerPlugin: OverlayPlugin {
             core?.trigger(event)
         }
         didSet {
-            let event: Event = isClosed ? .didHideDrawerPlugin : .didShowDrawerPlugin
-            core?.trigger(event)
-            isClosed ? hide() : show()
+            if isClosed {
+                hide()
+                core?.trigger(.didHideDrawerPlugin)
+            } else {
+                show()
+                core?.trigger(.didShowDrawerPlugin)
+            }
         }
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/OverlayPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/OverlayPluginTests.swift
@@ -58,6 +58,40 @@ class OverlayPluginTests: QuickSpec {
                         expect(plugin.view.frame.size).to(equal(parentView.frame.size))
                     }
                 }
+
+                context("on show") {
+                    it("triggers didShowOverlayPlugin") {
+                        let core = CoreStub()
+                        let plugin = OverlayPluginMock(context: core)
+
+                        var didCallEvent = false
+
+                        core.on(Event.didShowOverlayPlugin.rawValue) { _ in
+                            didCallEvent.toggle()
+                        }
+
+                        plugin.show()
+
+                        expect(didCallEvent).to(beTrue())
+                    }
+                }
+
+                context("on hide") {
+                    it("triggers didHideOverlayPlugin") {
+                        let core = CoreStub()
+                        let plugin = OverlayPluginMock(context: core)
+
+                        var didCallEvent = false
+
+                        core.on(Event.didHideOverlayPlugin.rawValue) { _ in
+                            didCallEvent.toggle()
+                        }
+
+                        plugin.hide()
+
+                        expect(didCallEvent).to(beTrue())
+                    }
+                }
             }
         }
     }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
@@ -38,9 +38,9 @@ class QuickSeekCorePluginTests: QuickSpec {
             }
 
             describe("adding and removing doubleTap gesture") {
-                context("given that a didShowModal event is triggered") {
+                context("given that a didShowOverlay event is triggered") {
                     it("ends up with one gesture only") {
-                        core.trigger(.didShowModal)
+                        core.trigger(.didShowOverlayPlugin)
 
                         expect(core.view.gestureRecognizers?.count).to(equal(1))
                     }
@@ -48,25 +48,8 @@ class QuickSeekCorePluginTests: QuickSpec {
 
                 context("given that a didShowModal and a didHideModal events are triggered") {
                     it("ends up with two gestures") {
-                        core.trigger(.didShowModal)
-                        core.trigger(.didHideModal)
-
-                        expect(core.view.gestureRecognizers?.count).to(equal(2))
-                    }
-                }
-
-                context("given that a didShowDrawerPlugin event is triggered") {
-                    it("ends up with one gesture only") {
-                        core.trigger(.didShowDrawerPlugin)
-
-                        expect(core.view.gestureRecognizers?.count).to(equal(1))
-                    }
-                }
-
-                context("given that a didShowDrawerPlugin and a didHideDrawerPlugin events are triggered") {
-                    it("ends up with one gesture only") {
-                        core.trigger(.didShowDrawerPlugin)
-                        core.trigger(.didHideDrawerPlugin)
+                        core.trigger(.didShowOverlayPlugin)
+                        core.trigger(.didHideOverlayPlugin)
 
                         expect(core.view.gestureRecognizers?.count).to(equal(2))
                     }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
@@ -36,6 +36,42 @@ class QuickSeekCorePluginTests: QuickSpec {
                     expect(core.view.gestureRecognizers?.count).to(equal(2))
                 }
             }
+
+            describe("adding and removing doubleTap gesture") {
+                context("given that a didShowModal event is triggered") {
+                    it("ends up with one gesture only") {
+                        core.trigger(.didShowModal)
+
+                        expect(core.view.gestureRecognizers?.count).to(equal(1))
+                    }
+                }
+
+                context("given that a didShowModal and a didHideModal events are triggered") {
+                    it("ends up with two gestures") {
+                        core.trigger(.didShowModal)
+                        core.trigger(.didHideModal)
+
+                        expect(core.view.gestureRecognizers?.count).to(equal(2))
+                    }
+                }
+
+                context("given that a didShowDrawerPlugin event is triggered") {
+                    it("ends up with one gesture only") {
+                        core.trigger(.didShowDrawerPlugin)
+
+                        expect(core.view.gestureRecognizers?.count).to(equal(1))
+                    }
+                }
+
+                context("given that a didShowDrawerPlugin and a didHideDrawerPlugin events are triggered") {
+                    it("ends up with one gesture only") {
+                        core.trigger(.didShowDrawerPlugin)
+                        core.trigger(.didHideDrawerPlugin)
+
+                        expect(core.view.gestureRecognizers?.count).to(equal(2))
+                    }
+                }
+            }
             
             describe("when quickSeek is triggered") {
                 context("and its position is less than half of the view (left)") {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
@@ -46,7 +46,7 @@ class QuickSeekCorePluginTests: QuickSpec {
                     }
                 }
 
-                context("given that a didShowModal and a didHideModal events are triggered") {
+                context("given that a didShowOverlay and a didHideOverlay events are triggered") {
                     it("ends up with two gestures") {
                         core.trigger(.didShowOverlayPlugin)
                         core.trigger(.didHideOverlayPlugin)


### PR DESCRIPTION
## 🏁 Goal:
- To prevent quick seek to overpass the overlay plugins while presenting them

## ✅ How to test:
1. Create a dummy DrawerPlugin:

```swift
class CustomBottomDrawerPlugin: BottomDrawerPlugin {
    open class override var name: String {
        return "CustomBottomDrawerPlugin"
    }

    override var placeholder: CGFloat {
        return 32.0
    }

    override func render() {
        super.render()

        view.backgroundColor = .red
    }
}
```
and add it to the list of built in plugins `(Player.swift file)`

2. Run the sample app
3. Tap on the red area to present the drawer plugin
4. Try to double tap the screen like if you were to quick seek forward or backward
5. Nothing should happen