### PR TITLE
Prevent play when application is not active

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -246,9 +246,7 @@ open class AVFoundationPlayback: Playback {
         guard let asset = asset else { return triggerSetupError() }
 
         createPlayerInstance(with: AVPlayerItem(asset: asset))
-        playerLayer = AVPlayerLayer(player: player)
-        playerLayer?.frame = view.bounds
-        setupMaxResolution(for: playerLayer!.frame.size)
+        playerLayer?.player = player
 
         asset.wait(for: .characteristics, then: selectDefaultMediaOptionIfNeeded)
         asset.wait(for: .duration, then: durationAvailable)
@@ -693,7 +691,10 @@ open class AVFoundationPlayback: Playback {
     open override func render() {
         super.render()
         
+        playerLayer = AVPlayerLayer(player: AVPlayer())
         view.layer.addSublayer(playerLayer!)
+        playerLayer?.frame = view.bounds
+        setupMaxResolution(for: playerLayer!.frame.size)
         
         if asset != nil {
             trigger(.ready)

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -155,8 +155,13 @@ open class AVFoundationPlayback: Playback {
 
         return AVURLAsset.isPlayableExtendedMIMEType(mimeType)
     }
+    
+    open var isApplicationActive: Bool {
+        UIApplication.shared.applicationState == .active
+    }
 
     open override var canPlay: Bool {
+        if !isApplicationActive { return false }
         switch state {
         case .idle, .paused:
             return true

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -19,7 +19,7 @@ open class AVFoundationPlayback: Playback {
             }
         }
     }
-    private var playerLayer: AVPlayerLayer?
+    private var playerLayer: AVPlayerLayer? = AVPlayerLayer(player: AVPlayer())
     private var playerStatus: AVPlayerItem.Status = .unknown
     private var isStopped = false
     private var timeObserver: Any?
@@ -156,12 +156,7 @@ open class AVFoundationPlayback: Playback {
         return AVURLAsset.isPlayableExtendedMIMEType(mimeType)
     }
     
-    open var isApplicationActive: Bool {
-        UIApplication.shared.applicationState == .active
-    }
-
     open override var canPlay: Bool {
-        if !isApplicationActive { return false }
         switch state {
         case .idle, .paused:
             return true
@@ -252,7 +247,6 @@ open class AVFoundationPlayback: Playback {
 
         createPlayerInstance(with: AVPlayerItem(asset: asset))
         playerLayer = AVPlayerLayer(player: player)
-        view.layer.addSublayer(playerLayer!)
         playerLayer?.frame = view.bounds
         setupMaxResolution(for: playerLayer!.frame.size)
 
@@ -345,9 +339,13 @@ open class AVFoundationPlayback: Playback {
 
         droppedFrames += numberOfDroppedVideoFrames
     }
+    
+    open var isApplicationActive: Bool {
+        UIApplication.shared.applicationState == .active
+    }
 
     private func handlePlaybackLikelyToKeepUp(_ player: AVPlayer) {
-        guard state != .paused else { return }
+        guard state != .paused, isApplicationActive else { return }
 
         if hasEnoughBufferToPlay {
             play()
@@ -694,6 +692,9 @@ open class AVFoundationPlayback: Playback {
 
     open override func render() {
         super.render()
+        
+        view.layer.addSublayer(playerLayer!)
+        
         if asset != nil {
             trigger(.ready)
         }


### PR DESCRIPTION
# Goal
Prevent the video playing while the application is in background.

# How to test
- Open the sample
- Start a new video
- Go to home screen of the phone before video start playing
- The audio should not play