### PR TITLE
Refactor media control

### DIFF
--- a/Sources/Clappr/Classes/Base/BaseObject.swift
+++ b/Sources/Clappr/Classes/Base/BaseObject.swift
@@ -140,4 +140,8 @@ public extension BaseObject {
     func listenTo<T: EventProtocol>(_ contextObject: T, event: Event, callback: @escaping EventCallback) {
         listenTo(contextObject, eventName: event.rawValue, callback: callback)
     }
+    
+    func listenToOnce<T: EventProtocol>(_ contextObject: T, event: Event, callback: @escaping EventCallback) {
+        listenToOnce(contextObject, eventName: event.rawValue, callback: callback)
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -110,7 +110,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         }
 
         listenTo(context, eventName: InternalEvent.didFinishScrubbing.rawValue) { [weak self] _ in
-            guard self?.activePlayback?.state == .playing else { return }
+            guard self?.activePlayback?.state != .paused else { return }
             self?.disappearAfterSomeTime()
         }
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -251,21 +251,20 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     private func sortElementsIfNeeded(_ elements: [MediaControl.Element]) -> [MediaControl.Element] {
-        if let elementsOrder = core?.options[kMediaControlElementsOrder] as? [String] {
-            var orderedElements = [MediaControl.Element]()
-            elementsOrder.forEach { elementName in
-                if let selectedElement = elements.first(where: { $0.pluginName == elementName }) {
-                    orderedElements.append(selectedElement)
-                } else {
-                    Logger.logInfo("Element \(elementName) not found.")
-                }
-            }
-            orderedElements.append(contentsOf: elements.filter { !elementsOrder.contains($0.pluginName) })
-
-            return orderedElements
+        guard let elementsOrder = core?.options[kMediaControlElementsOrder] as? [String] else {
+            return elements
         }
-
-        return elements
+        var orderedElements = [MediaControl.Element]()
+        elementsOrder.forEach { elementName in
+            if let selectedElement = elements.first(where: { $0.pluginName == elementName }) {
+                orderedElements.append(selectedElement)
+            } else {
+                Logger.logInfo("Element \(elementName) not found.")
+            }
+        }
+        orderedElements.append(contentsOf: elements.filter { !elementsOrder.contains($0.pluginName) })
+        
+        return orderedElements
     }
 
     private func showIfAlwaysVisible() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -12,12 +12,12 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     public var mediaControlShow = ClapprAnimationDuration.mediaControlShow
     public var mediaControlHide = ClapprAnimationDuration.mediaControlHide
 
-    private var showControls = true
     private var alwaysVisible = false
     private var currentlyShowing = false
     private var currentlyHiding = false
     private var isDrawerActive = false
     private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
+    private var controlsEnabled = true
 
     var options: Options? { core?.options }
     private var alwaysVisible: Bool { core?.options.bool(kMediaControlAlwaysVisible) ?? false }
@@ -58,8 +58,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     private func bindPlaybackEvents() {
         if let playback = activePlayback {
-            listenTo(playback, eventName: Event.ready.rawValue) { [weak self] _ in
-                self?.showControls = true
+            listenTo(playback, event: .ready) { [weak self] _ in
+                self?.controlsEnabled = true
+            }
             }
 
             listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in
@@ -80,8 +81,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
                 }
             }
 
-            listenTo(playback, eventName: Event.error.rawValue) { [weak self] _ in
-                self?.showControls = false
+            listenTo(playback, event: .error) { [weak self] _ in
+                self?.controlsEnabled = false
             }
         }
     }
@@ -273,11 +274,11 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         }
     }
 
-    fileprivate func toggleVisibility() {
-        if showControls {
-            show(animated: true) { [weak self] in
-                self?.disappearAfterSomeTime(self?.longTimeToHideMediaControl)
-            }
+    private func toggleVisibility() {
+        guard controlsEnabled else { return }
+        
+        show(animated: true) {
+            self.disappearAfterSomeTime(self.longTimeToHideMediaControl)
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -101,7 +101,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
     
     private func showIfAlwaysVisible() {
-        show(animated: true) { self.disappearAfterSomeTime(self.longTimeToHideMediaControl)
+        show(animated: true) {
+            guard !self.alwaysVisible else { return }
+            self.disappearAfterSomeTime(self.longTimeToHideMediaControl)
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -40,6 +40,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     open func bindCoreEvents() {
         guard let core = core else { return }
+
         listenTo(core, event: .requestPadding) { [weak self] info in
             self?.onPaddingRequested(info: info)
         }
@@ -54,25 +55,24 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     private func bindContainerEvents() {
-        if let container = activeContainer {
-            listenTo(container,
-                     event: Event.enableMediaControl) { [weak self] _ in self?.show(animated: true) }
-            listenTo(container,
-                     event: Event.disableMediaControl) { [weak self] _ in self?.hide(animated: true) }
-        }
+        guard let container = activeContainer else { return }
+
+        listenTo(container, event: Event.enableMediaControl) { [weak self] _ in self?.show(animated: true) }
+        listenTo(container, event: Event.disableMediaControl) { [weak self] _ in self?.hide(animated: true) }
     }
 
     private func bindPlaybackEvents() {
-        if let playback = activePlayback {
-            listenTo(playback, event: .ready) { [weak self] _ in self?.controlsEnabled = true }
-            listenTo(playback, event: .error) { [weak self] _ in self?.controlsEnabled = false }
-            
-            listenToOnce(playback, event: .playing) { [weak self] _ in
-                self?.showIfAlwaysVisible()
-            }
-            listenTo(playback, event: .didPause) { [weak self] _ in self?.onPause() }
-            listenTo(playback, event: .didComplete) { [weak self] _ in self?.onComplete() }
+        guard let playback = activePlayback else { return }
+
+        listenTo(playback, event: .ready) { [weak self] _ in self?.controlsEnabled = true }
+        listenTo(playback, event: .error) { [weak self] _ in self?.controlsEnabled = false }
+
+        listenToOnce(playback, event: .playing) { [weak self] _ in
+            self?.showIfAlwaysVisible()
         }
+
+        listenTo(playback, event: .didPause) { [weak self] _ in self?.onPause() }
+        listenTo(playback, event: .didComplete) { [weak self] _ in self?.onComplete() }
     }
 
     private func listenToFullscreenEvents(context: UIObject) {
@@ -96,7 +96,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         }
 
         listenTo(context, event: .didShowDrawerPlugin) { [weak self] _ in self?.onDrawerShowed() }
-
         listenTo(context, event: .didHideDrawerPlugin) { [weak self] _ in self?.onDrawerHidden() }
     }
     
@@ -116,6 +115,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     
     private func onPaddingRequested(info: EventUserInfo) {
         guard let padding = info?["padding"] as? CGFloat else { return }
+
         mediaControlView.bottomPadding.constant = padding
     }
     
@@ -126,6 +126,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     
     private func onComplete() {
         guard !isDrawerActive else { return }
+
         show(animated: true)
         keepVisible()
         resetTimerOnPlay()
@@ -133,16 +134,19 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     
     private func onFullscreenStateChanged() {
         guard isTimerValid else { return }
+
         disappearAfterSomeTime()
     }
     
     private func onScrubbingFinished() {
         guard shouldDisappearAfterSomeTime else { return }
+
         disappearAfterSomeTime()
     }
     
     private func onDrawerDragged(info: EventUserInfo) {
         guard let alpha = info?["alpha"] as? CGFloat else { return }
+
         view.alpha = alpha
     }
     
@@ -156,6 +160,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         isDrawerActive = false
         
         guard let state = activePlayback?.state else { return }
+
         if state == .playing {
             show(animated: true) { self.disappearAfterSomeTime() }
         } else if statesToShow.contains(state) {
@@ -167,6 +172,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
 
     private func resetTimerOnPlay() {
         guard let playback = activePlayback else { return }
+
         listenToOnce(playback, event: .playing) { [weak self] _ in
             self?.disappearAfterSomeTime()
         }
@@ -247,6 +253,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         view.isHidden = true
         view.alpha = 0
         view.backgroundColor = UIColor.clear
+
         if let constrastView = mediaControlView.contrastView {
             constrastView.backgroundColor = UIColor.clapprBlack60Color()
         }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -1,18 +1,10 @@
 import Foundation
 
 open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
+    open class override var name: String { "MediaControl" }
 
     public var tapGesture: UITapGestureRecognizer?
-
     var mediaControlView: MediaControlView = .fromNib()
-
-    var options: Options? {
-        return core?.options
-    }
-
-    open class override var name: String {
-        return "MediaControl"
-    }
 
     public var hideControlsTimer: Timer?
     public var shortTimeToHideMediaControl = 0.4
@@ -27,10 +19,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     private var isDrawerActive = false
     private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
 
-    required public init(context: UIObject) {
-        super.init(context: context)
-        alwaysVisible = (core?.options[kMediaControlAlwaysVisible] as? Bool) ?? false
-    }
+    var options: Options? { core?.options }
+    private var alwaysVisible: Bool { core?.options.bool(kMediaControlAlwaysVisible) ?? false }
 
     override open func bindEvents() {
         bindCoreEvents()

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -302,6 +302,16 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        return true
+        return !seekbarWasTouched(touch)
+    }
+
+    private func seekbarWasTouched(_ touch: UITouch) -> Bool {
+        let seekbar = core?.plugins.first { $0.pluginName == Seekbar.name }
+        if let seekbar = seekbar as? MediaControl.Element,
+            seekbar.view.frame.contains(touch.location(in: seekbar.view)) {
+            return true
+        }
+
+        return false
     }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -61,6 +61,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
             listenTo(playback, event: .ready) { [weak self] _ in
                 self?.controlsEnabled = true
             }
+            
+            listenToOnce(playback, event: .playing) { [weak self] _ in
+                self?.showIfAlwaysVisible()
             }
 
             listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in
@@ -217,22 +220,29 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         hideAndStopTimer()
     }
     
-    override open func render() {
-        view.addSubview(mediaControlView)
-        mediaControlView.bindFrameToSuperviewBounds()
-        
+    private func setupGestureRecognizer() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapped))
         tapGesture.delegate = self
         view.addGestureRecognizer(tapGesture)
         self.tapGesture = tapGesture
-        
+    }
+    
+    private func setupViews() {
         view.isHidden = true
+        view.alpha = 0
         view.backgroundColor = UIColor.clear
         if let constrastView = mediaControlView.contrastView {
             constrastView.backgroundColor = UIColor.clapprBlack60Color()
         }
+    }
+    
+    override open func render() {
+        view.addSubview(mediaControlView)
+        mediaControlView.bindFrameToSuperviewBounds()
+        
+        setupGestureRecognizer()
+        setupViews()
 
-        showIfAlwaysVisible()
         view.bindFrameToSuperviewBounds()
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -66,19 +66,19 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
                 self?.showIfAlwaysVisible()
             }
 
-            listenTo(playback, eventName: Event.didComplete.rawValue) { [weak self] _ in
+            listenTo(playback, event: .didComplete) { [weak self] _ in
                 self?.onComplete()
-                self?.listenToOnce(playback, eventName: Event.playing.rawValue) { [weak self] _ in
-                    self?.show { [weak self] in
+                self?.listenToOnce(playback, event: .playing) { [weak self] _ in
+                    self?.show {
                         self?.disappearAfterSomeTime()
                     }
                 }
             }
 
-            listenTo(playback, eventName: Event.didPause.rawValue) { [weak self] _ in
+            listenTo(playback, event: .didPause) { [weak self] _ in
                 self?.keepVisible()
-                self?.listenToOnce(playback, eventName: Event.playing.rawValue) { [weak self] _ in
-                    self?.show { [weak self] in
+                self?.listenToOnce(playback, event: .playing) { [weak self] _ in
+                    self?.show {
                         self?.disappearAfterSomeTime()
                     }
                 }
@@ -91,13 +91,13 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     private func listenFullscreenEvents(context: UIObject) {
-        listenTo(context, eventName: Event.didEnterFullscreen.rawValue) { [weak self] _ in
+        listenTo(context, event: .didEnterFullscreen) { [weak self] _ in
             if self?.hideControlsTimer?.isValid ?? false {
                 self?.disappearAfterSomeTime()
             }
         }
 
-        listenTo(context, eventName: Event.didExitFullscreen.rawValue) { [weak self] _ in
+        listenTo(context, event: .didExitFullscreen) { [weak self] _ in
             if self?.hideControlsTimer?.isValid ?? false {
                 self?.disappearAfterSomeTime()
             }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -305,7 +305,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
         return !seekbarWasTouched(touch)
     }
 
-    private func seekbarWasTouched(_ touch: UITouch) -> Bool {
+    open func seekbarWasTouched(_ touch: UITouch) -> Bool {
         let seekbar = core?.plugins.first { $0.pluginName == Seekbar.name }
         if let seekbar = seekbar as? MediaControl.Element,
             seekbar.view.frame.contains(touch.location(in: seekbar.view)) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -269,9 +269,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
 
     private func showIfAlwaysVisible() {
-        if alwaysVisible {
-            show()
-        }
+        guard alwaysVisible else { return }
+        
+        show()
     }
 
     private func toggleVisibility() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControlElement.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControlElement.swift
@@ -27,4 +27,10 @@ extension MediaControl {
             return .left
         }
     }
+    
+    enum AnimationState {
+        case showing
+        case hiding
+        case none
+    }
 }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControlElement.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControlElement.swift
@@ -19,15 +19,12 @@ public enum MediaControlPosition {
 
 extension MediaControl {
     open class Element: UICorePlugin, MediaControlElementType {
-        open var panel: MediaControlPanel {
-            return .center
-        }
-
-        open var position: MediaControlPosition {
-            return .left
-        }
+        open var panel: MediaControlPanel { .center }
+        open var position: MediaControlPosition { .left }
     }
-    
+}
+
+extension MediaControl {
     enum AnimationState {
         case showing
         case hiding

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
@@ -377,7 +377,7 @@ class MediaControlTests: QuickSpec {
                 context("didDragDrawer") {
                     it("changes its alpha") {
                         showMediaControl()
-                        var info = ["alpha":CGFloat(0.5)]
+                        let info = ["alpha": CGFloat(0.5)]
                         
                         coreStub.trigger(InternalEvent.didDragDrawer.rawValue, userInfo: info)
 
@@ -616,20 +616,54 @@ class MediaControlTests: QuickSpec {
                 }
             }
 
-            class MediaControlViewMock: MediaControlView {
-                var didCallAddSubview = false
-                var didCallAddSubviewWithView: UIView?
-                var didCallAddSubviewWithPanel: MediaControlPanel?
-                var didCallAddSubviewWithPosition: MediaControlPosition?
+            describe("#gestureRecognizer") {
+                context("when the touch occurs in seekbar view") {
+                    it("should not receive touch") {
+                        let core = CoreStub()
+                        let mediaControl = MediaControl(context: core)
+                        let seekbar = Seekbar(context: core)
+                        let touch = UITouchStub()
+                        core.addPlugin(seekbar)
+                        seekbar.view.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
 
-                override func addSubview(_ view: UIView, in panel: MediaControlPanel, at position: MediaControlPosition) {
-                    didCallAddSubviewWithView = view
-                    didCallAddSubviewWithPanel = panel
-                    didCallAddSubviewWithPosition = position
-                    didCallAddSubview = true
+                        let shouldReceiveTouch = mediaControl.gestureRecognizer(UITapGestureRecognizer(), shouldReceive: touch)
+
+                        expect(shouldReceiveTouch).to(beFalse())
+                    }
+                }
+
+                context("when the touch occurs in seekbar view") {
+                    it("should receives touch") {
+                        let core = CoreStub()
+                        let mediaControl = MediaControl(context: core)
+                        let seekbar = Seekbar(context: core)
+                        let touch = UITouchStub()
+                        core.addPlugin(seekbar)
+                        seekbar.view.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
+                        touch.x = 100
+                        touch.y = 100
+
+                        let shouldReceiveTouch = mediaControl.gestureRecognizer(UITapGestureRecognizer(), shouldReceive: touch)
+
+                        expect(shouldReceiveTouch).to(beTrue())
+                    }
                 }
             }
         }
+    }
+}
+
+class MediaControlViewMock: MediaControlView {
+    var didCallAddSubview = false
+    var didCallAddSubviewWithView: UIView?
+    var didCallAddSubviewWithPanel: MediaControlPanel?
+    var didCallAddSubviewWithPosition: MediaControlPosition?
+
+    override func addSubview(_ view: UIView, in panel: MediaControlPanel, at position: MediaControlPosition) {
+        didCallAddSubviewWithView = view
+        didCallAddSubviewWithPanel = panel
+        didCallAddSubviewWithPosition = position
+        didCallAddSubview = true
     }
 }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
@@ -29,13 +29,13 @@ class MediaControlTests: QuickSpec {
 
             describe("#shortTimeToHideMediaControl") {
                 it("is 0.4 seconds") {
-                    expect(mediaControl.shortTimeToHideMediaControl).to(equal(0.4))
+                    expect(mediaControl.shortTimeToHideMediaControl).to(equal(0.3))
                 }
             }
 
             describe("#longTimeToHideMediaControl") {
                 it("is 4 seconds") {
-                    expect(mediaControl.longTimeToHideMediaControl).to(equal(4))
+                    expect(mediaControl.longTimeToHideMediaControl).to(equal(3))
                 }
             }
 
@@ -456,15 +456,17 @@ class MediaControlTests: QuickSpec {
             describe("show") {
                 it("triggers willShowMediaControl before showing the view") {
                     var eventTriggered = false
+                    var viewWasVisible = false
                     mediaControl.render()
                     
                     coreStub.on(Event.willShowMediaControl.rawValue) { _ in
                         eventTriggered = true
+                        viewWasVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.show()
                     
                     expect(eventTriggered).toEventually(beTrue())
-                    expect(mediaControl.view.isHidden).to(beTrue())
+                    expect(viewWasVisible).to(beFalse())
                 }
                 
                 it("triggers didShowMediaControl after showing the view") {
@@ -484,14 +486,17 @@ class MediaControlTests: QuickSpec {
             describe("hide") {
                 it("triggers willHideMediaControl before hiding the view") {
                     var eventTriggered = false
+                    var viewWasVisible = false
+                    mediaControl.view.isHidden = false
                     
                     coreStub.on(Event.willHideMediaControl.rawValue) { _ in
                         eventTriggered = true
+                        viewWasVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.hide()
                     
                     expect(eventTriggered).toEventually(beTrue())
-                    expect(mediaControl.view.isHidden).to(beFalse())
+                    expect(viewWasVisible).to(beTrue())
                 }
                 
                 it("triggers didHideMediaControl after showing the view") {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
@@ -28,13 +28,13 @@ class MediaControlTests: QuickSpec {
             }
 
             describe("#shortTimeToHideMediaControl") {
-                it("is 0.4 seconds") {
+                it("is 0.3 seconds") {
                     expect(mediaControl.shortTimeToHideMediaControl).to(equal(0.3))
                 }
             }
 
             describe("#longTimeToHideMediaControl") {
-                it("is 4 seconds") {
+                it("is 3 seconds") {
                     expect(mediaControl.longTimeToHideMediaControl).to(equal(3))
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/MediaControlTests.swift
@@ -22,17 +22,18 @@ class MediaControlTests: QuickSpec {
 
             describe("#animationDuration") {
                 it("is 0.3 seconds") {
+                    expect(ClapprAnimationDuration.mediaControlHide).to(equal(0.3))
                     expect(ClapprAnimationDuration.mediaControlShow).to(equal(0.3))
                 }
             }
 
-            describe("#secondsToHideControlFast") {
+            describe("#shortTimeToHideMediaControl") {
                 it("is 0.4 seconds") {
                     expect(mediaControl.shortTimeToHideMediaControl).to(equal(0.4))
                 }
             }
 
-            describe("#secondsToHideControlSlow") {
+            describe("#longTimeToHideMediaControl") {
                 it("is 4 seconds") {
                     expect(mediaControl.longTimeToHideMediaControl).to(equal(4))
                 }
@@ -46,28 +47,14 @@ class MediaControlTests: QuickSpec {
                 }
             }
 
-            describe("#tapped") {
+            describe("#hideAndStopTimer") {
                 it("hides the mediacontrol and stop timer") {
                     mediaControl.render()
 
-                    mediaControl.tapped()
+                    mediaControl.hideAndStopTimer()
 
                     expect(mediaControl.hideControlsTimer?.isValid).to(beNil())
                     expect(mediaControl.view.isHidden).to(beTrue())
-                }
-
-                context("when kMediaControlAlwaysVisible is true") {
-                    it("keeps the media control visible without timer") {
-                        let options: Options = [kMediaControlAlwaysVisible: true]
-                        let core = Core(options: options)
-                        let mediaControl = MediaControl(context: core)
-                        mediaControl.render()
-
-                        mediaControl.tapped()
-
-                        expect(mediaControl.hideControlsTimer?.isValid).to(beNil())
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                    }
                 }
             }
 
@@ -109,311 +96,414 @@ class MediaControlTests: QuickSpec {
             }
 
             describe("options") {
-                context("on request padding") {
-                    it("applies padding to Media Control") {
-                        let core = Core()
-                        let mediaControl = MediaControl(context: core)
+                context("when kMediaControlAlwaysVisible is true") {
+                    it("keeps itself visible without timer") {
+                        let options: Options = [kMediaControlAlwaysVisible: true]
+                        coreStub.options = options
+                        let mediaControl = MediaControl(context: coreStub)
                         mediaControl.render()
 
-                        core.trigger(.requestPadding, userInfo: ["padding": CGFloat(32)])
+                        coreStub.activePlayback?.trigger(.playing)
 
-                        expect(mediaControl.mediaControlView.bottomPadding?.constant).to(equal(32.0))
+                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beNil())
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
                     }
                 }
 
                 it("has the same options as the Core") {
                     let options: Options = ["foo": "bar"]
-                    let core = Core(options: options)
+                    coreStub.options = options
 
-                    let mediaControl = MediaControl(context: core)
+                    let mediaControl = MediaControl(context: coreStub)
 
                     expect(mediaControl.options).toNot(beNil())
-                    expect((mediaControl.options!["foo"] as! String)).to(equal("bar"))
+                    expect(mediaControl.options?["foo"] as? String).to(equal("bar"))
                 }
             }
 
             describe("Events") {
                 beforeEach {
-                    mediaControl.mediaControlShow = 0.1
-                    mediaControl.mediaControlHide = 0.1
+                    mediaControl.showDuration = 0.1
+                    mediaControl.hideDuration = 0.1
                     mediaControl.shortTimeToHideMediaControl = 0.1
                     mediaControl.longTimeToHideMediaControl = 0.1
                     mediaControl.render()
                 }
                 
-                context("when ready") {
-                    it("hides the media control") {
-                        mediaControlHidden()
+                context("requestPadding") {
+                    it("applies padding") {
+                        mediaControl.render()
 
-                        coreStub.activePlayback?.trigger(Event.ready)
+                        coreStub.trigger(.requestPadding, userInfo: ["padding": CGFloat(32)])
 
-                        expect(mediaControl.view.isHidden).toEventually(beTrue())
-                        expect(mediaControl.view.alpha).toEventually(equal(0))
+                        expect(mediaControl.mediaControlView.bottomPadding?.constant).toEventually(equal(32.0))
                     }
                 }
 
-                context("when playing") {
-                    it("hides the media control") {
-                        mediaControlHidden()
-
-                        coreStub.activePlayback?.trigger(Event.playing)
-
-                        expect(mediaControl.view.isHidden).toEventually(beTrue())
-                        expect(mediaControl.view.alpha).toEventually(equal(0))
-                    }
-
-                    it("starts the timer to hide itself") {
-                        mediaControlVisible()
-
-                        coreStub.activePlayback?.trigger(Event.playing)
-
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
-                    }
-                }
-
-                context("when complete") {
-                    it("shows the media control") {
-                        mediaControl.view.isHidden = true
-                        mediaControl.view.alpha = 0.0
-
-                        coreStub.activePlayback?.trigger(Event.didComplete)
-
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                        expect(mediaControl.view.alpha).toEventually(equal(1))
-                    }
-                }
-
-                context("when showMediaControl") {
-                    it("shows itself when hidden") {
-                        mediaControlHidden()
-
-                        coreStub.trigger(InternalEvent.didTappedCore.rawValue)
-
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                        expect(mediaControl.view.alpha).toEventually(equal(1))
-                    }
-
-                    it("doesn't show itself if an error occurred") {
-                        mediaControlVisible()
-                        mediaControlHidden()
-
-                        coreStub.activePlayback?.trigger(Event.error.rawValue)
-                        coreStub.trigger(InternalEvent.didTappedCore.rawValue)
-
-                        expect(mediaControl.view.isHidden).toEventually(beTrue())
-                        expect(mediaControl.view.alpha).toEventually(equal(0))
-                    }
-                }
-
-                context("when paused") {
-                    it("keeps itself on the screen and visible") {
-                        mediaControlVisible()
-
-                        coreStub.activePlayback?.trigger(Event.didPause)
-
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                        expect(mediaControl.view.alpha).toEventually(equal(1))
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
-                    }
-                }
-
-                context("when willBeginScrubbing") {
-                    it("keeps itself on the screen and visible") {
-                        mediaControlVisible()
-
-                        coreStub.trigger(InternalEvent.willBeginScrubbing.rawValue)
-
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                        expect(mediaControl.view.alpha).toEventually(equal(1))
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
-                    }
-                }
-
-                context("when didFinishScrubbing") {
-                    it("hides the media control after some time if the video is playing") {
-                        mediaControlVisible()
-
-                        coreStub.trigger(InternalEvent.didFinishScrubbing.rawValue)
-
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
-                        expect(mediaControl.view.isHidden).toEventually(beTrue())
-                        expect(mediaControl.view.alpha).toEventually(equal(0))
-                    }
-
-                    it("doesn't hide the media control after some time if the video is paused") {
-                        mediaControlVisible()
-                        coreStub.activePlayback?.trigger(Event.didPause)
-
-                        coreStub.trigger(InternalEvent.willBeginScrubbing.rawValue)
-                        coreStub.trigger(InternalEvent.didFinishScrubbing.rawValue)
-
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-
-                    }
-                }
-                context("when didEnterFullscreen") {
-                    it("hides the media control after some time if the video is playing") {
-                        mediaControlVisible()
-
-                        coreStub.trigger(Event.didEnterFullscreen.rawValue)
-
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
-                        expect(mediaControl.view.isHidden).toEventually(beTrue())
-                        expect(mediaControl.view.alpha).toEventually(equal(0))
-                    }
-
-                    it("doesn't hide the media control after some time if the video is paused") {
-                        mediaControlVisible()
-                        coreStub.activePlayback?.trigger(Event.didPause)
-
-                        coreStub.trigger(Event.didEnterFullscreen.rawValue)
-
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
-                    }
-                }
-
-                context("when didExitFullscreen") {
-                    it("hides the media control after some time if the video is playing") {
-                        mediaControlVisible()
-
-                        coreStub.trigger(Event.didExitFullscreen.rawValue)
-
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
-                        expect(mediaControl.view.isHidden).toEventually(beTrue())
-                        expect(mediaControl.view.alpha).toEventually(equal(0))
-                    }
-
-                    it("doesn't hide the media control after some time if the video is paused") {
-                        mediaControlVisible()
-                        coreStub.activePlayback?.trigger(Event.didPause)
-
-                        coreStub.trigger(Event.didEnterFullscreen.rawValue)
-
-                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
-                    }
-                }
-
-                context("when disableMediaControl") {
-                    it("hides the media control immediately") {
-                        mediaControlVisible()
-
-                        coreStub.activeContainer?.trigger(Event.disableMediaControl.rawValue)
-
-                        expect(mediaControl.view.isHidden).toEventually(beTrue())
-                        expect(mediaControl.view.alpha).toEventually(equal(0))
-                    }
-                }
-
-                context("when enableMediaControl") {
-                    it("shows the media control") {
-                        mediaControlHidden()
-
-                        coreStub.activeContainer?.trigger(Event.enableMediaControl.rawValue)
-
-                        expect(mediaControl.view.isHidden).toEventually(beFalse())
-                        expect(mediaControl.view.alpha).toEventually(equal(1))
-                    }
-                }
-
-                context("when the drawer events are triggered") {
-                    context("and the video ends") {
-                        it("dont show Media Control") {
-                            var didCallShow = false
-
-                            coreStub.trigger(.didShowDrawerPlugin)
-                            coreStub.activePlayback?.trigger(.didComplete)
-                            coreStub.trigger(.didHideDrawerPlugin)
-
-                            mediaControl.show() { didCallShow = true }
-
-                            expect(didCallShow).to(beFalse())
+                context("playing") {
+                    context("after a pause") {
+                        it("hides itself after some time and stop timer") {
+                            showMediaControl()
+                            coreStub.activePlayback?.trigger(.didPause)
+                            
+                            coreStub.activePlayback?.trigger(.playing)
+                            
+                            expect(mediaControl.view.isHidden).toEventually(beTrue())
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
                         }
                     }
-
-                    context("and the video does not end") {
-                        it("shows Media Control") {
-                            var didCallShow = false
+                    
+                    context("after a complete") {
+                        it("hides itself after some time and stop timer") {
+                            showMediaControl()
+                            coreStub.activePlayback?.trigger(.didComplete)
                             
+                            coreStub.activePlayback?.trigger(.playing)
+                            
+                            expect(mediaControl.view.isHidden).toEventually(beTrue())
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                }
+
+                context("didComplete") {
+                    it("shows itself") {
+                        hideMediaControl()
+
+                        coreStub.activePlayback?.trigger(.didComplete)
+
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
+                    }
+                }
+
+                context("didTappedCore") {
+                    it("shows itself and start the timer to hide") {
+                        hideMediaControl()
+
+                        coreStub.trigger(InternalEvent.didTappedCore.rawValue)
+
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
+                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
+                    }
+                }
+
+                context("didPause") {
+                    it("keeps itself on the screen and visible") {
+                        mediaControl.hideControlsTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true, block: { _ in return })
+                        showMediaControl()
+
+                        coreStub.activePlayback?.trigger(.didPause)
+
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
+                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                    }
+                }
+
+                context("willBeginScrubbing") {
+                    it("keeps itself on the screen and visible") {
+                        mediaControl.hideControlsTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true, block: { _ in return })
+                        showMediaControl()
+
+                        coreStub.trigger(InternalEvent.willBeginScrubbing.rawValue)
+
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
+                        expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                    }
+                }
+
+                context("didFinishScrubbing") {
+                    beforeEach {
+                        mediaControl.hideControlsTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true, block: { _ in return })
+                        showMediaControl()
+                    }
+                    
+                    context("and the playback is playing") {
+                        it("hides itself after some time") {
                             coreStub.playbackMock?.set(state: .playing)
                             
-                            coreStub.trigger(.didShowDrawerPlugin)
-                            coreStub.trigger(.didHideDrawerPlugin)
+                            coreStub.trigger(InternalEvent.didFinishScrubbing.rawValue)
+
+                            expect(mediaControl.view.isHidden).toEventually(beTrue())
+                            expect(mediaControl.view.alpha).toEventually(equal(0))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                    
+                    context("and the playback is paused") {
+                        it("keeps itself on the screen and visible") {
+                            coreStub.playbackMock?.set(state: .paused)
+                            coreStub.activePlayback?.trigger(.didPause)
+
+                            coreStub.trigger(InternalEvent.didFinishScrubbing.rawValue)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                    
+                    context("and the playback is idle") {
+                        it("keeps itself on the screen and visible") {
+                            coreStub.playbackMock?.set(state: .idle)
+                            coreStub.activePlayback?.trigger(.didComplete)
+
+                            coreStub.trigger(InternalEvent.didFinishScrubbing.rawValue)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+
+                        }
+                    }
+                }
+                context("didEnterFullscreen") {
+                    beforeEach {
+                        mediaControl.hideControlsTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true, block: { _ in return })
+                        showMediaControl()
+                    }
+                    
+                    context("and the playback is playing") {
+                        it("hides itself after some time") {
+                            coreStub.playbackMock?.set(state: .playing)
                             
-                            mediaControl.show() { didCallShow = true }
-                            
-                            expect(didCallShow).to(beTrue())
+                            coreStub.trigger(.didEnterFullscreen)
+
+                            expect(mediaControl.view.isHidden).toEventually(beTrue())
+                            expect(mediaControl.view.alpha).toEventually(equal(0))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                    
+                    context("and the playback is paused") {
+                        it("keeps itself on the screen and visible") {
+                            coreStub.playbackMock?.set(state: .paused)
+                            coreStub.activePlayback?.trigger(.didPause)
+
+                            coreStub.trigger(.didEnterFullscreen)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                    
+                    context("and the playback is idle") {
+                        it("keeps itself on the screen and visible") {
+                            coreStub.playbackMock?.set(state: .idle)
+                            coreStub.activePlayback?.trigger(.didComplete)
+
+                            coreStub.trigger(.didEnterFullscreen)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+
                         }
                     }
                 }
 
-                func mediaControlHidden() {
-                    mediaControl.hide()
+                context("didExitFullscreen") {
+                    beforeEach {
+                        mediaControl.hideControlsTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true, block: { _ in return })
+                        showMediaControl()
+                    }
+                    
+                    context("and the playback is playing") {
+                        it("hides itself after some time") {
+                            coreStub.playbackMock?.set(state: .playing)
+                            
+                            coreStub.trigger(.didExitFullscreen)
+
+                            expect(mediaControl.view.isHidden).toEventually(beTrue())
+                            expect(mediaControl.view.alpha).toEventually(equal(0))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                    
+                    context("and the playback is paused") {
+                        it("keeps itself visible") {
+                            coreStub.playbackMock?.set(state: .paused)
+                            coreStub.activePlayback?.trigger(.didPause)
+
+                            coreStub.trigger(.didExitFullscreen)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                    
+                    context("and the playback is idle") {
+                        it("keeps itself on the screen and visible") {
+                            coreStub.playbackMock?.set(state: .idle)
+                            coreStub.activePlayback?.trigger(.didComplete)
+
+                            coreStub.trigger(.didExitFullscreen)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+
+                        }
+                    }
                 }
 
-                func mediaControlVisible() {
-                    coreStub.trigger(InternalEvent.didTappedCore.rawValue)
+                context("disableMediaControl") {
+                    it("hides itself immediately") {
+                        showMediaControl()
+
+                        coreStub.activeContainer?.trigger(.disableMediaControl)
+
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
+                    }
+                }
+
+                context("enableMediaControl") {
+                    it("shows itself immediately") {
+                        hideMediaControl()
+
+                        coreStub.activeContainer?.trigger(.enableMediaControl)
+
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(1))
+                    }
+                }
+                
+                context("didDragDrawer") {
+                    it("changes its alpha") {
+                        showMediaControl()
+                        var info = ["alpha":CGFloat(0.5)]
+                        
+                        coreStub.trigger(InternalEvent.didDragDrawer.rawValue, userInfo: info)
+
+                        expect(mediaControl.view.isHidden).toEventually(beFalse())
+                        expect(mediaControl.view.alpha).toEventually(equal(0.5))
+                    }
+                }
+                
+                context("didShowDrawerPlugin") {
+                    it("hides itself") {
+                        showMediaControl()
+                        
+                        coreStub.trigger(.didShowDrawerPlugin)
+                        
+                        expect(mediaControl.view.isHidden).toEventually(beTrue())
+                        expect(mediaControl.view.alpha).toEventually(equal(0))
+                    }
+                }
+                
+                context("didHideDrawerPlugin") {
+                    beforeEach {
+                        mediaControl.hideControlsTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true, block: { _ in return })
+                        showMediaControl()
+                    }
+                    
+                    context("and the playback is playing") {
+                        it("shows itself and starts the timer to hide") {
+                            coreStub.playbackMock?.set(state: .playing)
+                            
+                            coreStub.trigger(.didHideDrawerPlugin)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beTrue())
+                        }
+                    }
+                    
+                    context("and the playback is paused") {
+                        it("shows itself and keeps visible") {
+                            coreStub.playbackMock?.set(state: .paused)
+
+                            coreStub.trigger(.didHideDrawerPlugin)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+                        }
+                    }
+                    
+                    context("and the playback is idle") {
+                        it("shows itself and keeps visible") {
+                            coreStub.playbackMock?.set(state: .idle)
+
+                            coreStub.trigger(.didHideDrawerPlugin)
+
+                            expect(mediaControl.view.isHidden).toEventually(beFalse())
+                            expect(mediaControl.view.alpha).toEventually(equal(1))
+                            expect(mediaControl.hideControlsTimer?.isValid).toEventually(beFalse())
+
+                        }
+                    }
+
+                }
+
+                func hideMediaControl() {
+                    mediaControl.view.isHidden = true
+                    mediaControl.view.alpha = 0
+                }
+
+                func showMediaControl() {
+                    mediaControl.view.isHidden = false
+                    mediaControl.view.alpha = 1
                 }
             }
             
             describe("show") {
                 it("triggers willShowMediaControl before showing the view") {
                     var eventTriggered = false
-                    var viewIsVisible: Bool?
-                    
                     mediaControl.render()
+                    
                     coreStub.on(Event.willShowMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.show()
                     
                     expect(eventTriggered).toEventually(beTrue())
-                    expect(viewIsVisible).to(beFalse())
+                    expect(mediaControl.view.isHidden).to(beTrue())
                 }
                 
                 it("triggers didShowMediaControl after showing the view") {
                     var eventTriggered = false
-                    var viewIsVisible: Bool?
                     mediaControl.view.isHidden = true
                     
                     coreStub.on(Event.didShowMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.show()
                     
                     expect(eventTriggered).toEventually(beTrue())
-                    expect(viewIsVisible).to(beTrue())
+                    expect(mediaControl.view.isHidden).to(beFalse())
                 }
             }
             
             describe("hide") {
                 it("triggers willHideMediaControl before hiding the view") {
                     var eventTriggered = false
-                    var viewIsVisible: Bool?
                     
                     coreStub.on(Event.willHideMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.hide()
                     
                     expect(eventTriggered).toEventually(beTrue())
-                    expect(viewIsVisible).to(beTrue())
+                    expect(mediaControl.view.isHidden).to(beFalse())
                 }
                 
                 it("triggers didHideMediaControl after showing the view") {
                     var eventTriggered = false
-                    var viewIsVisible: Bool?
                     
                     coreStub.on(Event.didHideMediaControl.rawValue) { _ in
                         eventTriggered = true
-                        viewIsVisible = !mediaControl.view.isHidden
                     }
                     mediaControl.hide()
                     
                     expect(eventTriggered).toEventually(beTrue())
-                    expect(viewIsVisible).to(beFalse())
+                    expect(mediaControl.view.isHidden).to(beTrue())
                 }
             }
 
@@ -428,7 +518,7 @@ class MediaControlTests: QuickSpec {
                 }
 
                 context("for any element configuration") {
-                    it("always calls the MediaControlView to position the view") {
+                    it("adds the element view as subview of MediaControlView") {
                         let mediaControl = MediaControl(context: coreStub)
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
@@ -438,16 +528,16 @@ class MediaControlTests: QuickSpec {
                         expect(mediaControlViewMock.didCallAddSubview).to(beTrue())
                     }
 
-                    it("always calls the MediaControlView passing the element's view") {
+                    it("passes the element's view") {
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
                         
                         mediaControl.render(elements)
-
+                        
                         expect(mediaControlViewMock.didCallAddSubviewWithView).to(equal(elements.first?.view))
                     }
 
-                    it("always calls the MediaControlView passing the element's panel") {
+                    it("passes the element's panel") {
                         MediaControlElementMock._panel = .center
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
@@ -457,7 +547,7 @@ class MediaControlTests: QuickSpec {
                         expect(mediaControlViewMock.didCallAddSubviewWithPanel).to(equal(MediaControlPanel.center))
                     }
 
-                    it("always calls the MediaControlView passing the element's position") {
+                    it("passes the element's position") {
                         MediaControlElementMock._position = .left
                         mediaControl.mediaControlView = mediaControlViewMock
                         mediaControl.render()
@@ -467,7 +557,7 @@ class MediaControlTests: QuickSpec {
                         expect(mediaControlViewMock.didCallAddSubviewWithPosition).to(equal(MediaControlPosition.left))
                     }
 
-                    it("always calls the method render") {
+                    it("calls the element's render method") {
                         MediaControlElementMock._panel = .top
                         mediaControl.render()
                         
@@ -476,7 +566,7 @@ class MediaControlTests: QuickSpec {
                         expect(MediaControlElementMock.didCallRender).to(beTrue())
                     }
 
-                    it("protect the main thread when element crashes in render") {
+                    it("protects the main thread when element crashes in render") {
                         MediaControlElementMock.crashOnRender = true
                         mediaControl.render()
 
@@ -490,13 +580,13 @@ class MediaControlTests: QuickSpec {
                     it("renders the elements following the kMediaControlElementsOrder with all elements specified in the option") {
                         let core = Core()
                         core.options[kMediaControlElementsOrder] = ["FullscreenButton", "TimeIndicatorElementMock", "SecondElement", "FirstElement"]
-                        let elements = [FirstElement(context: core), SecondElement(context: core), TimeIndicatorElementMock(context: core), FullscreenButton(context: core), ]
+                        let elements = [FirstElement(context: core), SecondElement(context: core), TimeIndicatorElementMock(context: core), FullscreenButton(context: core)]
                         let mediaControl = MediaControl(context: core)
                         mediaControl.render()
-
-                        mediaControl.render(elements)
-
                         let bottomRightView = mediaControl.mediaControlView.bottomRight
+                        
+                        mediaControl.render(elements)
+                        
                         expect(bottomRightView?.subviews[0].subviews.first?.accessibilityIdentifier).to(equal("FullscreenButton"))
                         expect(bottomRightView?.subviews[1].subviews.first?.accessibilityIdentifier).to(equal("timeIndicator"))
                         expect(bottomRightView?.subviews[2].subviews.first?.accessibilityIdentifier).to(equal("SecondElement"))

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/Seekbar/Views/SeekbarViewTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/Seekbar/Views/SeekbarViewTests.swift
@@ -265,60 +265,61 @@ class SeekbarViewTests: QuickSpec {
         }
     }
 
-    class DragDetectorViewStub: DragDetectorView {
-        override var currentTouch: UITouch? {
-            return uiTouchStub
-        }
+}
 
-        override var touchState: DragDetectorView.State {
-            return _touchState
-        }
-
-        var uiTouchStub = UITouchStub()
-
-        var _touchState: DragDetectorView.State = .idle
-
-        func touch(x: CGFloat, y: CGFloat) {
-            uiTouchStub.x = x
-            uiTouchStub.y = y
-        }
-
-        func touch(state: DragDetectorView.State) {
-            _touchState = state
-        }
+class DragDetectorViewStub: DragDetectorView {
+    override var currentTouch: UITouch? {
+        return uiTouchStub
     }
 
-    class UITouchStub: UITouch {
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-
-        override func location(in view: UIView?) -> CGPoint {
-            return CGPoint(x: x, y: y)
-        }
+    override var touchState: DragDetectorView.State {
+        return _touchState
     }
 
-    class SeekbarDelegateMock: NSObject, SeekbarDelegate {
-        var didCallSeek = false
-        var didCallSeekWithValue: TimeInterval = 0
-        var didCallWillBeginScrubbing = false
-        var didCallDidFinishScrubbing = false
-        var didCallIsScrubbing = false
+    var uiTouchStub = UITouchStub()
 
-        func seek(_ time: TimeInterval) {
-            didCallSeek = true
-            didCallSeekWithValue = time
-        }
+    var _touchState: DragDetectorView.State = .idle
 
-        func willBeginScrubbing() {
-            didCallWillBeginScrubbing = true
-        }
+    func touch(x: CGFloat, y: CGFloat) {
+        uiTouchStub.x = x
+        uiTouchStub.y = y
+    }
 
-        func didFinishScrubbing() {
-            didCallDidFinishScrubbing = true
-        }
+    func touch(state: DragDetectorView.State) {
+        _touchState = state
+    }
+}
 
-        func isScrubbing(scrubberFrame: CGRect, currentSecond: Int) {
-            didCallIsScrubbing = true
-        }
+class UITouchStub: UITouch {
+    var x: CGFloat = 0
+    var y: CGFloat = 0
+
+    override func location(in view: UIView?) -> CGPoint {
+        return CGPoint(x: x, y: y)
+    }
+}
+
+class SeekbarDelegateMock: NSObject, SeekbarDelegate {
+    var didCallSeek = false
+    var didCallSeekWithValue: TimeInterval = 0
+    var didCallWillBeginScrubbing = false
+    var didCallDidFinishScrubbing = false
+    var didCallIsScrubbing = false
+
+    func seek(_ time: TimeInterval) {
+        didCallSeek = true
+        didCallSeekWithValue = time
+    }
+
+    func willBeginScrubbing() {
+        didCallWillBeginScrubbing = true
+    }
+
+    func didFinishScrubbing() {
+        didCallDidFinishScrubbing = true
+    }
+
+    func isScrubbing(scrubberFrame: CGRect, currentSecond: Int) {
+        didCallIsScrubbing = true
     }
 }


### PR DESCRIPTION
Goal
---
To refactor `MediaControl` code and adjust its behaviour.

How to Test
---
1. Interact with the Media Control and check if it respects the following rules:

    - Every transition is animated, including showing/hiding drawers
    - It appears at the beggining of the video after the first play
    - Has a inactivity time of 3 seconds
    - It automatically disappears after 0.3 seconds after a user interaction when `playing`
    - It does not automatically disappears after user interaction when `paused` / `idle`

2. Run tests