### PR TITLE
Fix QuickSeek when media control is visible

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
@@ -32,18 +32,20 @@ public class QuickSeekMediaControlPlugin: QuickSeekPlugin {
         }
     }
     
-    private func filteredOutModalPlugins() -> [UICorePlugin]? {
+    private func filteredOutPlugins() -> [UICorePlugin]? {
         let pluginsWithoutMediaControl = core?.plugins.filter({ $0.pluginName != MediaControl.name })
+        
         return pluginsWithoutMediaControl?
             .compactMap({ $0 as? UICorePlugin })
-            .filter({ ($0 as? MediaControl.Element)?.panel != .modal })
+            .filter({ ($0 as? MediaControl.Element)?.panel != .modal
+                && !$0.isKind(of: OverlayPlugin.self) })
     }
     
     override func shouldSeek(point: CGPoint) -> Bool {
         guard let mediaControlView = mediaControl?.mediaControlView else { return false }
         
-        let pluginColidingWithGesture = filteredOutModalPlugins()?.first(where: {
             $0.view.point(inside: mediaControlView.convert(point, to: $0.view), with: nil)
+        let pluginColidingWithGesture = filteredOutPlugins()?.first(where: {
         })
         
         return pluginColidingWithGesture == nil

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
@@ -44,8 +44,8 @@ public class QuickSeekMediaControlPlugin: QuickSeekPlugin {
     override func shouldSeek(point: CGPoint) -> Bool {
         guard let mediaControlView = mediaControl?.mediaControlView else { return false }
         
-            $0.view.point(inside: mediaControlView.convert(point, to: $0.view), with: nil)
         let pluginColidingWithGesture = filteredOutPlugins()?.first(where: {
+            $0.view.alpha != 0.0 && $0.view.point(inside: mediaControlView.convert(point, to: $0.view), with: nil)
         })
         
         return pluginColidingWithGesture == nil

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
@@ -24,7 +24,7 @@ public class QuickSeekMediaControlPlugin: QuickSeekPlugin {
     
     @objc private func didTap(gestureRecognizer: UITapGestureRecognizer) {
         if gestureRecognizer.state == .recognized {
-            let point = gestureRecognizer.location(in: view)
+            let point = gestureRecognizer.location(in: mediaControl?.mediaControlView)
             if shouldSeek(point: point) {
                 mediaControl?.hide()
                 quickSeek(xPosition: point.x)

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
@@ -77,11 +77,14 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                         mediaControl.render()
                         playButton.view.layoutIfNeeded()
                         mediaControl.view.layoutIfNeeded()
+                        
                     }
                     
                     context("and it collides with that plugin") {
                         it("does not seek") {
-                            let shouldSeek = quickSeekPlugin.shouldSeek(point: CGPoint(x: 100, y: 100))
+                            let playButtonCenterInMediaControlCoordinate = playButton.view.convert(playButton.view.center, to: mediaControl.mediaControlView)
+                            
+                            let shouldSeek = quickSeekPlugin.shouldSeek(point: playButtonCenterInMediaControlCoordinate)
                             
                             expect(shouldSeek).to(beFalse())
                         }
@@ -89,7 +92,10 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                     
                     context("and it does not collide with that plugin") {
                         it("does seek") {
-                            let shouldSeek = quickSeekPlugin.shouldSeek(point: CGPoint(x: 260, y: 100))
+                            let pointOutsidePlayButton = CGPoint(x: playButton.view.frame.width + 1, y: playButton.view.frame.height + 1)
+                            let outsidePointInMediaControlCoordinate = playButton.view.convert(pointOutsidePlayButton, to: mediaControl.mediaControlView)
+                            
+                            let shouldSeek = quickSeekPlugin.shouldSeek(point: outsidePointInMediaControlCoordinate)
                             
                             expect(shouldSeek).to(beTrue())
                         }
@@ -97,9 +103,10 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                     
                     context("and that plugin is not visible") {
                         it("does seek") {
+                            let playButtonCenterInMediaControlCoordinate = playButton.view.convert(playButton.view.center, to: mediaControl.mediaControlView)
                             playButton.view.alpha = 0.0
                             
-                            let shouldSeek = quickSeekPlugin.shouldSeek(point: CGPoint(x: 100, y: 100))
+                            let shouldSeek = quickSeekPlugin.shouldSeek(point: playButtonCenterInMediaControlCoordinate)
                             
                             expect(shouldSeek).to(beTrue())
                         }
@@ -113,8 +120,9 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                         core.render()
                         overlayPlugin.render()
                         overlayPlugin.view.layoutIfNeeded()
-                        
-                        let shouldSeek = quickSeekPlugin.shouldSeek(point: CGPoint(x: 260, y: 100))
+                        let overlayPluginCenterInMediaControlCoordinate = overlayPlugin.view.convert(overlayPlugin.view.center, to: mediaControl.mediaControlView)
+
+                        let shouldSeek = quickSeekPlugin.shouldSeek(point: overlayPluginCenterInMediaControlCoordinate)
                         
                         expect(shouldSeek).to(beTrue())
                     }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
@@ -72,7 +72,7 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                     }
                 }
                 
-                context("and it colides with another UICorePlugin") {
+                context("and it collides with another UICorePlugin") {
                     it("does not seek") {
                         playButton.view.layoutIfNeeded()
                         mediaControl.view.layoutIfNeeded()
@@ -96,7 +96,7 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                 }
                 
                 context("and there are plugins that are not visible") {
-                    fit("does seek") {
+                    it("does seek") {
                         mediaControl.view.layoutIfNeeded()
                         playButton.view.layoutIfNeeded()
                         playButton.view.alpha = 0.0

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
@@ -113,7 +113,7 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                     }
                 }
                 
-                context("and there are overlay plugins") {
+                context("and there are not visible overlay plugins") {
                     it("ignores them and seeks") {
                         overlayPlugin = OverlayPluginStub(context: core)
                         core.addPlugin(overlayPlugin)


### PR DESCRIPTION
Goal
-
To make `QuickSeek` work when the media control is visible and there are `Overlay` plugins.

How To Test
-
1. Play a video
1. Make the media control visible
1. Double tap on the sides
1. The quick seek should take effect