### PR TITLE
Add didStop listener on PlayButton

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/PlayButton.swift
@@ -33,6 +33,7 @@ open class PlayButton: MediaControl.Element {
             listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in self?.onPause() }
             listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.onPlay() }
             listenTo(playback, eventName: Event.stalling.rawValue) { [weak self] _ in self?.hide() }
+            listenTo(playback, eventName: Event.didStop.rawValue) { [weak self] _ in self?.onStop() }
         }
     }
 
@@ -56,6 +57,11 @@ open class PlayButton: MediaControl.Element {
         changeIcon()
     }
 
+    private func onStop() {
+        show()
+        changeIcon()
+    }
+    
     public func hide() {
         view.isHidden = true
     }
@@ -71,7 +77,7 @@ open class PlayButton: MediaControl.Element {
 
         if playback.state == .playing {
             activePlayback?.pause()
-        } else if playback.state == .paused {
+        } else if playback.state == .paused || playback.state == .idle {
             activePlayback?.play()
         }
     }
@@ -81,7 +87,7 @@ open class PlayButton: MediaControl.Element {
             return
         }
 
-        if playback.state == .paused {
+        if playback.state == .paused || playback.state == .idle {
             button.setImage(playIcon, for: .normal)
         } else if playback.state == .playing {
             button.setImage(pauseIcon, for: .normal)

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/PlayButtonTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/PlayButtonTests.swift
@@ -82,6 +82,24 @@ class PlayButtonTests: QuickSpec {
                         expect(playButton.view.isHidden).toEventually(beFalse())
                     }
                 }
+                
+                context("and a video is idle") {
+                    beforeEach {
+                        coreStub.playbackMock?.set(state: .idle)
+                    }
+
+                    it("calls the playback play") {
+                        playButton.button.sendActions(for: .touchUpInside)
+
+                        expect(coreStub.playbackMock?.didCallPlay).to(beTrue())
+                    }
+
+                    it("shows play button") {
+                        playButton.button.sendActions(for: .touchUpInside)
+
+                        expect(playButton.view.isHidden).toEventually(beFalse())
+                    }
+                }
             }
 
             context("when click on button during playback") {
@@ -192,6 +210,35 @@ class PlayButtonTests: QuickSpec {
                     coreStub.activePlayback?.trigger(.playing)
 
                     expect(playButton.view.isHidden).to(beFalse())
+                }
+            }
+            
+            describe("#events") {
+                context("didStop") {
+                    it("shows button view") {
+                        let core = CoreStub()
+                        let playButton = PlayButton(context: core)
+                        playButton.render()
+                        playButton.hide()
+                        
+                        core.activePlayback?.trigger(.didStop)
+                        
+                        expect(playButton.view.isHidden).to(beFalse())
+                    }
+                    
+                    it("changes button icon") {
+                        let core = CoreStub()
+                        let playIcon = UIImage.fromName("play", for: PlayButton.self)
+                        let playButton = PlayButton(context: core)
+                        playButton.render()
+                        core.playbackMock?.state = .playing
+                        core.activePlayback?.trigger(.playing)
+                        core.playbackMock?.state = .idle
+                        
+                        core.activePlayback?.trigger(.didStop)
+                        
+                        expect(playButton.button?.imageView?.image).to(equal(playIcon))
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Goal

Add `didStop` event listener to show `PlayButton` with a `play` icon.

# How to Test

- On `ViewController.swift#100`

```swift
@IBAction func recreatePlayer(_ sender: Any) {
        player.stop()
    }
```

- Run the sample and play a video
- Click on `Recreate Player` button and check if the play button will show on the player' screen.