### PR TITLE
Feature/chromeless

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -307,6 +307,12 @@
 		E7D0BD17218A389B00F5FDF2 /* SeekbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D0BD16218A389B00F5FDF2 /* SeekbarTests.swift */; };
 		EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652211D467CCA00627C48 /* UICorePluginTests.swift */; };
 		EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652231D46829100627C48 /* UIContainerPluginTests.swift */; };
+		EFEC757A23C51E1800FA6A52 /* PlaybackRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC757923C51E1800FA6A52 /* PlaybackRenderer.swift */; };
+		EFEC757C23C51F4F00FA6A52 /* PlaybackRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC757B23C51F4F00FA6A52 /* PlaybackRenderer.swift */; };
+		EFEC757E23C51FE700FA6A52 /* PlaybackRenderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC757D23C51FE700FA6A52 /* PlaybackRenderProtocol.swift */; };
+		EFEC757F23C51FE700FA6A52 /* PlaybackRenderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC757D23C51FE700FA6A52 /* PlaybackRenderProtocol.swift */; };
+		EFEC758223C52A9A00FA6A52 /* PlaybackRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC758023C52A7D00FA6A52 /* PlaybackRendererTests.swift */; };
+		EFEC758423C52D4500FA6A52 /* PlaybackRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC758323C52D4500FA6A52 /* PlaybackRendererTests.swift */; };
 		FB0A223C2175492E00D2180F /* Loader+Plugins.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE6A3E32163EEAE0083C9CC /* Loader+Plugins.swift */; };
 		FB0A223F21754CBD00D2180F /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB0A223D21754C1700D2180F /* PlayerTests.swift */; };
 		FB3A8F1A209F8D7000CEFC3D /* FullscreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB61A3F2209F885800BDF267 /* FullscreenTests.swift */; };
@@ -605,6 +611,11 @@
 		E7D0BD16218A389B00F5FDF2 /* SeekbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekbarTests.swift; sourceTree = "<group>"; };
 		EDF652211D467CCA00627C48 /* UICorePluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICorePluginTests.swift; sourceTree = "<group>"; };
 		EDF652231D46829100627C48 /* UIContainerPluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIContainerPluginTests.swift; sourceTree = "<group>"; };
+		EFEC757923C51E1800FA6A52 /* PlaybackRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRenderer.swift; sourceTree = "<group>"; };
+		EFEC757B23C51F4F00FA6A52 /* PlaybackRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRenderer.swift; sourceTree = "<group>"; };
+		EFEC757D23C51FE700FA6A52 /* PlaybackRenderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRenderProtocol.swift; sourceTree = "<group>"; };
+		EFEC758023C52A7D00FA6A52 /* PlaybackRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRendererTests.swift; sourceTree = "<group>"; };
+		EFEC758323C52D4500FA6A52 /* PlaybackRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRendererTests.swift; sourceTree = "<group>"; };
 		FB0A223D21754C1700D2180F /* PlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerTests.swift; sourceTree = "<group>"; };
 		FB46260021AC8D2B008D9A25 /* CoreFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreFactory.swift; sourceTree = "<group>"; };
 		FB61A3F2209F885800BDF267 /* FullscreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenTests.swift; sourceTree = "<group>"; };
@@ -749,6 +760,7 @@
 				FC7785BB2005251800EC879F /* AVFoundationPlaybackNowPlayingServiceTests.swift */,
 				32E4020E1FF43262001C2096 /* Info.plist */,
 				FB0A223D21754C1700D2180F /* PlayerTests.swift */,
+				EFEC758323C52D4500FA6A52 /* PlaybackRendererTests.swift */,
 			);
 			path = Clappr_tvOS_Tests;
 			sourceTree = "<group>";
@@ -967,6 +979,7 @@
 				96D362911D41339400CCB866 /* Loader.swift */,
 				96D362931D41339400CCB866 /* MediaOption.swift */,
 				ABAFEBA52152C25B007BA497 /* AvailableMediaOptions.swift */,
+				EFEC757D23C51FE700FA6A52 /* PlaybackRenderProtocol.swift */,
 				96D362951D41339400CCB866 /* Playback.swift */,
 			);
 			path = Base;
@@ -1117,6 +1130,7 @@
 				9E26CFF02016148400AE92B7 /* FullScreen */,
 				96D362961D41339400CCB866 /* Player.swift */,
 				C9B8414822E0F454009DE097 /* OrientationObserver.swift */,
+				EFEC757923C51E1800FA6A52 /* PlaybackRenderer.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1264,6 +1278,7 @@
 				96A9CE371C97387000C21E80 /* LoaderTests.swift */,
 				329624A72051ECFF0062AE32 /* MediaOptionTests.swift */,
 				9E3AE5331FB330C000DFBBEB /* OptionsUnboxerTests.swift */,
+				EFEC758023C52A7D00FA6A52 /* PlaybackRendererTests.swift */,
 				96664E581BF0D58400095E6E /* PlaybackTests.swift */,
 				9603A06B1C05E6D100B55D8F /* PlayerTests.swift */,
 				96664E551BF0CBD100095E6E /* UIObjectTests.swift */,
@@ -1478,6 +1493,7 @@
 			isa = PBXGroup;
 			children = (
 				FC77859E2005233D00EC879F /* Player.swift */,
+				EFEC757B23C51F4F00FA6A52 /* PlaybackRenderer.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -1961,6 +1977,7 @@
 				32B2F68C1FF6E23700820147 /* MediaOption.swift in Sources */,
 				32E401C01FF42321001C2096 /* PlaybackType.swift in Sources */,
 				9EED97022088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift in Sources */,
+				EFEC757C23C51F4F00FA6A52 /* PlaybackRenderer.swift in Sources */,
 				32E401CD1FF42386001C2096 /* DragDetectorView.swift in Sources */,
 				32E401BE1FF42321001C2096 /* MediaControlState.swift in Sources */,
 				48CF67C8230E2FE6007F3128 /* PassthroughView.swift in Sources */,
@@ -1984,6 +2001,7 @@
 				32E401C51FF42343001C2096 /* MediaOptionFactory.swift in Sources */,
 				32A7A297215EA27F00296DE3 /* NoOpPlayback.swift in Sources */,
 				32E401C21FF42321001C2096 /* Event.swift in Sources */,
+				EFEC757F23C51FE700FA6A52 /* PlaybackRenderProtocol.swift in Sources */,
 				32E401CA1FF42372001C2096 /* UIPlugin.swift in Sources */,
 				4822B6B522158FA300D1C134 /* ClapprAnimationDuration.swift in Sources */,
 				32E401CE1FF42386001C2096 /* GradientView.swift in Sources */,
@@ -2057,6 +2075,7 @@
 				C93466952305BC440062E8DE /* EventHandlerTests.swift in Sources */,
 				C94D8CEE221B1E5400C7855D /* ContainerPluginTests.swift in Sources */,
 				FB0A223C2175492E00D2180F /* Loader+Plugins.swift in Sources */,
+				EFEC758423C52D4500FA6A52 /* PlaybackRendererTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2111,6 +2130,7 @@
 				48F1E971232296F600EAD6A1 /* DrawerPluginTests.swift in Sources */,
 				C94D8CED221B1DDD00C7855D /* ContainerPluginTests.swift in Sources */,
 				96664E571BF0CBD400095E6E /* UIObjectTests.swift in Sources */,
+				EFEC758223C52A9A00FA6A52 /* PlaybackRendererTests.swift in Sources */,
 				48B39E8A23510FFF00CE9D72 /* TimeIntervalExtensionTests.swift in Sources */,
 				E7BEEB5C21751EE600B8F7FA /* TimeIndicatorTests.swift in Sources */,
 				C9EDF84F2162CF1600789E2F /* UINavigationControllerMock.swift in Sources */,
@@ -2159,6 +2179,7 @@
 				C957E82A2332C45B001F0612 /* PanGesture+Ext.swift in Sources */,
 				96D362E61D41339400CCB866 /* EventProtocol.swift in Sources */,
 				CD57FCF122949BB300AB24CF /* SimpleContainerPlugin.swift in Sources */,
+				EFEC757E23C51FE700FA6A52 /* PlaybackRenderProtocol.swift in Sources */,
 				48B9F9AD230D82C200CD07D5 /* OverlayPlugin.swift in Sources */,
 				C9F6D7B9218265140055A599 /* Seekbar.swift in Sources */,
 				C9177B2E21664D1C001D0292 /* UIImage+Ext.swift in Sources */,
@@ -2205,6 +2226,7 @@
 				48563229220B47B10096CDAE /* Core+Ext.swift in Sources */,
 				9EED97012088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift in Sources */,
 				96D362C41D41339400CCB866 /* BaseObject.swift in Sources */,
+				EFEC757A23C51E1800FA6A52 /* PlaybackRenderer.swift in Sources */,
 				488849B022845D97004B4AD1 /* AVAsset+Ext.swift in Sources */,
 				57AB0E882253CAB70096BCA4 /* PassthroughView.swift in Sources */,
 				96D362CB1D41339400CCB866 /* MediaOption.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		E7D0BD17218A389B00F5FDF2 /* SeekbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7D0BD16218A389B00F5FDF2 /* SeekbarTests.swift */; };
 		EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652211D467CCA00627C48 /* UICorePluginTests.swift */; };
 		EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF652231D46829100627C48 /* UIContainerPluginTests.swift */; };
+		EF5A5D3923D0A9B6001CCDBC /* Set+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF5A5D3823D0A9B6001CCDBC /* Set+ext.swift */; };
 		EFEC757A23C51E1800FA6A52 /* PlaybackRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC757923C51E1800FA6A52 /* PlaybackRenderer.swift */; };
 		EFEC757C23C51F4F00FA6A52 /* PlaybackRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC757B23C51F4F00FA6A52 /* PlaybackRenderer.swift */; };
 		EFEC757E23C51FE700FA6A52 /* PlaybackRenderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFEC757D23C51FE700FA6A52 /* PlaybackRenderProtocol.swift */; };
@@ -611,6 +612,7 @@
 		E7D0BD16218A389B00F5FDF2 /* SeekbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekbarTests.swift; sourceTree = "<group>"; };
 		EDF652211D467CCA00627C48 /* UICorePluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICorePluginTests.swift; sourceTree = "<group>"; };
 		EDF652231D46829100627C48 /* UIContainerPluginTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIContainerPluginTests.swift; sourceTree = "<group>"; };
+		EF5A5D3823D0A9B6001CCDBC /* Set+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+ext.swift"; sourceTree = "<group>"; };
 		EFEC757923C51E1800FA6A52 /* PlaybackRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRenderer.swift; sourceTree = "<group>"; };
 		EFEC757B23C51F4F00FA6A52 /* PlaybackRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRenderer.swift; sourceTree = "<group>"; };
 		EFEC757D23C51FE700FA6A52 /* PlaybackRenderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackRenderProtocol.swift; sourceTree = "<group>"; };
@@ -1462,6 +1464,14 @@
 			path = Seekbar;
 			sourceTree = "<group>";
 		};
+		EF5A5D3723D0A95A001CCDBC /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				EF5A5D3823D0A9B6001CCDBC /* Set+ext.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		FB4625FF21AC8D11008D9A25 /* Factories */ = {
 			isa = PBXGroup;
 			children = (
@@ -1483,6 +1493,7 @@
 		FC7785942005233D00EC879F /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				EF5A5D3723D0A95A001CCDBC /* Extension */,
 				FC7785952005233D00EC879F /* Base */,
 				FC7785A02005233D00EC879F /* Plugin */,
 			);
@@ -1988,6 +1999,7 @@
 				5733D1C021BAA6EE002107D2 /* Dictionary+Ext.swift in Sources */,
 				32E401C11FF42321001C2096 /* PluginType.swift in Sources */,
 				32E401C91FF42359001C2096 /* UICorePlugin.swift in Sources */,
+				EF5A5D3923D0A9B6001CCDBC /* Set+ext.swift in Sources */,
 				32E401CB1FF42379001C2096 /* Plugin.swift in Sources */,
 				32B3D23D2007FA7D00D81C0A /* ClapprDateFormatter.swift in Sources */,
 				48A29C12221DF8CD0004AD3B /* CorePlugin.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -54,6 +54,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
 
     @objc open var isFullscreen: Bool = false
+    private var isChromeless: Bool { options.bool(kChromeless) }
 
     public required init(options: Options = [:]) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
@@ -62,8 +63,11 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         super.init()
 
         view.backgroundColor = .black
-
-        addTapGestures()
+        
+        if !isChromeless {
+            addTapGestures()
+        }
+        
         bindEventListeners()
         
         Loader.shared.corePlugins.forEach { addPlugin($0.init(context: self)) }

--- a/Sources/Clappr/Classes/Base/Options.swift
+++ b/Sources/Clappr/Classes/Base/Options.swift
@@ -13,6 +13,7 @@ public let kDefaultAudioSource = "defaultAudioSource"
 public let kMinDvrSize = "minDvrSize"
 public let kMediaControl = "mediaControl"
 public let kMediaControlAlwaysVisible = "mediaControlAlwaysVisible"
+public let kChromeless = "chromeless"
 
 // List of MediaControl Elements
 public let kMediaControlElements = "mediaControlElements"

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -23,6 +23,9 @@ open class Playback: UIObject, NamedType {
     open var selectedAudioSource: MediaOption?
     fileprivate(set) open var subtitles: [MediaOption]?
     fileprivate(set) open var audioSources: [MediaOption]?
+    
+    var isChromeless: Bool { options.bool(kChromeless) }
+    var playbackRenderer: PlaybackRendererProtocol = PlaybackRenderer()
 
     @objc internal(set) open var options: Options {
         didSet {
@@ -70,19 +73,15 @@ open class Playback: UIObject, NamedType {
     }
 
     @objc public required init(context _: UIObject) {
-        fatalError("Use init(url: NSURL) instead")
+        fatalError("Use init(options: Options) instead")
     }
 
     @objc open class func canPlay(_: Options) -> Bool {
         return false
     }
-
+    
     open override func render() {
-        #if os(tvOS)
-        DispatchQueue.main.asyncAfter(deadline: .now()) { [weak self] in
-            self?.play()
-        }
-        #endif
+        playbackRenderer.render(playback: self)
     }
 
     @objc open var canPlay: Bool {

--- a/Sources/Clappr/Classes/Base/PlaybackRenderProtocol.swift
+++ b/Sources/Clappr/Classes/Base/PlaybackRenderProtocol.swift
@@ -1,0 +1,3 @@
+protocol PlaybackRendererProtocol {
+    func render(playback: Playback)
+}

--- a/Sources/Clappr_iOS/Classes/Base/PlaybackRenderer.swift
+++ b/Sources/Clappr_iOS/Classes/Base/PlaybackRenderer.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+class PlaybackRenderer: PlaybackRendererProtocol {
+    func render(playback: Playback) {
+        if playback.isChromeless {
+            DispatchQueue.main.asyncAfter(deadline: .now()) {
+                playback.play()
+            }
+        }
+    }
+}

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -1,6 +1,7 @@
 open class PosterPlugin: UIContainerPlugin {
     var poster = UIImageView(frame: CGRect.zero)
     fileprivate var playButton = UIButton(frame: CGRect.zero)
+    private var isChromeless: Bool { container?.options.bool(kChromeless) ?? false }
 
     open override class var name: String {
         return "poster"
@@ -14,6 +15,11 @@ open class PosterPlugin: UIContainerPlugin {
 
     open override func render() {
         guard let container = container else { return }
+        
+        if isChromeless {
+            view.isHidden = true
+        }
+        
         if let urlString = container.options[kPosterUrl] as? String {
             setPosterImage(with: urlString)
         } else {
@@ -63,6 +69,7 @@ open class PosterPlugin: UIContainerPlugin {
     }
 
     override open func bindEvents() {
+        guard !isChromeless else { return }
         bindContainerEvents()
         bindPlaybackEvents()
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -24,6 +24,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     private var alwaysVisible = false
     private var currentlyShowing = false
     private var currentlyHiding = false
+    private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
+
 
     required public init(context: UIObject) {
         super.init(context: context)
@@ -133,7 +135,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     func show(animated: Bool = false, completion: (() -> Void)? = nil) {
-        if currentlyShowing {
+        if currentlyShowing || isChromeless {
             completion?()
             return
         }

--- a/Sources/Clappr_tvOS/Classes/Base/PlaybackRenderer.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/PlaybackRenderer.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class PlaybackRenderer: PlaybackRendererProtocol {
+    func render(playback: Playback) {
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+            playback.play()
+        }
+    }
+}

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -313,9 +313,3 @@ extension Player {
         super.pressesBegan(presses, with: event)
     }
 }
-
-extension Set where Element == UIPress {
-    func containsAny(pressTypes: [UIPress.PressType]) -> Bool {
-        return self.contains { pressTypes.contains($0.type) }
-    }
-}

--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -7,10 +7,15 @@ open class Player: AVPlayerViewController {
     private(set) var core: Core?
     static var hasAlreadyRegisteredPlaybacks = false
     private let baseObject = BaseObject()
+    private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
 
     override open func viewDidLoad() {
         super.viewDidLoad()
         core?.parentView = view
+
+        if isChromeless {
+            showsPlaybackControls = false
+        }
 
         if isMediaControlEnabled {
             core?.parentView = contentOverlayView
@@ -30,7 +35,7 @@ open class Player: AVPlayerViewController {
     }
 
     @objc private func willEnterForeground() {
-        if let playback = activePlayback as? AVFoundationPlayback, !isMediaControlEnabled {
+        if let playback = activePlayback as? AVFoundationPlayback, !isMediaControlEnabled || isChromeless {
             Logger.logDebug("forced play after return from background", scope: "Player")
             playback.play()
         }

--- a/Sources/Clappr_tvOS/Classes/Extension/Set+ext.swift
+++ b/Sources/Clappr_tvOS/Classes/Extension/Set+ext.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension Set where Element == UIPress {
+    func containsAny(pressTypes: [UIPress.PressType]) -> Bool {
+        return self.contains { pressTypes.contains($0.type) }
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Base/PlaybackRendererTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlaybackRendererTests.swift
@@ -1,0 +1,37 @@
+import Quick
+import Nimble
+@testable import Clappr
+
+class PlaybackRendererTests: QuickSpec {
+
+    override func spec() {
+        describe("PlaybackRenderer") {
+            it("should play video when in chromeless mode") {
+                let playback = StubPlayback(options: [kChromeless: true])
+                let playbackRenderer = PlaybackRenderer()
+                
+                playbackRenderer.render(playback: playback)
+                
+                expect(playback.didCallPlay).toEventually(beTrue())
+            }
+            
+            it("should not play video when not in chromeless mode") {
+                let playback = StubPlayback(options: [:])
+                let playbackRenderer = PlaybackRenderer()
+                
+                playbackRenderer.render(playback: playback)
+                
+                expect(playback.didCallPlay).toEventually(beFalse())
+            }
+        }
+    }
+    
+    class StubPlayback: Playback {
+        var didCallPlay = false
+        
+        override func play() {
+            didCallPlay = true
+        }
+    }
+}
+

--- a/Tests/Clappr_Tests/Classes/Base/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlaybackTests.swift
@@ -6,11 +6,11 @@ class PlaybackTests: QuickSpec {
 
     override func spec() {
         describe("Playback") {
-            var playback: StubPlayback!
+            var playback: Playback!
             let options = [kSourceUrl: "http://globo.com/video.mp4"]
 
             beforeEach {
-                playback = StubPlayback(options: options as Options)
+                playback = Playback(options: options as Options)
             }
 
             describe("#name") {
@@ -94,50 +94,50 @@ class PlaybackTests: QuickSpec {
             }
 
             it("has a canPlay flag set to false") {
-                let playback = StubPlayback(options: [:])
+                let playback = Playback(options: [:])
                 expect(playback.canPlay).to(beFalse())
             }
 
             it("has a canPause flag set to false") {
-                let playback = StubPlayback(options: [:])
+                let playback = Playback(options: [:])
                 expect(playback.canPause).to(beFalse())
             }
 
             it("has a canSeek flag set to false") {
-                let playback = StubPlayback(options: [:])
+                let playback = Playback(options: [:])
                 expect(playback.canSeek).to(beFalse())
+            }
+            
+            it("delegate render to PlaybackRenderer") {
+                let playback = Playback(options: [:])
+                let playbackRenderer = MockPlaybackRenderer()
+                playback.playbackRenderer = playbackRenderer
+                
+                playback.render()
+                
+                expect(playbackRenderer.didCallRender).to(beTrue())
             }
 
             context("StartAt") {
                 it("set start at property from options") {
-                    let playback = StubPlayback(options: [kStartAt: 10.0])
+                    let playback = Playback(options: [kStartAt: 10.0])
                     expect(playback.startAt) == 10.0
                 }
 
                 it("has startAt with 0 if no time is set on options") {
-                    let playback = StubPlayback(options: [:])
+                    let playback = Playback(options: [:])
                     expect(playback.startAt) == 0.0
-                }
-
-                context("when video is live") {
-                    it("doesn't seek video when rendering if startAt is set") {
-                        let playback = StubPlayback(options: [kStartAt: 15.0])
-                        playback.type = .live
-                        playback.render()
-                        playback.play()
-                        expect(playback.seekWasCalled).to(beFalse())
-                    }
                 }
             }
 
             context("Playback source") {
                 it("has a source property with the url sent via options") {
-                    let playback = StubPlayback(options: [kSourceUrl: "someUrl"])
+                    let playback = Playback(options: [kSourceUrl: "someUrl"])
                     expect(playback.source) == "someUrl"
                 }
 
                 it("has a source property with nil if no source is set") {
-                    let playback = StubPlayback(options: [:])
+                    let playback = Playback(options: [:])
                     expect(playback.source).to(beNil())
                 }
             }
@@ -156,29 +156,12 @@ class PlaybackTests: QuickSpec {
             }
         }
     }
+}
 
-    class StubPlayback: Playback {
-        var playWasCalled = false
-        var seekWasCalled = false
-        var seekWasCalledWithValue: TimeInterval = -1
-        var type: PlaybackType = .unknown
-
-        override class var name: String {
-            return "stupPlayback"
-        }
-
-        override func play() {
-            trigger(.ready)
-            playWasCalled = true
-        }
-
-        override func seek(_ timeInterval: TimeInterval) {
-            seekWasCalledWithValue = timeInterval
-            seekWasCalled = true
-        }
-
-        override var playbackType: PlaybackType {
-            return type
-        }
+class MockPlaybackRenderer: PlaybackRendererProtocol {
+    var didCallRender = false
+    
+    func render(playback: Playback) {
+        didCallRender = true
     }
 }

--- a/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
@@ -386,12 +386,56 @@ class PlayerTests: QuickSpec {
                     expect(player.activeContainer).to(beNil())
                 }
             }
+            
+            context("when in Chromeless mode") {
+                let options: Options = [kSourceUrl: "http://sitedoesnotexist.com.br/",
+                                        kChromeless: true]
+                Loader.shared.resetPlugins()
+                Player.register(playbacks: [StubPlayback.self])
+                let player = Player(options: options)
+                let playback = player.activePlayback as? StubPlayback
+                
+                it("auto play when come from background") {
+                    playback?.didCallPlay = false
+                    
+                    NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+                    
+                    expect(playback?.didCallPlay).to(beTrue())
+                }
+            }
+            
+            context("when not in Chromeless mode") {
+                let options: Options = [kSourceUrl: "http://sitedoesnotexist.com.br/"]
+                Loader.shared.resetPlugins()
+                Player.register(playbacks: [StubPlayback.self])
+                let player = Player(options: options)
+                let playback = player.activePlayback as? StubPlayback
+                
+                it("does not auto play when come from background") {
+                    playback?.didCallPlay = false
+                    
+                    NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+                    
+                    expect(playback?.didCallPlay).to(beFalse())
+                }
+            }
         }
     }
 
     class StubPlayback: Playback {
+        var didCallPlay = false
+        var didCallStop = false
+        
         override class var name: String {
             return "StubPlayback"
+        }
+        
+        override func play() {
+            didCallPlay = true
+        }
+        
+        override func stop() {
+            didCallStop = true
         }
 
         override class func canPlay(_: Options) -> Bool {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -90,7 +90,14 @@ class CoreTests: QuickSpec {
 
 
                 it("add gesture recognizer") {
-                    expect(core.view.gestureRecognizers?.count) > 0
+                    expect(core.view.gestureRecognizers?.count).to(beGreaterThan(0))
+                }
+                
+                it("does not add gesture recognizer when in Chromeless mode") {
+                    let options = [kChromeless: true]
+                    let core = Core(options: options)
+                    
+                    expect(core.view.gestureRecognizers).to(beNil())
                 }
                 #endif
             }

--- a/Tests/Clappr_tvOS_Tests/PlaybackRendererTests.swift
+++ b/Tests/Clappr_tvOS_Tests/PlaybackRendererTests.swift
@@ -1,0 +1,27 @@
+import Quick
+import Nimble
+@testable import Clappr
+
+class PlaybackRendererTests: QuickSpec {
+    override func spec() {
+        describe("PlaybackRenderer") {
+            it("should play video") {
+                let playback = StubPlayback(options: [:])
+                let playbackRenderer = PlaybackRenderer()
+                
+                playbackRenderer.render(playback: playback)
+                
+                expect(playback.didCallPlay).toEventually(beTrue())
+            }
+        }
+    }
+    
+    class StubPlayback: Playback {
+        var didCallPlay = false
+        
+        override func play() {
+            didCallPlay = true
+        }
+    }
+}
+


### PR DESCRIPTION
## Goal
- Add on iOS and tvOS the full chromeless feature through the option kChromeless, the player should init with no controls and no interaction with the user.

## How to Test
### iOS:
On Example/Clapper/DashboardViewController.swift add the option `kChromeless: true` on line 24.

### tvOS:
On Example/Clapper_tvOS/ViewController.swift add the option `kChromeless: true` on line 16.

