### PR TITLE
Fix default subtitle

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -279,6 +279,8 @@
 		C98C014C2166B50E009DFE0A /* FullscreenButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98C014B2166B50E009DFE0A /* FullscreenButtonTests.swift */; };
 		C990DAA52194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
 		C990DAA62194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */; };
+		C9A1CCB023E995D100621048 /* AVFoundationPlaybackMediaSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A1CCAF23E995D000621048 /* AVFoundationPlaybackMediaSelectionTests.swift */; };
+		C9A1CCB123E995D100621048 /* AVFoundationPlaybackMediaSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A1CCAF23E995D000621048 /* AVFoundationPlaybackMediaSelectionTests.swift */; };
 		C9B6D6E7216FDD5400588896 /* FullscreenButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B6D6E6216FDD5400588896 /* FullscreenButton.swift */; };
 		C9B8414922E0F454009DE097 /* OrientationObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B8414822E0F454009DE097 /* OrientationObserver.swift */; };
 		C9C8BFAE2305C9B800A8FA55 /* SimpleCorePluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C8BFAD2305C9B800A8FA55 /* SimpleCorePluginTests.swift */; };
@@ -587,6 +589,7 @@
 		C957E8292332C45B001F0612 /* PanGesture+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PanGesture+Ext.swift"; sourceTree = "<group>"; };
 		C98C014B2166B50E009DFE0A /* FullscreenButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullscreenButtonTests.swift; sourceTree = "<group>"; };
 		C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackStateMachineEventsTests.swift; sourceTree = "<group>"; };
+		C9A1CCAF23E995D000621048 /* AVFoundationPlaybackMediaSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackMediaSelectionTests.swift; sourceTree = "<group>"; };
 		C9B6D6E6216FDD5400588896 /* FullscreenButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FullscreenButton.swift; sourceTree = "<group>"; };
 		C9B8414822E0F454009DE097 /* OrientationObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationObserver.swift; sourceTree = "<group>"; };
 		C9C8BFAD2305C9B800A8FA55 /* SimpleCorePluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCorePluginTests.swift; sourceTree = "<group>"; };
@@ -1266,6 +1269,7 @@
 			children = (
 				9684B6C81D186E2D00D012C2 /* AVFoundationPlaybackTests.swift */,
 				C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */,
+				C9A1CCAF23E995D000621048 /* AVFoundationPlaybackMediaSelectionTests.swift */,
 			);
 			path = Playback;
 			sourceTree = "<group>";
@@ -2075,6 +2079,7 @@
 				C923387D221DD43F002202F8 /* BaseObjectTests.swift in Sources */,
 				C93466962305BC510062E8DE /* LoaderTests.swift in Sources */,
 				3251114821359C48001FEEBA /* CoreTests.swift in Sources */,
+				C9A1CCB123E995D100621048 /* AVFoundationPlaybackMediaSelectionTests.swift in Sources */,
 				C990DAA62194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift in Sources */,
 				48A29C11221DF3C00004AD3B /* CorePluginStub.swift in Sources */,
 				571B7B2D21750173005C0942 /* AVPlayerStub.swift in Sources */,
@@ -2119,6 +2124,7 @@
 				C9EDF84D2162CEF500789E2F /* UIViewControllerMock.swift in Sources */,
 				EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */,
 				7B51DF0C230B58A800C2B045 /* MediaControlElementTests.swift in Sources */,
+				C9A1CCB023E995D100621048 /* AVFoundationPlaybackMediaSelectionTests.swift in Sources */,
 				5733D1BE21BAA6E4002107D2 /* Dictionary+ExtTests.swift in Sources */,
 				96912C3E1C21A1AF003A4AFD /* PosterPluginTests.swift in Sources */,
 				FBE6A3E42163EEAE0083C9CC /* Loader+Plugins.swift in Sources */,

--- a/Example/Clappr_tvOS/ViewController.swift
+++ b/Example/Clappr_tvOS/ViewController.swift
@@ -10,10 +10,11 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let options = [
+        let options: Options = [
             kSourceUrl: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8",
             kMediaControl: true
-            ] as [String: Any]
+        ]
+
         player = Player(options: options)
 
         listenToPlayerEvents()

--- a/Sources/Clappr/Classes/Base/MediaOption.swift
+++ b/Sources/Clappr/Classes/Base/MediaOption.swift
@@ -12,6 +12,6 @@ public struct MediaOption: Equatable {
     }
 
     public static func ==(lhs: MediaOption, rhs: MediaOption) -> Bool {
-        return lhs.name == rhs.name && lhs.type == rhs.type && lhs.language == rhs.language
+        lhs.name == rhs.name && lhs.type == rhs.type && lhs.language == rhs.language
     }
 }

--- a/Sources/Clappr/Classes/Factory/MediaOptionFactory.swift
+++ b/Sources/Clappr/Classes/Factory/MediaOptionFactory.swift
@@ -10,10 +10,10 @@ class MediaOptionFactory {
     }
 
     class func subtitle(from option: AVMediaSelectionOption?) -> MediaOption {
-        return fromAVMediaOption(option, type: .subtitle) ?? offSubtitle()
+        fromAVMediaOption(option, type: .subtitle) ?? offSubtitle()
     }
 
     class func offSubtitle() -> MediaOption {
-        return MediaOption(name: "Off", type: .subtitle, language: "off", raw: AVMediaSelectionOption())
+        MediaOption(name: "Off", type: .subtitle, language: "off", raw: AVMediaSelectionOption())
     }
 }

--- a/Sources/Clappr/Classes/Factory/MediaOptionFactory.swift
+++ b/Sources/Clappr/Classes/Factory/MediaOptionFactory.swift
@@ -10,10 +10,12 @@ class MediaOptionFactory {
     }
 
     class func subtitle(from option: AVMediaSelectionOption?) -> MediaOption {
-        fromAVMediaOption(option, type: .subtitle) ?? offSubtitle()
+        fromAVMediaOption(option, type: .subtitle) ?? .offSubtitle
     }
+}
 
-    class func offSubtitle() -> MediaOption {
-        MediaOption(name: "Off", type: .subtitle, language: "off", raw: AVMediaSelectionOption())
-    }
+extension MediaOption {
+    var avMediaSelectionOption: AVMediaSelectionOption? { raw as? AVMediaSelectionOption }
+
+    static var offSubtitle = MediaOption(name: "Off", type: .subtitle, language: "off", raw: AVMediaSelectionOption())
 }

--- a/Sources/Clappr/Classes/Factory/MediaOptionFactory.swift
+++ b/Sources/Clappr/Classes/Factory/MediaOptionFactory.swift
@@ -14,6 +14,6 @@ class MediaOptionFactory {
     }
 
     class func offSubtitle() -> MediaOption {
-        return MediaOption(name: "Off", type: .subtitle, language: "off", raw: nil)
+        return MediaOption(name: "Off", type: .subtitle, language: "off", raw: AVMediaSelectionOption())
     }
 }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -67,8 +67,13 @@ open class AVFoundationPlayback: Playback {
             return MediaOptionFactory.subtitle(from: option)
         }
         set {
-            let newOption = newValue?.raw as? AVMediaSelectionOption
-            setMediaSelectionOption(newOption, characteristic: .legible)
+            if newValue == MediaOption.offSubtitle {
+                setMediaSelectionOption(nil, characteristic: .legible)
+            } else {
+                let newOption = newValue?.avMediaSelectionOption
+                setMediaSelectionOption(newOption, characteristic: .legible)
+            }
+
             triggerMediaOptionSelectedEvent(option: newValue, event: .didSelectSubtitle)
         }
     }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -99,7 +99,7 @@ open class AVFoundationPlayback: Playback {
     open override var subtitles: [MediaOption]? {
         guard let mediaGroup = mediaSelectionGroup(.legible) else { return [] }
         let availableOptions = mediaGroup.options.compactMap({ MediaOptionFactory.fromAVMediaOption($0, type: .subtitle) })
-        return availableOptions + [MediaOptionFactory.offSubtitle()]
+        return availableOptions + [MediaOption.offSubtitle]
     }
 
     open override var audioSources: [MediaOption]? {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -84,7 +84,7 @@ open class AVFoundationPlayback: Playback {
             return MediaOptionFactory.fromAVMediaOption(option, type: .audioSource)
         }
         set {
-            if let newOption = newValue?.raw as? AVMediaSelectionOption {
+            if let newOption = newValue?.avMediaSelectionOption {
                 setMediaSelectionOption(newOption, characteristic: .audible)
             }
             triggerMediaOptionSelectedEvent(option: newValue, event: Event.didSelectAudio)
@@ -592,7 +592,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     private func defaultMediaOption(for source: [MediaOption], with language: String?) -> AVMediaSelectionOption? {
-        source.first { $0.language == language }?.raw as? AVMediaSelectionOption
+        source.first { $0.language == language }?.avMediaSelectionOption
     }
 
     func selectDefaultMediaOptionIfNeeded() {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -587,7 +587,7 @@ open class AVFoundationPlayback: Playback {
     }
 
     private func defaultMediaOption(for source: [MediaOption], with language: String?) -> AVMediaSelectionOption? {
-        return source.first(where: { $0.language == language })?.raw as? AVMediaSelectionOption
+        source.first { $0.language == language }?.raw as? AVMediaSelectionOption
     }
 
     func selectDefaultMediaOptionIfNeeded() {
@@ -595,7 +595,7 @@ open class AVFoundationPlayback: Playback {
         selectDefaultSubtitleIfNeeded()
     }
     
-    internal func selectDefaultSubtitleIfNeeded() {
+    func selectDefaultSubtitleIfNeeded() {
         guard let subtitles = subtitles else { return }
         var isFirstSelection = false
         let defaultSubtitle = defaultMediaOption(for: subtitles, with: defaultSubtitleLanguage) ?? mediaSelectionGroup(.legible)?.defaultOption
@@ -606,7 +606,7 @@ open class AVFoundationPlayback: Playback {
         trigger(.didFindSubtitle, userInfo: ["subtitles": AvailableMediaOptions(subtitles, hasDefaultSelected: isFirstSelection)])
     }
 
-    internal func selectDefaultAudioIfNeeded() {
+    func selectDefaultAudioIfNeeded() {
         guard let audios = audioSources else { return }
         var isFirstSelection = false
         let defaultAudio = defaultMediaOption(for: audios, with: defaultAudioSource)

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -26,7 +26,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     private var currentlyHiding = false
     private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
 
-
     required public init(context: UIObject) {
         super.init(context: context)
         alwaysVisible = (core?.options[kMediaControlAlwaysVisible] as? Bool) ?? false

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
@@ -8,25 +8,25 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
     override func spec() {
         describe(".AVFoundationPlaybackMediaSelection") {
             describe("subtitle selection") {
-                context("when option is off") {
-                    var stubsDescriptor: OHHTTPStubsDescriptor?
+                var stubsDescriptor: OHHTTPStubsDescriptor?
 
-                    beforeEach {
-                        OHHTTPStubs.removeAllStubs()
+                beforeEach {
+                    OHHTTPStubs.removeAllStubs()
 
-                        stubsDescriptor = stub(condition: isHost("clappr.io")   ) { result in
-                            let stubPath = OHPathForFile("sample.m3u8", type(of: self))
-                            return fixture(filePath: stubPath!, headers: ["Content-Type":"application/vnd.apple.mpegURL; charset=utf-8"])
-                        }
-
-                        stubsDescriptor?.name = "StubToHighlineVideo.mp4"
+                    stubsDescriptor = stub(condition: isHost("clappr.io")   ) { result in
+                        let stubPath = OHPathForFile("sample.m3u8", type(of: self))
+                        return fixture(filePath: stubPath!, headers: ["Content-Type":"application/vnd.apple.mpegURL; charset=utf-8"])
                     }
 
-                    afterEach {
-                        OHTTPStubsHelper.removeStub(with: stubsDescriptor)
-                    }
+                    stubsDescriptor?.name = "StubToHighlineVideo.mp4"
+                }
 
-                    it("sets characteristic to nil") {
+                afterEach {
+                    OHTTPStubsHelper.removeStub(with: stubsDescriptor)
+                }
+
+                context("when option defaultSubtitle is off") {
+                    it("sets language to off") {
                         let options = [
                             kSourceUrl: "http://clappr.io/highline.mp4",
                             kDefaultSubtitle: "off"
@@ -37,8 +37,10 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
 
                         expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("off"))
                     }
+                }
 
-                    it("sets characteristic to pt") {
+                context("when option defaultSubtitle is pt") {
+                    it("sets language to pt") {
                         let options = [
                             kSourceUrl: "http://clappr.io/highline.mp4",
                             kDefaultSubtitle: "pt"
@@ -48,6 +50,21 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
                         avfoundationPlayback.play()
 
                         expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("pt"))
+                    }
+
+                    context("and sets selectedSubtitle to off") {
+                        it("sets language to off") {
+                            let options = [
+                                kSourceUrl: "http://clappr.io/highline.mp4",
+                                kDefaultSubtitle: "pt"
+                            ]
+                            let avfoundationPlayback = AVFoundationPlayback(options: options)
+                            avfoundationPlayback.play()
+
+                            avfoundationPlayback.selectedSubtitle = MediaOptionFactory.offSubtitle()
+
+                            expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("off"))
+                        }
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
@@ -61,7 +61,7 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
                             let avfoundationPlayback = AVFoundationPlayback(options: options)
                             avfoundationPlayback.play()
 
-                            avfoundationPlayback.selectedSubtitle = MediaOptionFactory.offSubtitle()
+                            avfoundationPlayback.selectedSubtitle = MediaOption.offSubtitle
 
                             expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("off"))
                         }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
@@ -1,9 +1,52 @@
-//
-//  AVFoundationPlaybackMediaSelectionTests.swift
-//  Clappr
-//
-//  Created by Paulo Gama on 04/02/20.
-//  Copyright © 2020 CocoaPods. All rights reserved.
-//
+import Quick
+import Nimble
+import OHHTTPStubs
 
-import Foundation
+@testable import Clappr
+
+class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
+    override func spec() {
+        describe(".AVFoundationPlaybackMediaSelection") {
+            describe("subtitle selection") {
+                context("when option is off") {
+                    var stubsDescriptor: OHHTTPStubsDescriptor?
+
+                    beforeEach {
+                        OHHTTPStubs.removeAllStubs()
+                        OHHTTPStubs.onStubMissing(<#T##block: ((URLRequest) -> Void)?##((URLRequest) -> Void)?##(URLRequest) -> Void#>)
+                        stubsDescriptor = stub(condition: isHost("clappr.io")   ) { result in
+                            let stubPath = OHPathForFile("sample.m3u8", type(of: self))
+                            return fixture(filePath: stubPath!, headers: [:])
+                        }
+
+                        stubsDescriptor?.name = "StubToHighlineVideo.mp4"
+                    }
+
+                    afterEach {
+                        OHTTPStubsHelper.removeStub(with: stubsDescriptor)
+                    }
+
+                    it("sets characteristic to nil") {
+                        let options = [
+                            kSourceUrl: "http://clappr.io/highline.mp4",
+                            kDefaultSubtitle: "off"
+                        ]
+                        let avfoundationPlayback = AVFoundationPlayback(options: options)
+
+                        avfoundationPlayback.play()
+
+                        expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal(MediaOptionFactory.offSubtitle().language))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private class OHTTPStubsHelper {
+    class func removeStub(with descriptor: OHHTTPStubsDescriptor?) {
+        guard let descriptor = descriptor else { return }
+
+        print("Removing stub named -> \"\(descriptor.name ?? "NoName")\" with result: \(OHHTTPStubs.removeStub(descriptor))")
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
@@ -13,10 +13,10 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
 
                     beforeEach {
                         OHHTTPStubs.removeAllStubs()
-                        OHHTTPStubs.onStubMissing(<#T##block: ((URLRequest) -> Void)?##((URLRequest) -> Void)?##(URLRequest) -> Void#>)
+
                         stubsDescriptor = stub(condition: isHost("clappr.io")   ) { result in
                             let stubPath = OHPathForFile("sample.m3u8", type(of: self))
-                            return fixture(filePath: stubPath!, headers: [:])
+                            return fixture(filePath: stubPath!, headers: ["Content-Type":"application/vnd.apple.mpegURL; charset=utf-8"])
                         }
 
                         stubsDescriptor?.name = "StubToHighlineVideo.mp4"
@@ -35,7 +35,19 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
 
                         avfoundationPlayback.play()
 
-                        expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal(MediaOptionFactory.offSubtitle().language))
+                        expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("off"))
+                    }
+
+                    it("sets characteristic to pt") {
+                        let options = [
+                            kSourceUrl: "http://clappr.io/highline.mp4",
+                            kDefaultSubtitle: "pt"
+                        ]
+                        let avfoundationPlayback = AVFoundationPlayback(options: options)
+
+                        avfoundationPlayback.play()
+
+                        expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("pt"))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
@@ -1,0 +1,9 @@
+//
+//  AVFoundationPlaybackMediaSelectionTests.swift
+//  Clappr
+//
+//  Created by Paulo Gama on 04/02/20.
+//  Copyright © 2020 CocoaPods. All rights reserved.
+//
+
+import Foundation

--- a/Tests/Clappr_Tests/Classes/Stubs/CoreStub.swift
+++ b/Tests/Clappr_Tests/Classes/Stubs/CoreStub.swift
@@ -6,9 +6,8 @@ class CoreStub: Core {
         get {
             return _container
         }
-        
         set {
-            _container = activeContainer
+            _container = newValue
         }
     }
     


### PR DESCRIPTION
### Goal

Fix default subtitle when `options[kDefaultSubtitle] = "off"` is passed.

### How to test

You can modify the DashboardViewController.swift#19 to:
```swift
let options: Options = [
kSourceUrl: "http://sample.vodobox.com/planete_interdite/planete_interdite_alternate.m3u8",
kPosterUrl: "http://clappr.io/poster.png",
kDefaultSubtitle: "off",
kFullscreen: switchFullscreen.isOn,
kFullscreenByApp: switchFullscreenControledByApp.isOn
]
```
With this, the subtitle should not appear on video.


```swift
let options: Options = [
kSourceUrl: "http://sample.vodobox.com/planete_interdite/planete_interdite_alternate.m3u8",
kPosterUrl: "http://clappr.io/poster.png",
kDefaultSubtitle: "fre",
kFullscreen: switchFullscreen.isOn,
kFullscreenByApp: switchFullscreenControledByApp.isOn
]
```
With this, the subtitle should appear on video with french language.

