### PR TITLE
Request Destroy Player

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -96,7 +96,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     private func bindEventListeners() {
         #if os(iOS)
         listenTo(self, eventName: InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler?.enterInFullscreen() }
-        listenTo(self, eventName: InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] _ in self?.fullscreenHandler?.exitFullscreen() }
+        listenTo(self, eventName: InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] _ in self?.onUserRequestExitFullscreen() }
         orientationObserver = OrientationObserver(core: self)
         #endif
     }
@@ -207,6 +207,20 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         #endif
     }
 
+    private var shouldDestroyPlayer: Bool {
+        !optionsUnboxer.fullscreenControledByApp && optionsUnboxer.fullscreenDisable && optionsUnboxer.fullscreen
+    }
+    
+    private func onUserRequestExitFullscreen() {
+        #if os(iOS)
+        if shouldDestroyPlayer {
+            trigger(InternalEvent.requestDestroyPlayer.rawValue)
+        } else {
+            fullscreenHandler?.exitFullscreen()
+        }
+        #endif
+    }
+    
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Core")
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -170,6 +170,10 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         return optionsUnboxer.fullscreen && !optionsUnboxer.fullscreenControledByApp
     }
 
+    private var isFullscreenButtonDisable: Bool { optionsUnboxer.fullscreenDisable }
+    private var isFullscreenControlledByPlayer: Bool { !optionsUnboxer.fullscreenControledByApp }
+    private var shouldDestroyPlayer: Bool { isFullscreenButtonDisable && isFullscreenControlledByPlayer }
+
     private func addToContainer() {
         #if os(iOS)
         if shouldEnterInFullScreen {
@@ -205,10 +209,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         #if os(iOS)
         fullscreenHandler?.set(fullscreen: fullscreen)
         #endif
-    }
-
-    private var shouldDestroyPlayer: Bool {
-        !optionsUnboxer.fullscreenControledByApp && optionsUnboxer.fullscreenDisable && optionsUnboxer.fullscreen
     }
 
     private func onUserRequestExitFullscreen() {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -170,7 +170,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         return optionsUnboxer.fullscreen && !optionsUnboxer.fullscreenControledByApp
     }
 
-    private var isFullscreenButtonDisable: Bool { optionsUnboxer.fullscreenDisable }
+    private var isFullscreenButtonDisable: Bool { optionsUnboxer.fullscreenDisabled }
     private var isFullscreenControlledByPlayer: Bool { !optionsUnboxer.fullscreenControledByApp }
     private var shouldDestroyPlayer: Bool { isFullscreenButtonDisable && isFullscreenControlledByPlayer }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -210,7 +210,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     private var shouldDestroyPlayer: Bool {
         !optionsUnboxer.fullscreenControledByApp && optionsUnboxer.fullscreenDisable && optionsUnboxer.fullscreen
     }
-    
+
     private func onUserRequestExitFullscreen() {
         #if os(iOS)
         if shouldDestroyPlayer {
@@ -220,7 +220,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         }
         #endif
     }
-    
+
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Core")
 

--- a/Sources/Clappr/Classes/Base/Options.swift
+++ b/Sources/Clappr/Classes/Base/Options.swift
@@ -33,11 +33,7 @@ public let kMetaDataArtwork = "mdArtwork"
 struct OptionsUnboxer {
     let options: Options
 
-    var fullscreenControledByApp: Bool {
-        return options[kFullscreenByApp] as? Bool ?? false
-    }
-
-    var fullscreen: Bool {
-        return options[kFullscreen] as? Bool ?? false
-    }
+    var fullscreenControledByApp: Bool { options.bool(kFullscreenByApp, orElse: false)}
+    var fullscreen: Bool { options.bool(kFullscreen, orElse: false) }
+    var fullscreenDisable: Bool { options.bool(kFullscreenDisabled, orElse: false) }
 }

--- a/Sources/Clappr/Classes/Base/Options.swift
+++ b/Sources/Clappr/Classes/Base/Options.swift
@@ -35,5 +35,5 @@ struct OptionsUnboxer {
 
     var fullscreenControledByApp: Bool { options.bool(kFullscreenByApp, orElse: false)}
     var fullscreen: Bool { options.bool(kFullscreen, orElse: false) }
-    var fullscreenDisable: Bool { options.bool(kFullscreenDisabled, orElse: false) }
+    var fullscreenDisabled: Bool { options.bool(kFullscreenDisabled, orElse: false) }
 }

--- a/Sources/Clappr/Classes/Enum/InternalEvent.swift
+++ b/Sources/Clappr/Classes/Enum/InternalEvent.swift
@@ -6,4 +6,5 @@ public enum InternalEvent: String {
     case didFinishScrubbing = "Clappr:didFinishScrubbing"
     case didQuickSeek = "Clappr:didQuickSeek"
     case didDragDrawer = "Clappr:didDragDrawer"
+    case requestDestroyPlayer = "Clappr:requestDestroyPlayer"
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -261,8 +261,8 @@ open class Player: BaseObject {
         Logger.logDebug("destroying core", scope: "Player")
         self.core?.destroy()
         self.core = nil
-        stopListening()
         trigger(.didDestroy)
+        stopListening()
         Logger.logDebug("destroyed", scope: "Player")
     }
     

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -96,10 +96,15 @@ open class Player: BaseObject {
     }
 
     private func bindCoreEvents() {
-        core?.on(Event.willChangeActivePlayback.rawValue) { [weak self] _ in self?.unbindPlaybackEvents() }
-        core?.on(Event.didChangeActivePlayback.rawValue) { [weak self] _ in self?.bindPlaybackEvents() }
-        core?.on(InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.requestFullscreen.rawValue, userInfo: info) }
-        core?.on(InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] (info: EventUserInfo) in self?.trigger(Event.exitFullscreen.rawValue, userInfo: info) }
+        guard let core = core else { return }
+        
+        listenTo(core, event: .willChangeActivePlayback) { [weak self] _ in self?.unbindPlaybackEvents() }
+        listenTo(core, event: .didChangeActivePlayback) { [weak self] _ in self?.bindPlaybackEvents() }
+
+        listenTo(core, eventName: InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] userInfo in self?.trigger(.requestFullscreen, userInfo: userInfo)
+        }
+        listenTo(core, eventName: InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] userInfo in self?.trigger(.exitFullscreen, userInfo: userInfo)
+        }
     }
     
     private func bindMediaControlEvents() {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -97,13 +97,16 @@ open class Player: BaseObject {
 
     private func bindCoreEvents() {
         guard let core = core else { return }
-        
+
         listenTo(core, event: .willChangeActivePlayback) { [weak self] _ in self?.unbindPlaybackEvents() }
         listenTo(core, event: .didChangeActivePlayback) { [weak self] _ in self?.bindPlaybackEvents() }
 
         listenTo(core, eventName: InternalEvent.userRequestEnterInFullscreen.rawValue) { [weak self] userInfo in self?.trigger(.requestFullscreen, userInfo: userInfo)
         }
         listenTo(core, eventName: InternalEvent.userRequestExitFullscreen.rawValue) { [weak self] userInfo in self?.trigger(.exitFullscreen, userInfo: userInfo)
+        }
+        listenTo(core, eventName: InternalEvent.requestDestroyPlayer.rawValue) { [weak self] _ in
+            self?.destroy()
         }
     }
     
@@ -259,6 +262,7 @@ open class Player: BaseObject {
         self.core?.destroy()
         self.core = nil
         stopListening()
+        trigger(.didDestroy)
         Logger.logDebug("destroyed", scope: "Player")
     }
     

--- a/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
@@ -231,6 +231,18 @@ class PlayerTests: QuickSpec {
                         
                         expect(callbackWasCalled).to(beTrue())
                     }
+                    
+                    it("triggers a didDestroy event when requestDestroyPlayer was listened") {
+                        let baseObject = BaseObject()
+
+                        baseObject.listenTo(player, event: .didDestroy) { _ in
+                            callbackWasCalled = true
+                        }
+
+                        player.core?.trigger(InternalEvent.requestDestroyPlayer.rawValue)
+
+                        expect(callbackWasCalled).to(beTrue())
+                    }
                 }
 
                 context("core dependency") {

--- a/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
@@ -233,9 +233,7 @@ class PlayerTests: QuickSpec {
                     }
                     
                     it("triggers a didDestroy event when requestDestroyPlayer was listened") {
-                        let baseObject = BaseObject()
-
-                        baseObject.listenTo(player, event: .didDestroy) { _ in
+                        player.on(.didDestroy) { _ in
                             callbackWasCalled = true
                         }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -358,6 +358,69 @@ class CoreTests: QuickSpec {
                             expect(core.parentView?.subviews.filter { $0 == core.view }.count).to(equal(1))
                         }
                     }
+
+                    describe("#shouldDestroy") {
+                        describe("Event.userRequestExitFullscreen is triggered") {
+                            context("isFullscreenByPlayer") {
+                                context("when isFullscreen and isFullscreenByPlayer and isFullscreenDisable") {
+                                    it("triggers shouldDestroyPlayer event") {
+                                        let options: Options = [
+                                            kFullscreen: true,
+                                            kFullscreenByApp: false,
+                                            kFullscreenDisabled: true
+                                        ]
+                                        let core = Core(options: options)
+                                        var didTriggerEvent = false
+
+                                        core.on(InternalEvent.requestDestroyPlayer.rawValue) { _ in
+                                            didTriggerEvent = true
+                                        }
+                                        core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
+
+                                        expect(didTriggerEvent).to(beTrue())
+                                    }
+                                }
+
+                                context("when isFullscreen and isFullscreenEnabled") {
+                                    it("doesn't trigger shouldDestroyPlayer event") {
+                                        let options: Options = [
+                                            kFullscreen: true,
+                                            kFullscreenByApp: false,
+                                            kFullscreenDisabled: false
+                                        ]
+                                        let core = Core(options: options)
+                                        var didTriggerEvent = false
+
+                                        core.on(InternalEvent.requestDestroyPlayer.rawValue) { _ in
+                                            didTriggerEvent = true
+                                        }
+                                        core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
+
+                                        expect(didTriggerEvent).to(beFalse())
+                                    }
+                                }
+
+                                context("when is not in fullscreen and isFullscreenDisable") {
+                                    it("doesn't trigger shouldDestroyPlayer event") {
+                                        let options: Options = [
+                                            kFullscreen: false,
+                                            kFullscreenByApp: false,
+                                            kFullscreenDisabled: true
+                                        ]
+                                        let core = Core(options: options)
+                                        var didTriggerEvent = false
+
+                                        core.on(InternalEvent.requestDestroyPlayer.rawValue) { _ in
+                                            didTriggerEvent = true
+                                        }
+                                        core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
+
+                                        expect(didTriggerEvent).to(beFalse())
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
 
                 describe("Forward events") {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -362,10 +362,9 @@ class CoreTests: QuickSpec {
                     describe("#shouldDestroy") {
                         describe("Event.userRequestExitFullscreen is triggered") {
                             context("isFullscreenByPlayer") {
-                                context("when isFullscreen and isFullscreenByPlayer and isFullscreenDisable") {
+                                context("when isFullscreenByPlayer and isFullscreenDisable") {
                                     it("triggers shouldDestroyPlayer event") {
                                         let options: Options = [
-                                            kFullscreen: true,
                                             kFullscreenByApp: false,
                                             kFullscreenDisabled: true
                                         ]
@@ -381,31 +380,11 @@ class CoreTests: QuickSpec {
                                     }
                                 }
 
-                                context("when isFullscreen and isFullscreenEnabled") {
+                                context("when isFullscreenEnabled") {
                                     it("doesn't trigger shouldDestroyPlayer event") {
                                         let options: Options = [
-                                            kFullscreen: true,
                                             kFullscreenByApp: false,
                                             kFullscreenDisabled: false
-                                        ]
-                                        let core = Core(options: options)
-                                        var didTriggerEvent = false
-
-                                        core.on(InternalEvent.requestDestroyPlayer.rawValue) { _ in
-                                            didTriggerEvent = true
-                                        }
-                                        core.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
-
-                                        expect(didTriggerEvent).to(beFalse())
-                                    }
-                                }
-
-                                context("when is not in fullscreen and isFullscreenDisable") {
-                                    it("doesn't trigger shouldDestroyPlayer event") {
-                                        let options: Options = [
-                                            kFullscreen: false,
-                                            kFullscreenByApp: false,
-                                            kFullscreenDisabled: true
                                         ]
                                         let core = Core(options: options)
                                         var didTriggerEvent = false


### PR DESCRIPTION
# Goal

Introduce request destroy player behavior when user request exit full screen on Core

# How to Test

on `Example/Clappr`
`Player.swift#272`

```swift
open func exitFullscreen() {
    core?.trigger(InternalEvent.userRequestExitFullscreen.rawValue)
}
```

`ViewController.swift#21`
```swift
player.on(Event.playing) { [weak self] _ in
    self?.exitFullscreen()
    print("on Play")
}
```

`ViewController.swift#60`
```swift
player.on(Event.didDestroy) { _ in
    print("on didDestroy")
}
```

`ViewController.swift#65`
```swift
private func exitFullscreen() {
    DispatchQueue.main.asyncAfter(deadline: .now()+5) { [weak self] in
        self?.player.exitFullscreen()
    }
}
```

5 seconds after the first `playing` event, the player should destroy and the console should have the message `on didDestroy`