### PR TITLE
Allow the player to be muted on iOS

### DIFF
--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -163,6 +163,10 @@ open class Player: BaseObject {
     open func seek(_ timeInterval: TimeInterval) {
         core?.activePlayback?.seek(timeInterval)
     }
+    
+    open func mute(enabled: Bool) {
+        core?.activePlayback?.mute(enabled)
+    }
 
     open func setFullscreen(_ fullscreen: Bool) {
         core?.setFullscreen(fullscreen)

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -1725,6 +1725,25 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
             }
             #endif
+            
+            describe("#mute") {
+                context("when mute is enabled") {
+                    it("sets volume to zero") {
+                        playback.mute(true)
+                        
+                        expect(player.volume).to(equal(0))
+                    }
+                }
+                context("when mute is disabled") {
+                    it("sets volume to maximum") {
+                        player.volume = 0
+                        
+                        playback.mute(false)
+                        
+                        expect(player.volume).to(equal(1))
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### 🏁 Goal
Allow for the iOS Player to be muted. This was already possible on the tvOS target, this PR uses the same strategy on iOS and add some tests.

### ✅ How to test
- Run the test suite