### PR TITLE
Clear objects on AVFoundationPlayback.destroy()

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -135,6 +135,8 @@
 		48EC492122A1908300DC7A2D /* AVPlayerItem+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EC491F22A1908300DC7A2D /* AVPlayerItem+Ext.swift */; };
 		48F1E971232296F600EAD6A1 /* DrawerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F1E970232296F600EAD6A1 /* DrawerPluginTests.swift */; };
 		48F1E97423229FDC00EAD6A1 /* DrawerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F1E97323229FDC00EAD6A1 /* DrawerPlugin.swift */; };
+		522C8997246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */; };
+		522C8998246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */; };
 		524B66AB242A9BE70085789D /* PlayerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD29B7E23FDDE7300C82098 /* PlayerMock.swift */; };
 		524B66AC242A9BEA0085789D /* PlayerItemMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD29B8023FDDEDC00C82098 /* PlayerItemMock.swift */; };
 		524B66AD242A9BEF0085789D /* AccessLogEventMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD29B8423FDDF5300C82098 /* AccessLogEventMock.swift */; };
@@ -480,6 +482,7 @@
 		48EC491F22A1908300DC7A2D /* AVPlayerItem+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayerItem+Ext.swift"; sourceTree = "<group>"; };
 		48F1E970232296F600EAD6A1 /* DrawerPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPluginTests.swift; sourceTree = "<group>"; };
 		48F1E97323229FDC00EAD6A1 /* DrawerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPlugin.swift; sourceTree = "<group>"; };
+		522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackStopActionTests.swift; sourceTree = "<group>"; };
 		571B7B30217503BB005C0942 /* NowPlayingServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingServiceStub.swift; sourceTree = "<group>"; };
 		5733D1BB21BAA3C8002107D2 /* Dictionary+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Ext.swift"; sourceTree = "<group>"; };
 		5733D1BD21BAA6E4002107D2 /* Dictionary+ExtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+ExtTests.swift"; sourceTree = "<group>"; };
@@ -1284,6 +1287,7 @@
 				C990DAA42194B17D00EB6FFA /* AVFoundationPlaybackStateMachineEventsTests.swift */,
 				C9A1CCAF23E995D000621048 /* AVFoundationPlaybackMediaSelectionTests.swift */,
 				7BD29B8623FDE20000C82098 /* AVFoundationPlaybackQualityMetricsTests.swift */,
+				522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */,
 			);
 			path = Playback;
 			sourceTree = "<group>";
@@ -2086,6 +2090,7 @@
 				32755E2421503A830088724E /* PlaybackTests.swift in Sources */,
 				48A29BFA221C8F290004AD3B /* CoreStub.swift in Sources */,
 				486E8DFE23156A880024E6CA /* OverlayPluginTests.swift in Sources */,
+				522C8998246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */,
 				524B66AC242A9BEA0085789D /* PlayerItemMock.swift in Sources */,
 				524B66AD242A9BEF0085789D /* AccessLogEventMock.swift in Sources */,
 				48A29BF9221C8F1A0004AD3B /* AVFoundationPlaybackMock.swift in Sources */,
@@ -2147,6 +2152,7 @@
 				C9EDF84D2162CEF500789E2F /* UIViewControllerMock.swift in Sources */,
 				7BD29B8523FDDF5300C82098 /* AccessLogEventMock.swift in Sources */,
 				EDF652241D46829100627C48 /* UIContainerPluginTests.swift in Sources */,
+				522C8997246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */,
 				7B51DF0C230B58A800C2B045 /* MediaControlElementTests.swift in Sources */,
 				C9A1CCB023E995D100621048 /* AVFoundationPlaybackMediaSelectionTests.swift in Sources */,
 				5733D1BE21BAA6E4002107D2 /* Dictionary+ExtTests.swift in Sources */,

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -682,11 +682,20 @@ open class AVFoundationPlayback: Playback {
 
     private func removeObservers() {
         guard let player = player, player.observationInfo != nil else { return }
-        if let timeObserver = timeObserver {
-            player.removeTimeObserver(timeObserver)
-            self.timeObserver = nil
-        }
+
+        removeTimeObserver()
         loopObserver = nil
+        removePlayerObservers()
+    }
+
+    private func removeTimeObserver() {
+        guard let player = player, let timeObserver = timeObserver else { return }
+
+        player.removeTimeObserver(timeObserver)
+        self.timeObserver = nil
+    }
+
+    private func removePlayerObservers() {
         observers.forEach { $0.invalidate() }
         observers.removeAll()
     }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -326,9 +326,13 @@ open class AVFoundationPlayback: Playback {
 
     @objc func onFailedToPlayToEndTime(notification: NSNotification?) {
         let errorKey = "AVPlayerItemFailedToPlayToEndTimeErrorKey"
-        guard let error = notification?.userInfo?[errorKey] as? NSError else { return }
-
-        trigger(.error, userInfo: ["error": error])
+        
+        if let error = notification?.userInfo?[errorKey] as? NSError {
+            trigger(.error, userInfo: ["error": error])
+        } else {
+            let defaultError = createFailedToPlayToEndError()
+            trigger(.error, userInfo: ["error": defaultError])
+        }
     }
     
     @objc func onAccessLogEntry(notification: NSNotification?) {
@@ -336,6 +340,15 @@ open class AVFoundationPlayback: Playback {
         updateBitrate()
     }
 
+    private func createFailedToPlayToEndError() -> NSError {
+        let userInfo = [
+            "AVPlayerItemFailedToPlayToEndTimeErrorKey": "defaultError"
+        ]
+        let error = NSError(domain: "AVPlayer", code: 0, userInfo: userInfo)
+        
+        return error
+    }
+    
     private func updateBitrate() {
         guard lastBitrate != bitrate else { return }
         

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -477,7 +477,7 @@ open class AVFoundationPlayback: Playback {
         updateState(.idle)
         player?.pause()
         releaseResources()
-        clearObjects()
+        resetPlaybackProperties()
         trigger(.didStop)
     }
 
@@ -489,7 +489,7 @@ open class AVFoundationPlayback: Playback {
         player = nil
     }
 
-    private func clearObjects() {
+    private func resetPlaybackProperties() {
         droppedFrames = 0
         playerStatus = .unknown
     }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -684,6 +684,7 @@ open class AVFoundationPlayback: Playback {
         guard let player = player, player.observationInfo != nil else { return }
         if let timeObserver = timeObserver {
             player.removeTimeObserver(timeObserver)
+            self.timeObserver = nil
         }
         loopObserver = nil
         observers.forEach { $0.invalidate() }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -473,6 +473,7 @@ open class AVFoundationPlayback: Playback {
         updateState(.idle)
         player?.pause()
         releaseResources()
+        clearObjects()
         trigger(.didStop)
     }
 
@@ -482,7 +483,11 @@ open class AVFoundationPlayback: Playback {
         playerLayer = nil
         player?.replaceCurrentItem(with: nil)
         player = nil
+    }
+
+    private func clearObjects() {
         droppedFrames = 0
+        playerStatus = .unknown
     }
 
     @objc var isReadyToPlay: Bool {

--- a/Tests/Clappr_Tests/Classes/Mocks/PlayerMock.swift
+++ b/Tests/Clappr_Tests/Classes/Mocks/PlayerMock.swift
@@ -5,7 +5,7 @@ class PlayerMock: AVPlayer {
     private var isFinished: Bool
     private var playerItemMock: PlayerItemMock
     
-    init(accessLogEvent: AccessLogEventMock, isFinished: Bool = false) {
+    init(accessLogEvent: AccessLogEventMock = AccessLogEventMock(), isFinished: Bool = false) {
         self.accessLogEvent = accessLogEvent
         self.isFinished = isFinished
         self.playerItemMock = PlayerItemMock(accessLogEvent: accessLogEvent, isFinished: isFinished)

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStopActionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStopActionTests.swift
@@ -1,0 +1,65 @@
+import Quick
+import Nimble
+
+@testable import Clappr
+
+class AVFoundationPlaybackStopActionTests: QuickSpec {
+    override func spec() {
+        describe(".AVFoundationPlaybackStopActionTests") {
+            describe("when stop is called") {
+                it("updates state to idle") {
+                    let avfoundationPlayback = AVFoundationPlayback(options: [:])
+                    avfoundationPlayback.player = PlayerMock()
+                    avfoundationPlayback.addObservers()
+                    avfoundationPlayback.state = .playing
+                    
+                    avfoundationPlayback.stop()
+                    
+                    expect(avfoundationPlayback.state).to(equal(.idle))
+                }
+
+                it("changes player instance to nil") {
+                    let avfoundationPlayback = AVFoundationPlayback(options: [:])
+                    avfoundationPlayback.player = PlayerMock()
+                    avfoundationPlayback.addObservers()
+                    
+                    avfoundationPlayback.stop()
+                    
+                    expect(avfoundationPlayback.player).to(beNil())
+                }
+
+                context("#events") {
+                    it("triggers willStop event") {
+                        var didCallWillStop = false
+                        let baseObject = BaseObject()
+                        let avfoundationPlayback = AVFoundationPlayback(options: [:])
+                        avfoundationPlayback.player = PlayerMock()
+                        avfoundationPlayback.addObservers()
+                        baseObject.listenTo(avfoundationPlayback, event: .willStop) { _ in
+                            didCallWillStop = true
+                        }
+                        
+                        avfoundationPlayback.stop()
+                        
+                        expect(didCallWillStop).to(beTrue())
+                    }
+
+                    it("triggers didStop event") {
+                        var didCallDidStop = false
+                        let baseObject = BaseObject()
+                        let avfoundationPlayback = AVFoundationPlayback(options: [:])
+                        avfoundationPlayback.player = PlayerMock()
+                        avfoundationPlayback.addObservers()
+                        baseObject.listenTo(avfoundationPlayback, event: .didStop) { _ in
+                            didCallDidStop = true
+                        }
+
+                        avfoundationPlayback.stop()
+
+                        expect(didCallDidStop).to(beTrue())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -925,6 +925,24 @@ class AVFoundationPlaybackTests: QuickSpec {
 
                     expect(didErrorCalled).to(beTrue())
                 }
+                
+                context("user info on notification is nil") {
+                    it("triggers default error") {
+                        let errorKey = "AVPlayerItemFailedToPlayToEndTimeErrorKey"
+                        let playback = AVFoundationPlayback(options: [:])
+                        let notification = NSNotification(name: NSNotification.Name(""), object: playback.player?.currentItem, userInfo: nil)
+
+                        var error: NSError?
+                        playback.on(Event.error.rawValue) { userInfo in
+                            error = userInfo?["error"] as? NSError
+                        }
+
+                        playback.onFailedToPlayToEndTime(notification: notification)
+
+                        let errorDescription = error?.userInfo[errorKey] as? String
+                        expect(errorDescription).to(equal("defaultError"))
+                    }
+                }
             }
 
             context("when sets a kvo on player") {


### PR DESCRIPTION
# Goal

- Reset properties on `AVFoundationPlayback.destroy()`
- Introduce `AVFoundationPlaybackStopActionTests`
- Create default error on `AVFoundationPlayback.onFailedToPlayToEndTime`
- Minor code styles refactor