### PR TITLE
Add the current live date property to playback

### DIFF
--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -131,6 +131,10 @@ extension Playback {
     @objc open var currentDate: Date? {
         return nil
     }
+
+    @objc open var currentLiveDate: Date? {
+        return nil
+    }
     
     @objc open var seekableTimeRanges: [NSValue] {
         return []

--- a/Sources/Clappr/Classes/Extension/AVFoundationPlayback+DVR.swift
+++ b/Sources/Clappr/Classes/Extension/AVFoundationPlayback+DVR.swift
@@ -22,7 +22,7 @@ extension AVFoundationPlayback {
     }
 
     open override var currentLiveDate: Date? {
-        guard let currentDate = currentDate else { return nil }
+        guard let currentDate = currentDate, playbackType == .live else { return nil }
         let liveDate = currentDate.timeIntervalSince1970 + (duration - TimeInterval(position))
 
         return Date(timeIntervalSince1970: liveDate)

--- a/Sources/Clappr/Classes/Extension/AVFoundationPlayback+DVR.swift
+++ b/Sources/Clappr/Classes/Extension/AVFoundationPlayback+DVR.swift
@@ -20,6 +20,13 @@ extension AVFoundationPlayback {
     open override var currentDate: Date? {
         return player?.currentItem?.currentDate()
     }
+
+    open override var currentLiveDate: Date? {
+        guard let currentDate = currentDate else { return nil }
+        let liveDate = currentDate.timeIntervalSince1970 + (duration - TimeInterval(position))
+
+        return Date(timeIntervalSince1970: liveDate)
+    }
     
     open override var seekableTimeRanges: [NSValue] {
         guard let ranges = player?.currentItem?.seekableTimeRanges else { return [] }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -489,6 +489,22 @@ class AVFoundationPlaybackTests: QuickSpec {
                         expect(playback.currentDate).to(equal(date))
                     }
                 }
+
+                describe("#currentLiveDate") {
+                    context("when there's a currentDate") {
+                        it("returns the currentLiveDate of the video") {
+                            let playback = StubbedLiveDatePlayback(options: [:])
+                            playback.player = player
+                            let currentDate = Date()
+
+                            item.set(currentDate: currentDate)
+                            playback._position = 0
+                            playback._duration = 0
+
+                            expect(playback.currentLiveDate?.timeIntervalSince1970).to(equal(currentDate.timeIntervalSince1970))
+                        }
+                    }
+                }
             }
 
             describe("#duration") {
@@ -1676,4 +1692,12 @@ private class MockAccessLogEvent: AVPlayerItemAccessLogEvent {
     override var indicatedBitrate: Double {
         return 5
     }
+}
+
+private class StubbedLiveDatePlayback: AVFoundationPlayback {
+    var _position: Double = .zero
+    override var position: Double { _position }
+
+    var _duration: Double = .zero
+    override var duration: Double { _duration }
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -491,6 +491,16 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
 
                 describe("#currentLiveDate") {
+                    context("when a video is not live") {
+                        it("returns nil") {
+                            let playback = StubbedLiveDatePlayback(options: [:])
+                            playback.player = player
+                            playback._playbackType = .vod
+
+                            expect(playback.currentLiveDate).to(beNil())
+                        }
+                    }
+
                     context("when there's a currentDate") {
                         it("returns the currentLiveDate of the video") {
                             let playback = StubbedLiveDatePlayback(options: [:])
@@ -1714,4 +1724,7 @@ private class StubbedLiveDatePlayback: AVFoundationPlayback {
 
     var _duration: Double = .zero
     override var duration: Double { _duration }
+
+    var _playbackType: PlaybackType = .live
+    override var playbackType: PlaybackType { _playbackType }
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -504,6 +504,20 @@ class AVFoundationPlaybackTests: QuickSpec {
                             expect(playback.currentLiveDate?.timeIntervalSince1970).to(equal(currentDate.timeIntervalSince1970))
                         }
                     }
+
+                    context("when the video is not at the live position") {
+                        it("returns the currentLiveDate of the video") {
+                            let playback = StubbedLiveDatePlayback(options: [:])
+                            playback.player = player
+                            let currentDate = Date()
+
+                            item.set(currentDate: currentDate)
+                            playback._position = 30
+                            playback._duration = 1000
+
+                            expect(currentDate.timeIntervalSince1970).to(beLessThan(playback.currentLiveDate?.timeIntervalSince1970))
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
## 🏁 Goal:
As we need to know what time is the current live date, we are adding a property that is meant to expose the current live time of a given video.

## ✅ How to test:
1. Since this property is not used in the current player sample app, please run the tests and see that nothing breaks.