### PR TITLE
Subtitle Style

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -11,6 +11,14 @@
 		23EDF918224D83FD00FB0D96 /* Clappr.podspec in Resources */ = {isa = PBXBuildFile; fileRef = D8810057D2C05E1F7A2759D7 /* Clappr.podspec */; };
 		23EDF91B224E8EB900FB0D96 /* .swift-version in Resources */ = {isa = PBXBuildFile; fileRef = 23EDF91A224E8EB800FB0D96 /* .swift-version */; };
 		23EDF91E224EAF9A00FB0D96 /* String+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF91D224EAF9A00FB0D96 /* String+Ext.swift */; };
+		262B490C24D8898F0049DAF7 /* AVPlayerItem+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490A24D8898F0049DAF7 /* AVPlayerItem+Style.swift */; };
+		262B490D24D8898F0049DAF7 /* UIColor+ARGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490B24D8898F0049DAF7 /* UIColor+ARGB.swift */; };
+		262B491424D889C60049DAF7 /* Alignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490F24D889C50049DAF7 /* Alignment.swift */; };
+		262B491524D889C60049DAF7 /* EdgeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491024D889C50049DAF7 /* EdgeStyle.swift */; };
+		262B491624D889C60049DAF7 /* TextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491124D889C50049DAF7 /* TextStyle.swift */; };
+		262B491724D889C60049DAF7 /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491224D889C50049DAF7 /* Direction.swift */; };
+		262B491824D889C60049DAF7 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491324D889C60049DAF7 /* Font.swift */; };
+		262B491A24D88BD60049DAF7 /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491924D88BD60049DAF7 /* FontTests.swift */; };
 		320A7A0F216D45A9006D2B24 /* PlayButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320A7A0E216D45A9006D2B24 /* PlayButtonTests.swift */; };
 		320A7A15216FBF89006D2B24 /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320A7A14216FBF89006D2B24 /* PlayButton.swift */; };
 		321781B21FED97D100EDD678 /* Clappr.h in Headers */ = {isa = PBXBuildFile; fileRef = 96D362881D41339400CCB866 /* Clappr.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -437,6 +445,14 @@
 		23EDF915224D819600FB0D96 /* SwiftVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftVersionTests.swift; sourceTree = "<group>"; };
 		23EDF91A224E8EB800FB0D96 /* .swift-version */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ".swift-version"; sourceTree = SOURCE_ROOT; };
 		23EDF91D224EAF9A00FB0D96 /* String+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Ext.swift"; sourceTree = "<group>"; };
+		262B490A24D8898F0049DAF7 /* AVPlayerItem+Style.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AVPlayerItem+Style.swift"; sourceTree = "<group>"; };
+		262B490B24D8898F0049DAF7 /* UIColor+ARGB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+ARGB.swift"; sourceTree = "<group>"; };
+		262B490F24D889C50049DAF7 /* Alignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Alignment.swift; sourceTree = "<group>"; };
+		262B491024D889C50049DAF7 /* EdgeStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgeStyle.swift; sourceTree = "<group>"; };
+		262B491124D889C50049DAF7 /* TextStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStyle.swift; sourceTree = "<group>"; };
+		262B491224D889C50049DAF7 /* Direction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
+		262B491324D889C60049DAF7 /* Font.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
+		262B491924D88BD60049DAF7 /* FontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontTests.swift; sourceTree = "<group>"; };
 		320A7A0E216D45A9006D2B24 /* PlayButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayButtonTests.swift; sourceTree = "<group>"; };
 		320A7A14216FBF89006D2B24 /* PlayButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayButton.swift; sourceTree = "<group>"; };
 		321781A81FED90CC00EDD678 /* Clappr.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Clappr.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -739,6 +755,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		262B490E24D8899C0049DAF7 /* Font */ = {
+			isa = PBXGroup;
+			children = (
+				262B490F24D889C50049DAF7 /* Alignment.swift */,
+				262B491224D889C50049DAF7 /* Direction.swift */,
+				262B491024D889C50049DAF7 /* EdgeStyle.swift */,
+				262B491324D889C60049DAF7 /* Font.swift */,
+				262B491124D889C50049DAF7 /* TextStyle.swift */,
+			);
+			path = Font;
+			sourceTree = "<group>";
+		};
 		321781A91FED90CC00EDD678 /* Clappr_tvOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -1006,6 +1034,7 @@
 		96D3628B1D41339400CCB866 /* Base */ = {
 			isa = PBXGroup;
 			children = (
+				262B490E24D8899C0049DAF7 /* Font */,
 				A32A51E724C61F4600A00439 /* Layers */,
 				96D3628C1D41339400CCB866 /* BaseObject.swift */,
 				96D362971D41339400CCB866 /* UIObject.swift */,
@@ -1039,6 +1068,8 @@
 		96D362A21D41339400CCB866 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				262B490A24D8898F0049DAF7 /* AVPlayerItem+Style.swift */,
+				262B490B24D8898F0049DAF7 /* UIColor+ARGB.swift */,
 				9EED97002088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift */,
 				488849AF22845D97004B4AD1 /* AVAsset+Ext.swift */,
 				96D362A31D41339400CCB866 /* UIView+Ext.swift */,
@@ -1334,6 +1365,7 @@
 				96664E551BF0CBD100095E6E /* UIObjectTests.swift */,
 				A32A51E324C60FC100A00439 /* LayersCompositorTests.swift */,
 				A32A51E524C61BDF00A00439 /* BackgroundLayerTests.swift */,
+				262B491924D88BD60049DAF7 /* FontTests.swift */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -2217,6 +2249,7 @@
 				C94D8CED221B1DDD00C7855D /* ContainerPluginTests.swift in Sources */,
 				96664E571BF0CBD400095E6E /* UIObjectTests.swift in Sources */,
 				7BD29B8723FDE20000C82098 /* AVFoundationPlaybackQualityMetricsTests.swift in Sources */,
+				262B491A24D88BD60049DAF7 /* FontTests.swift in Sources */,
 				EFEC758223C52A9A00FA6A52 /* PlaybackRendererTests.swift in Sources */,
 				48B39E8A23510FFF00CE9D72 /* TimeIntervalExtensionTests.swift in Sources */,
 				E7BEEB5C21751EE600B8F7FA /* TimeIndicatorTests.swift in Sources */,
@@ -2298,6 +2331,7 @@
 				968E5BD91D6CBFA50092F372 /* Logger.swift in Sources */,
 				5733D1BC21BAA3C8002107D2 /* Dictionary+Ext.swift in Sources */,
 				96D362EA1D41339400CCB866 /* GradientView.swift in Sources */,
+				262B491824D889C60049DAF7 /* Font.swift in Sources */,
 				96D362E51D41339400CCB866 /* UIPlugin.swift in Sources */,
 				ABAFEBA62152C25B007BA497 /* AvailableMediaOptions.swift in Sources */,
 				320A7A15216FBF89006D2B24 /* PlayButton.swift in Sources */,
@@ -2305,10 +2339,13 @@
 				96D362D61D41339400CCB866 /* PlaybackType.swift in Sources */,
 				96D362E91D41339400CCB866 /* DragDetectorView.swift in Sources */,
 				AB0A58DF21FA2F520075729E /* QuickSeekAnimation.swift in Sources */,
+				262B491624D889C60049DAF7 /* TextStyle.swift in Sources */,
 				48D81F1D21F9F41200B2D52E /* QuickSeekCorePlugin.swift in Sources */,
+				262B491424D889C60049DAF7 /* Alignment.swift in Sources */,
 				A3C8F3EF24CF489F002CA3F5 /* BackgroundLayer.swift in Sources */,
 				96D362D41D41339400CCB866 /* MediaOptionType.swift in Sources */,
 				FC6418DE2007DB9100E81B7C /* ClapprDateFormatter.swift in Sources */,
+				262B490C24D8898F0049DAF7 /* AVPlayerItem+Style.swift in Sources */,
 				9E26CFF32016149600AE92B7 /* FullScreenStateHandler.swift in Sources */,
 				C92747E7220DD4E0009465A7 /* UIImageView+Ext.swift in Sources */,
 				96D362CC1D41339400CCB866 /* Options.swift in Sources */,
@@ -2323,12 +2360,15 @@
 				4856322B220B4C9C0096CDAE /* QuickSeekMediaControlPlugin.swift in Sources */,
 				96E7D2741E786FEE0056F358 /* InternalEvent.swift in Sources */,
 				96D362CF1D41339400CCB866 /* UIObject.swift in Sources */,
+				262B490D24D8898F0049DAF7 /* UIColor+ARGB.swift in Sources */,
 				4856322E220B54B90096CDAE /* QuickSeekPlugin.swift in Sources */,
 				CD10D93D22C28D4C0096B035 /* Environment.swift in Sources */,
 				96D362C51D41339400CCB866 /* Container.swift in Sources */,
 				963B19981E4B827700A0A6BA /* Event.swift in Sources */,
 				48F1E97423229FDC00EAD6A1 /* DrawerPlugin.swift in Sources */,
+				262B491524D889C60049DAF7 /* EdgeStyle.swift in Sources */,
 				96D362DF1D41339400CCB866 /* SpinnerPlugin.swift in Sources */,
+				262B491724D889C60049DAF7 /* Direction.swift in Sources */,
 				C9F6D7B62182650B0055A599 /* SeekbarView.swift in Sources */,
 				A3C8F3ED24CF489F002CA3F5 /* LayersCompositor.swift in Sources */,
 				E7BEEB59217506C100B8F7FA /* TimeIndicator.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -11,6 +11,11 @@
 		23EDF918224D83FD00FB0D96 /* Clappr.podspec in Resources */ = {isa = PBXBuildFile; fileRef = D8810057D2C05E1F7A2759D7 /* Clappr.podspec */; };
 		23EDF91B224E8EB900FB0D96 /* .swift-version in Resources */ = {isa = PBXBuildFile; fileRef = 23EDF91A224E8EB800FB0D96 /* .swift-version */; };
 		23EDF91E224EAF9A00FB0D96 /* String+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF91D224EAF9A00FB0D96 /* String+Ext.swift */; };
+		26211C1F24DC70C6000501A4 /* EdgeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491024D889C50049DAF7 /* EdgeStyle.swift */; };
+		26211C2024DC70CE000501A4 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491324D889C60049DAF7 /* Font.swift */; };
+		26211C2124DC70D5000501A4 /* Alignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490F24D889C50049DAF7 /* Alignment.swift */; };
+		26211C2224DC70E7000501A4 /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491224D889C50049DAF7 /* Direction.swift */; };
+		26211C2324DC7102000501A4 /* UIColor+ARGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490B24D8898F0049DAF7 /* UIColor+ARGB.swift */; };
 		262B490C24D8898F0049DAF7 /* AVPlayerItem+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490A24D8898F0049DAF7 /* AVPlayerItem+Style.swift */; };
 		262B490D24D8898F0049DAF7 /* UIColor+ARGB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490B24D8898F0049DAF7 /* UIColor+ARGB.swift */; };
 		262B491424D889C60049DAF7 /* Alignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490F24D889C50049DAF7 /* Alignment.swift */; };
@@ -19,6 +24,8 @@
 		262B491724D889C60049DAF7 /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491224D889C50049DAF7 /* Direction.swift */; };
 		262B491824D889C60049DAF7 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491324D889C60049DAF7 /* Font.swift */; };
 		262B491A24D88BD60049DAF7 /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491924D88BD60049DAF7 /* FontTests.swift */; };
+		2652A2BC24DC6DA0009C52CF /* TextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491124D889C50049DAF7 /* TextStyle.swift */; };
+		2652A2BD24DC6DA4009C52CF /* AVPlayerItem+Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B490A24D8898F0049DAF7 /* AVPlayerItem+Style.swift */; };
 		320A7A0F216D45A9006D2B24 /* PlayButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320A7A0E216D45A9006D2B24 /* PlayButtonTests.swift */; };
 		320A7A15216FBF89006D2B24 /* PlayButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320A7A14216FBF89006D2B24 /* PlayButton.swift */; };
 		321781B21FED97D100EDD678 /* Clappr.h in Headers */ = {isa = PBXBuildFile; fileRef = 96D362881D41339400CCB866 /* Clappr.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -2077,14 +2084,19 @@
 				32E401C01FF42321001C2096 /* PlaybackType.swift in Sources */,
 				9EED97022088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift in Sources */,
 				EFEC757C23C51F4F00FA6A52 /* PlaybackRenderer.swift in Sources */,
+				2652A2BD24DC6DA4009C52CF /* AVPlayerItem+Style.swift in Sources */,
 				32E401CD1FF42386001C2096 /* DragDetectorView.swift in Sources */,
+				2652A2BC24DC6DA0009C52CF /* TextStyle.swift in Sources */,
 				32E401BE1FF42321001C2096 /* MediaControlState.swift in Sources */,
 				48CF67C8230E2FE6007F3128 /* PassthroughView.swift in Sources */,
 				32E401CC1FF42386001C2096 /* BorderView.swift in Sources */,
 				48B39E8823510FB700CE9D72 /* TimeInterval+Extensions.swift in Sources */,
 				32E401C81FF42351001C2096 /* UIContainerPlugin.swift in Sources */,
+				26211C2024DC70CE000501A4 /* Font.swift in Sources */,
+				26211C1F24DC70C6000501A4 /* EdgeStyle.swift in Sources */,
 				571B7B252174DBDD005C0942 /* AVFoundationPlayback.swift in Sources */,
 				5733D1C021BAA6EE002107D2 /* Dictionary+Ext.swift in Sources */,
+				26211C2124DC70D5000501A4 /* Alignment.swift in Sources */,
 				32E401C11FF42321001C2096 /* PluginType.swift in Sources */,
 				32E401C91FF42359001C2096 /* UICorePlugin.swift in Sources */,
 				EF5A5D3923D0A9B6001CCDBC /* Set+ext.swift in Sources */,
@@ -2101,6 +2113,7 @@
 				32E401C61FF42343001C2096 /* PlaybackFactory.swift in Sources */,
 				32E401C51FF42343001C2096 /* MediaOptionFactory.swift in Sources */,
 				32A7A297215EA27F00296DE3 /* NoOpPlayback.swift in Sources */,
+				26211C2324DC7102000501A4 /* UIColor+ARGB.swift in Sources */,
 				32E401C21FF42321001C2096 /* Event.swift in Sources */,
 				EFEC757F23C51FE700FA6A52 /* PlaybackRenderProtocol.swift in Sources */,
 				32E401CA1FF42372001C2096 /* UIPlugin.swift in Sources */,
@@ -2131,6 +2144,7 @@
 				32DA34191FFBCFC400484C90 /* Container.swift in Sources */,
 				FBD47AB021AD6856003265AF /* ContainerFactory.swift in Sources */,
 				571B7B262174E324005C0942 /* AVFoundationPlayback+tvOS.swift in Sources */,
+				26211C2224DC70E7000501A4 /* Direction.swift in Sources */,
 				32E401BF1FF42321001C2096 /* MediaOptionType.swift in Sources */,
 				C9177B2F21664D1C001D0292 /* UIImage+Ext.swift in Sources */,
 				AB25CC2C22EB7DE500AD4759 /* AVFoundationPlayback+DVR.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Font/Alignment.swift
+++ b/Sources/Clappr/Classes/Base/Font/Alignment.swift
@@ -1,0 +1,15 @@
+import CoreMedia
+
+enum Alignment: String, Equatable {
+    case start, middle, end, left, right
+
+    var value: String {
+        switch self {
+        case .start: return String(kCMTextMarkupAlignmentType_Start)
+        case .middle: return String(kCMTextMarkupAlignmentType_Middle)
+        case .end: return String(kCMTextMarkupAlignmentType_End)
+        case .left: return String(kCMTextMarkupAlignmentType_Left)
+        case .right: return String(kCMTextMarkupAlignmentType_Right)
+        }
+    }
+}

--- a/Sources/Clappr/Classes/Base/Font/Alignment.swift
+++ b/Sources/Clappr/Classes/Base/Font/Alignment.swift
@@ -1,6 +1,6 @@
 import CoreMedia
 
-enum Alignment: String, Equatable {
+public enum Alignment: String, Equatable {
     case start, middle, end, left, right
 
     var value: String {

--- a/Sources/Clappr/Classes/Base/Font/Direction.swift
+++ b/Sources/Clappr/Classes/Base/Font/Direction.swift
@@ -1,6 +1,6 @@
 import CoreMedia
 
-enum Direction {
+public enum Direction {
     case ltr, rtl
 
     var value: String {

--- a/Sources/Clappr/Classes/Base/Font/Direction.swift
+++ b/Sources/Clappr/Classes/Base/Font/Direction.swift
@@ -1,0 +1,12 @@
+import CoreMedia
+
+enum Direction {
+    case ltr, rtl
+
+    var value: String {
+        switch self {
+        case .ltr: return String(kCMTextVerticalLayout_LeftToRight)
+        case .rtl: return String(kCMTextVerticalLayout_RightToLeft)
+        }
+    }
+}

--- a/Sources/Clappr/Classes/Base/Font/EdgeStyle.swift
+++ b/Sources/Clappr/Classes/Base/Font/EdgeStyle.swift
@@ -1,6 +1,6 @@
 import AVKit
 
-enum EdgeStyle {
+public enum EdgeStyle {
     case none
     case raised
     case depressed

--- a/Sources/Clappr/Classes/Base/Font/EdgeStyle.swift
+++ b/Sources/Clappr/Classes/Base/Font/EdgeStyle.swift
@@ -1,0 +1,19 @@
+import AVKit
+
+enum EdgeStyle {
+    case none
+    case raised
+    case depressed
+    case uniform
+    case dropShadow
+
+    var value: CFString {
+        switch self {
+        case .none: return kCMTextMarkupCharacterEdgeStyle_None
+        case .raised: return kCMTextMarkupCharacterEdgeStyle_Raised
+        case .depressed: return kCMTextMarkupCharacterEdgeStyle_Depressed
+        case .uniform: return kCMTextMarkupCharacterEdgeStyle_Uniform
+        case .dropShadow: return kCMTextMarkupCharacterEdgeStyle_DropShadow
+        }
+    }
+}

--- a/Sources/Clappr/Classes/Base/Font/Font.swift
+++ b/Sources/Clappr/Classes/Base/Font/Font.swift
@@ -1,0 +1,42 @@
+import CoreMedia
+
+enum Font {
+    case `default`
+    case serif
+    case sansSerif
+    case monospace
+    case proportionalSerif
+    case proportionalSansSerif
+    case monospaceSerif
+    case monospaceSansSerif
+    case casual
+    case cursive
+    case fantasy
+    case smallCapital
+    case custom(String)
+
+    var key: String {
+        switch self {
+        case .custom: return String(kCMTextMarkupAttribute_FontFamilyName)
+        default: return String(kCMTextMarkupAttribute_GenericFontFamilyName)
+        }
+    }
+
+    var value: String {
+        switch self {
+        case .default: return String(kCMTextMarkupGenericFontName_Default)
+        case .serif: return String(kCMTextMarkupGenericFontName_Serif)
+        case .sansSerif: return String(kCMTextMarkupGenericFontName_SansSerif)
+        case .monospace: return String(kCMTextMarkupGenericFontName_Monospace)
+        case .proportionalSerif: return String(kCMTextMarkupGenericFontName_ProportionalSerif)
+        case .proportionalSansSerif: return String(kCMTextMarkupGenericFontName_ProportionalSansSerif)
+        case .monospaceSerif: return String(kCMTextMarkupGenericFontName_MonospaceSerif)
+        case .monospaceSansSerif: return String(kCMTextMarkupGenericFontName_MonospaceSansSerif)
+        case .casual: return String(kCMTextMarkupGenericFontName_Casual)
+        case .cursive: return String(kCMTextMarkupGenericFontName_Cursive)
+        case .fantasy: return String(kCMTextMarkupGenericFontName_Fantasy)
+        case .smallCapital: return String(kCMTextMarkupGenericFontName_SmallCapital)
+        case .custom(let value): return value
+        }
+    }
+}

--- a/Sources/Clappr/Classes/Base/Font/Font.swift
+++ b/Sources/Clappr/Classes/Base/Font/Font.swift
@@ -1,6 +1,6 @@
 import CoreMedia
 
-enum Font {
+public enum Font {
     case `default`
     case serif
     case sansSerif

--- a/Sources/Clappr/Classes/Base/Font/TextStyle.swift
+++ b/Sources/Clappr/Classes/Base/Font/TextStyle.swift
@@ -1,7 +1,7 @@
 import AVKit
 import UIKit
 
-enum TextStyle {
+public enum TextStyle {
     case characterBackground(UIColor)
     case background(UIColor)
     case foreground(UIColor)

--- a/Sources/Clappr/Classes/Base/Font/TextStyle.swift
+++ b/Sources/Clappr/Classes/Base/Font/TextStyle.swift
@@ -49,3 +49,9 @@ public enum TextStyle {
         }
     }
 }
+
+extension TextStyle: Equatable {
+    public static func == (lhs: TextStyle, rhs: TextStyle) -> Bool {
+        lhs.key == rhs.key && lhs.value == rhs.value
+    }
+}

--- a/Sources/Clappr/Classes/Base/Font/TextStyle.swift
+++ b/Sources/Clappr/Classes/Base/Font/TextStyle.swift
@@ -1,0 +1,51 @@
+import AVKit
+import UIKit
+
+enum TextStyle {
+    case characterBackground(UIColor)
+    case background(UIColor)
+    case foreground(UIColor)
+    case fontSize(Int)
+    case bold
+    case italic
+    case underline
+    case edge(EdgeStyle)
+    case font(Font)
+    case alignment(Alignment)
+    case direction(Direction)
+
+    var key: String {
+        switch self {
+        case .background: return String(kCMTextMarkupAttribute_BackgroundColorARGB)
+        case .characterBackground: return String(kCMTextMarkupAttribute_CharacterBackgroundColorARGB)
+        case .foreground: return String(kCMTextMarkupAttribute_ForegroundColorARGB)
+        case .fontSize: return String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight)
+        case .bold: return String(kCMTextMarkupAttribute_BoldStyle)
+        case .underline: return String(kCMTextMarkupAttribute_UnderlineStyle)
+        case .italic: return String(kCMTextMarkupAttribute_ItalicStyle)
+        case .edge: return String(kCMTextMarkupAttribute_CharacterEdgeStyle)
+        case .alignment: return String(kCMTextMarkupAttribute_Alignment)
+        case .direction: return String(kCMTextMarkupAttribute_VerticalLayout)
+        default: return ""
+        }
+    }
+
+    var value: AVTextStyleRule {
+        switch self {
+        case .bold, .italic, .underline:
+            return AVTextStyleRule(textMarkupAttributes: [ self.key: true])!
+        case .fontSize(let size):
+            return AVTextStyleRule(textMarkupAttributes: [ self.key: size])!
+        case .background(let color), .characterBackground(let color), .foreground(let color):
+            return AVTextStyleRule(textMarkupAttributes: [ self.key: color.argb])!
+        case .edge(let edge):
+            return AVTextStyleRule(textMarkupAttributes: [ self.key: edge.value])!
+        case .font(let font):
+            return AVTextStyleRule(textMarkupAttributes: [ font.key: font.value])!
+        case .alignment(let alignment):
+            return AVTextStyleRule(textMarkupAttributes: [ self.key: alignment.value])!
+        case .direction(let direction):
+            return AVTextStyleRule(textMarkupAttributes: [ self.key: direction.value])!
+        }
+    }
+}

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -106,7 +106,6 @@ open class Playback: UIObject, NamedType {
     @objc open func seek(_: TimeInterval) {}
     @objc open func seekToLivePosition() {}
     open func mute(_: Bool) {}
-    open func changeSubtitle(style textStyle: [TextStyle]) {}
 
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Playback")

--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -106,6 +106,7 @@ open class Playback: UIObject, NamedType {
     @objc open func seek(_: TimeInterval) {}
     @objc open func seekToLivePosition() {}
     open func mute(_: Bool) {}
+    open func changeSubtitle(style textStyle: [TextStyle]) {}
 
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Playback")

--- a/Sources/Clappr/Classes/Extension/AVPlayerItem+Style.swift
+++ b/Sources/Clappr/Classes/Extension/AVPlayerItem+Style.swift
@@ -1,0 +1,8 @@
+import AVFoundation
+
+extension AVPlayerItem {
+    var textStyle: [TextStyle] {
+        get { return [] }
+        set { self.textStyleRules = newValue.map { $0.value } }
+    }
+}

--- a/Sources/Clappr/Classes/Extension/UIColor+ARGB.swift
+++ b/Sources/Clappr/Classes/Extension/UIColor+ARGB.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+extension UIColor {
+    var argb: [CGFloat] {
+        let color = CIColor(color: self)
+        return [ color.alpha, color.red, color.green, color.blue ]
+    }
+}

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -635,7 +635,7 @@ open class AVFoundationPlayback: Playback {
         #endif
     }
 
-    public func changeSubtitle(style textStyle: [TextStyle]) {
+    open override func changeSubtitle(style textStyle: [TextStyle]) {
         self.player?.currentItem?.textStyle = textStyle
     }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -759,4 +759,8 @@ open class AVFoundationPlayback: Playback {
             view.accessibilityIdentifier = "AVFoundationPlaybackError"
         }
     }
+
+    func changeSubtitle(style textStyle: [TextStyle]) {
+        self.player?.currentItem?.textStyle = textStyle
+    }
 }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -635,6 +635,7 @@ open class AVFoundationPlayback: Playback {
         #endif
     }
 
+    @discardableResult
     open func applySubtitleStyle(with textStyle: [TextStyle]) -> Bool {
         guard let currentItem = player?.currentItem else { return false }
         currentItem.textStyle = textStyle

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -760,7 +760,7 @@ open class AVFoundationPlayback: Playback {
         }
     }
 
-    func changeSubtitle(style textStyle: [TextStyle]) {
+    public func changeSubtitle(style textStyle: [TextStyle]) {
         self.player?.currentItem?.textStyle = textStyle
     }
 }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -635,8 +635,11 @@ open class AVFoundationPlayback: Playback {
         #endif
     }
 
-    open override func changeSubtitle(style textStyle: [TextStyle]) {
-        self.player?.currentItem?.textStyle = textStyle
+    open func applySubtitleStyle(with textStyle: [TextStyle]) -> Bool {
+        guard let currentItem = player?.currentItem else { return false }
+        currentItem.textStyle = textStyle
+
+        return true
     }
 
     private var defaultSubtitleLanguage: String? {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -635,6 +635,10 @@ open class AVFoundationPlayback: Playback {
         #endif
     }
 
+    public func changeSubtitle(style textStyle: [TextStyle]) {
+        self.player?.currentItem?.textStyle = textStyle
+    }
+
     private var defaultSubtitleLanguage: String? {
         return options[kDefaultSubtitle] as? String
     }
@@ -758,9 +762,5 @@ open class AVFoundationPlayback: Playback {
         case .error:
             view.accessibilityIdentifier = "AVFoundationPlaybackError"
         }
-    }
-
-    public func changeSubtitle(style textStyle: [TextStyle]) {
-        self.player?.currentItem?.textStyle = textStyle
     }
 }

--- a/Tests/Clappr_Tests/Classes/Base/FontTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/FontTests.swift
@@ -1,0 +1,369 @@
+import Quick
+import Nimble
+import CoreMedia
+import AVKit
+@testable import Clappr
+
+class FontTests: QuickSpec {
+    
+    override func spec() {
+        
+        // MARK: - Aligment
+        
+        describe("Aligment") {
+            context(".start") {
+                it("has value equal to kCMTextMarkupAlignmentType_Start") {
+                    let aligment: Alignment = .start
+                    expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Start)))
+                }
+            }
+            
+            context(".middle") {
+                it("has value equal to kCMTextMarkupAlignmentType_Middle") {
+                    let aligment: Alignment = .middle
+                    expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Middle)))
+                }
+            }
+            
+            context(".end") {
+                it("has value equal to kCMTextMarkupAlignmentType_End") {
+                    let aligment: Alignment = .end
+                    expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_End)))
+                }
+            }
+            
+            context(".left") {
+                it("has value equal to kCMTextMarkupAlignmentType_Left") {
+                    let aligment: Alignment = .left
+                    expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Left)))
+                }
+            }
+            
+            context(".right") {
+                it("has value equal to kCMTextMarkupAlignmentType_Right") {
+                    let aligment: Alignment = .right
+                    expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Right)))
+                }
+            }
+        }
+        
+        // MARK: - Direction
+        
+        describe("Direction") {
+            context(".ltr") {
+                it("") {
+                    let direction: Direction = .ltr
+                    expect(direction.value).to(equal(String(kCMTextVerticalLayout_LeftToRight)))
+                }
+            }
+            
+            context(".rtl") {
+                it("") {
+                    let direction: Direction = .rtl
+                    expect(direction.value).to(equal(String(kCMTextVerticalLayout_RightToLeft)))
+                }
+            }
+        }
+        
+        // MARK: - EdgeStyle
+        
+        describe("EdgeStyle") {
+            context(".none") {
+                it("") {
+                    let edgeStyle: EdgeStyle = .none
+                    expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_None))
+                }
+            }
+            
+            context(".raised") {
+                let edgeStyle: EdgeStyle = .raised
+                expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_Raised))
+            }
+            
+            context(".depressed") {
+                it("") {
+                    let edgeStyle: EdgeStyle = .depressed
+                    expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_Depressed))
+                }
+            }
+            
+            context(".uniform") {
+                it("") {
+                    let edgeStyle: EdgeStyle = .uniform
+                    expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_Uniform))
+                }
+            }
+            
+            context(".dropShadow") {
+                it("") {
+                    let edgeStyle: EdgeStyle = .dropShadow
+                    expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_DropShadow))
+                }
+            }
+        }
+        
+        // MARK: - Font
+        
+        describe("Font") {
+            context(".custom") {
+                it("has value equals CleanSans and key equal kCMTextMarkupAttribute_FontFamilyName") {
+                    let fontCustom: Font = .custom("ClearSans")
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_FontFamilyName)))
+                    expect(fontCustom.value).to(equal("ClearSans"))
+                }
+            }
+            
+            context(".default") {
+                it("has value equals kCMTextMarkupGenericFontName_Default and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .default
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_Default)))
+                }
+            }
+            
+            context(".serif") {
+                it("has value equals kCMTextMarkupGenericFontName_Serif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .serif
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_Serif)))
+                }
+            }
+            
+            context(".sansSerif") {
+                it("has value equals kCMTextMarkupGenericFontName_SansSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .sansSerif
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_SansSerif)))
+                }
+            }
+            
+            context(".monospace") {
+                it("has value equals kCMTextMarkupGenericFontName_Monospace and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .monospace
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_Monospace)))
+                }
+            }
+            
+            context(".proportionalSerif") {
+                it("has value equals kCMTextMarkupGenericFontName_ProportionalSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .proportionalSerif
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_ProportionalSerif)))
+                }
+            }
+            
+            context(".proportionalSansSerif") {
+                it("has value equals kCMTextMarkupGenericFontName_ProportionalSansSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .proportionalSansSerif
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_ProportionalSansSerif)))
+                }
+            }
+            
+            context(".monospaceSerif") {
+                it("has value equals kCMTextMarkupGenericFontName_MonospaceSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .monospaceSerif
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_MonospaceSerif)))
+                }
+            }
+            
+            context(".monospaceSansSerif") {
+                it("has value equals kCMTextMarkupGenericFontName_MonospaceSansSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .monospaceSansSerif
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_MonospaceSansSerif)))
+                }
+            }
+            
+            context(".casual") {
+                it("has value equals kCMTextMarkupGenericFontName_Casual and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .casual
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_Casual)))
+                }
+            }
+            
+            context(".cursive") {
+                it("has value equals kCMTextMarkupGenericFontName_Cursive and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .cursive
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_Cursive)))
+                }
+            }
+            
+            context(".fantasy") {
+                it("has value equals kCMTextMarkupGenericFontName_Fantasy and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .fantasy
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_Fantasy)))
+                }
+            }
+            
+            context(".smallCapital") {
+                it("has value equals kCMTextMarkupGenericFontName_SmallCapital and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                    let fontCustom: Font = .smallCapital
+                    
+                    expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
+                    expect(fontCustom.value).to(equal(String(kCMTextMarkupGenericFontName_SmallCapital)))
+                }
+            }
+        }
+        
+        // MARK: - TextStyle
+        
+        describe("TextStyle") {
+            context(".characterBackground") {
+                it("has ...") {
+                    let style: TextStyle = .characterBackground(.white)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_CharacterBackgroundColorARGB) : [1.0, 1.0, 1.0, 1.0]])
+                    
+                    expect(style.key).to(equal(String(kCMTextMarkupAttribute_CharacterBackgroundColorARGB)))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".background") {
+                it("has...") {
+                    let style: TextStyle = .background(.white)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BackgroundColorARGB) : [1.0, 1.0, 1.0, 1.0]])
+                    
+                    expect(style.key).to(equal(String(kCMTextMarkupAttribute_BackgroundColorARGB)))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".foreground") {
+                it("") {
+                    let style: TextStyle = .foreground(.red)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_ForegroundColorARGB) : [1.0, 1.0, 0, 0]])
+                    
+                    expect(style.key).to(equal(String(kCMTextMarkupAttribute_ForegroundColorARGB)))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".fontSize") {
+                it("") {
+                    let style: TextStyle = .fontSize(12)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight) : 12])
+                    
+                    expect(style.key).to(equal(String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight)))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".bold") {
+                it("") {
+                    let style: TextStyle = .bold
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BoldStyle) : true])
+                    
+                    expect(style.key).to(equal(String(kCMTextMarkupAttribute_BoldStyle)))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".underline") {
+                it("") {
+                    let style: TextStyle = .underline
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_UnderlineStyle) : true])
+                    
+                    expect(style.key).to(equal(String(kCMTextMarkupAttribute_UnderlineStyle)))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".italic") {
+                it("") {
+                    let style: TextStyle = .italic
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_ItalicStyle) : true])
+                    
+                    expect(style.key).to(equal(String((kCMTextMarkupAttribute_ItalicStyle))))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".edge") {
+                it("") {
+                    let style: TextStyle = .edge(.dropShadow)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_CharacterEdgeStyle)) : kCMTextMarkupCharacterEdgeStyle_DropShadow])
+                    
+                    expect(style.key).to(equal(String((kCMTextMarkupAttribute_CharacterEdgeStyle))))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".alignment") {
+                it("") {
+                    let style: TextStyle = .alignment(.left)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_Alignment)) : (kCMTextMarkupAlignmentType_Left)])
+                    
+                    expect(style.key).to(equal(String((kCMTextMarkupAttribute_Alignment))))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+            
+            context(".direction") {
+                it("") {
+                    let style: TextStyle = .direction(.ltr)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_VerticalLayout)) : (kCMTextVerticalLayout_LeftToRight)])
+                    
+                    expect(style.key).to(equal(String((kCMTextMarkupAttribute_VerticalLayout))))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+        }
+        
+        // MARK: - AVPlayerItem
+        
+        describe("AVPlayerItem") {
+            context("textStyle") {
+                it("") {
+                    let currentItem = AVPlayerItem(url: URL(fileURLWithPath: ""))
+                    currentItem.textStyle = [
+                        .alignment(.left),
+                        .background(.white),
+                        .bold,
+                        .characterBackground(.red),
+                        .direction(.ltr),
+                        .edge(.dropShadow),
+                        .font(.casual),
+                        .fontSize(12),
+                        .foreground(.blue),
+                        .italic,
+                        .underline
+                    ]
+                    
+                    let expectedValue = [
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_Alignment)) : (kCMTextMarkupAlignmentType_Left)]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_BackgroundColorARGB)) : [1.0, 1.0, 1.0, 1.0]]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_BoldStyle)) : true]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_CharacterBackgroundColorARGB)) : [1.0, 1.0, 0, 0]]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_VerticalLayout)) : (kCMTextVerticalLayout_LeftToRight)]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_CharacterEdgeStyle)) : kCMTextMarkupCharacterEdgeStyle_DropShadow]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_GenericFontFamilyName)) : kCMTextMarkupGenericFontName_Casual]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight)) : 12]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_ForegroundColorARGB)) : [1.0, 0, 0, 1.0]]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_ItalicStyle)) : true]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_UnderlineStyle)) : true])
+                    ]
+                    
+                    expect(currentItem.textStyleRules).to(equal(expectedValue))
+                }
+            }
+        }
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Base/FontTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/FontTests.swift
@@ -333,6 +333,11 @@ class FontTests: QuickSpec {
         
         describe("AVPlayerItem") {
             context(".textStyleRule") {
+                it("should the default value be nil") {
+                    let currentItem = AVPlayerItem(url: URL(fileURLWithPath: ""))
+                    expect(currentItem.textStyleRules).to(beNil())
+                }
+
                 it("should the value be equal a map from 'textStyle' to an array of AVTextStyleRule") {
                     let currentItem = AVPlayerItem(url: URL(fileURLWithPath: ""))
                     currentItem.textStyle = [

--- a/Tests/Clappr_Tests/Classes/Base/FontTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/FontTests.swift
@@ -12,35 +12,35 @@ class FontTests: QuickSpec {
         
         describe("Aligment") {
             context(".start") {
-                it("has value equal to kCMTextMarkupAlignmentType_Start") {
+                it("should the value be equal to kCMTextMarkupAlignmentType_Start") {
                     let aligment: Alignment = .start
                     expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Start)))
                 }
             }
             
             context(".middle") {
-                it("has value equal to kCMTextMarkupAlignmentType_Middle") {
+                it("should the value be equal to kCMTextMarkupAlignmentType_Middle") {
                     let aligment: Alignment = .middle
                     expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Middle)))
                 }
             }
             
             context(".end") {
-                it("has value equal to kCMTextMarkupAlignmentType_End") {
+                it("should the value be equal to kCMTextMarkupAlignmentType_End") {
                     let aligment: Alignment = .end
                     expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_End)))
                 }
             }
             
             context(".left") {
-                it("has value equal to kCMTextMarkupAlignmentType_Left") {
+                it("should the value be equal to kCMTextMarkupAlignmentType_Left") {
                     let aligment: Alignment = .left
                     expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Left)))
                 }
             }
             
             context(".right") {
-                it("has value equal to kCMTextMarkupAlignmentType_Right") {
+                it("should the value be equal to kCMTextMarkupAlignmentType_Right") {
                     let aligment: Alignment = .right
                     expect(aligment.value).to(equal(String(kCMTextMarkupAlignmentType_Right)))
                 }
@@ -51,14 +51,14 @@ class FontTests: QuickSpec {
         
         describe("Direction") {
             context(".ltr") {
-                it("") {
+                it("should the value be equal to kCMTextVerticalLayout_LeftToRight") {
                     let direction: Direction = .ltr
                     expect(direction.value).to(equal(String(kCMTextVerticalLayout_LeftToRight)))
                 }
             }
             
             context(".rtl") {
-                it("") {
+                it("should the value be equal to kCMTextVerticalLayout_RightToLeft") {
                     let direction: Direction = .rtl
                     expect(direction.value).to(equal(String(kCMTextVerticalLayout_RightToLeft)))
                 }
@@ -69,33 +69,35 @@ class FontTests: QuickSpec {
         
         describe("EdgeStyle") {
             context(".none") {
-                it("") {
+                it("should the value be equal to kCMTextMarkupCharacterEdgeStyle_None") {
                     let edgeStyle: EdgeStyle = .none
                     expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_None))
                 }
             }
             
             context(".raised") {
-                let edgeStyle: EdgeStyle = .raised
-                expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_Raised))
+                it("should the value be equal to kCMTextMarkupCharacterEdgeStyle_Raised") {
+                    let edgeStyle: EdgeStyle = .raised
+                    expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_Raised))
+                }
             }
             
             context(".depressed") {
-                it("") {
+                it("should the value be equal to kCMTextMarkupCharacterEdgeStyle_Depressed") {
                     let edgeStyle: EdgeStyle = .depressed
                     expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_Depressed))
                 }
             }
             
             context(".uniform") {
-                it("") {
+                it("should the value be equal kCMTextMarkupCharacterEdgeStyle_Uniform") {
                     let edgeStyle: EdgeStyle = .uniform
                     expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_Uniform))
                 }
             }
             
             context(".dropShadow") {
-                it("") {
+                it("should the value be equal kCMTextMarkupCharacterEdgeStyle_DropShadow") {
                     let edgeStyle: EdgeStyle = .dropShadow
                     expect(edgeStyle.value).to(equal(kCMTextMarkupCharacterEdgeStyle_DropShadow))
                 }
@@ -106,7 +108,7 @@ class FontTests: QuickSpec {
         
         describe("Font") {
             context(".custom") {
-                it("has value equals CleanSans and key equal kCMTextMarkupAttribute_FontFamilyName") {
+                it("should the value be equal CleanSans and the key equal kCMTextMarkupAttribute_FontFamilyName") {
                     let fontCustom: Font = .custom("ClearSans")
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_FontFamilyName)))
@@ -115,7 +117,7 @@ class FontTests: QuickSpec {
             }
             
             context(".default") {
-                it("has value equals kCMTextMarkupGenericFontName_Default and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_Default and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .default
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -124,7 +126,7 @@ class FontTests: QuickSpec {
             }
             
             context(".serif") {
-                it("has value equals kCMTextMarkupGenericFontName_Serif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_Serif and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .serif
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -133,7 +135,7 @@ class FontTests: QuickSpec {
             }
             
             context(".sansSerif") {
-                it("has value equals kCMTextMarkupGenericFontName_SansSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_SansSerif and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .sansSerif
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -142,7 +144,7 @@ class FontTests: QuickSpec {
             }
             
             context(".monospace") {
-                it("has value equals kCMTextMarkupGenericFontName_Monospace and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_Monospace and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .monospace
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -151,7 +153,7 @@ class FontTests: QuickSpec {
             }
             
             context(".proportionalSerif") {
-                it("has value equals kCMTextMarkupGenericFontName_ProportionalSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_ProportionalSerif and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .proportionalSerif
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -160,7 +162,7 @@ class FontTests: QuickSpec {
             }
             
             context(".proportionalSansSerif") {
-                it("has value equals kCMTextMarkupGenericFontName_ProportionalSansSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_ProportionalSansSerif and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .proportionalSansSerif
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -169,7 +171,7 @@ class FontTests: QuickSpec {
             }
             
             context(".monospaceSerif") {
-                it("has value equals kCMTextMarkupGenericFontName_MonospaceSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_MonospaceSerif and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .monospaceSerif
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -178,7 +180,7 @@ class FontTests: QuickSpec {
             }
             
             context(".monospaceSansSerif") {
-                it("has value equals kCMTextMarkupGenericFontName_MonospaceSansSerif and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_MonospaceSansSerif and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .monospaceSansSerif
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -187,7 +189,7 @@ class FontTests: QuickSpec {
             }
             
             context(".casual") {
-                it("has value equals kCMTextMarkupGenericFontName_Casual and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_Casual and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .casual
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -196,7 +198,7 @@ class FontTests: QuickSpec {
             }
             
             context(".cursive") {
-                it("has value equals kCMTextMarkupGenericFontName_Cursive and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_Cursive and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .cursive
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -205,7 +207,7 @@ class FontTests: QuickSpec {
             }
             
             context(".fantasy") {
-                it("has value equals kCMTextMarkupGenericFontName_Fantasy and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_Fantasy and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .fantasy
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -214,7 +216,7 @@ class FontTests: QuickSpec {
             }
             
             context(".smallCapital") {
-                it("has value equals kCMTextMarkupGenericFontName_SmallCapital and key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
+                it("should the value be equal kCMTextMarkupGenericFontName_SmallCapital and the key equal kCMTextMarkupAttribute_GenericFontFamilyName") {
                     let fontCustom: Font = .smallCapital
                     
                     expect(fontCustom.key).to(equal(String(kCMTextMarkupAttribute_GenericFontFamilyName)))
@@ -227,7 +229,7 @@ class FontTests: QuickSpec {
         
         describe("TextStyle") {
             context(".characterBackground") {
-                it("has ...") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_CharacterBackgroundColorARGB and the value be equal to [1, 1, 1, 1]") {
                     let style: TextStyle = .characterBackground(.white)
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_CharacterBackgroundColorARGB) : [1.0, 1.0, 1.0, 1.0]])
                     
@@ -237,7 +239,7 @@ class FontTests: QuickSpec {
             }
             
             context(".background") {
-                it("has...") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_BackgroundColorARGB and the value be equal to [1, 1, 1, 1]") {
                     let style: TextStyle = .background(.white)
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BackgroundColorARGB) : [1.0, 1.0, 1.0, 1.0]])
                     
@@ -247,7 +249,7 @@ class FontTests: QuickSpec {
             }
             
             context(".foreground") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_ForegroundColorARGB and the value be equal to [1, 1, 1, 1]") {
                     let style: TextStyle = .foreground(.red)
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_ForegroundColorARGB) : [1.0, 1.0, 0, 0]])
                     
@@ -257,7 +259,7 @@ class FontTests: QuickSpec {
             }
             
             context(".fontSize") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight and the value be equal to 12") {
                     let style: TextStyle = .fontSize(12)
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight) : 12])
                     
@@ -267,7 +269,7 @@ class FontTests: QuickSpec {
             }
             
             context(".bold") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_BoldStyle and the value be equal to true") {
                     let style: TextStyle = .bold
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BoldStyle) : true])
                     
@@ -277,7 +279,7 @@ class FontTests: QuickSpec {
             }
             
             context(".underline") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_UnderlineStyle and the value be equal to true") {
                     let style: TextStyle = .underline
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_UnderlineStyle) : true])
                     
@@ -287,7 +289,7 @@ class FontTests: QuickSpec {
             }
             
             context(".italic") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_ItalicStyle and the value be equal to true") {
                     let style: TextStyle = .italic
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_ItalicStyle) : true])
                     
@@ -297,9 +299,9 @@ class FontTests: QuickSpec {
             }
             
             context(".edge") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_CharacterEdgeStyle and the value be equal to kCMTextMarkupCharacterEdgeStyle_DropShadow") {
                     let style: TextStyle = .edge(.dropShadow)
-                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_CharacterEdgeStyle)) : kCMTextMarkupCharacterEdgeStyle_DropShadow])
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_CharacterEdgeStyle) : kCMTextMarkupCharacterEdgeStyle_DropShadow])
                     
                     expect(style.key).to(equal(String((kCMTextMarkupAttribute_CharacterEdgeStyle))))
                     expect(style.value).to(equal(expectedValue))
@@ -307,9 +309,9 @@ class FontTests: QuickSpec {
             }
             
             context(".alignment") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_Alignment and the value be equal to kCMTextMarkupAlignmentType_Left") {
                     let style: TextStyle = .alignment(.left)
-                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_Alignment)) : (kCMTextMarkupAlignmentType_Left)])
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_Alignment) : kCMTextMarkupAlignmentType_Left])
                     
                     expect(style.key).to(equal(String((kCMTextMarkupAttribute_Alignment))))
                     expect(style.value).to(equal(expectedValue))
@@ -317,9 +319,9 @@ class FontTests: QuickSpec {
             }
             
             context(".direction") {
-                it("") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_VerticalLayout and the value be equal to kCMTextVerticalLayout_LeftToRight") {
                     let style: TextStyle = .direction(.ltr)
-                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_VerticalLayout)) : (kCMTextVerticalLayout_LeftToRight)])
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_VerticalLayout) : kCMTextVerticalLayout_LeftToRight])
                     
                     expect(style.key).to(equal(String((kCMTextMarkupAttribute_VerticalLayout))))
                     expect(style.value).to(equal(expectedValue))
@@ -330,8 +332,8 @@ class FontTests: QuickSpec {
         // MARK: - AVPlayerItem
         
         describe("AVPlayerItem") {
-            context("textStyle") {
-                it("") {
+            context(".textStyleRule") {
+                it("should the value be equal a map from 'textStyle' to an array of AVTextStyleRule") {
                     let currentItem = AVPlayerItem(url: URL(fileURLWithPath: ""))
                     currentItem.textStyle = [
                         .alignment(.left),

--- a/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
+++ b/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
@@ -18,6 +18,7 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     var didCallSeekToLivePosition = false
     var _playbackType: PlaybackType = .vod
     var _state: PlaybackState = .none
+    var didCallChangeSubtitleStyle = false
 
     override open var state: PlaybackState {
         get {
@@ -99,6 +100,10 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     
     override var currentDate: Date? {
         return _currentDate
+    }
+
+    override func changeSubtitle(style textStyle: [TextStyle]) {
+        self.didCallChangeSubtitleStyle = true
     }
     
     #if os(iOS)

--- a/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
+++ b/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
@@ -18,7 +18,6 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     var didCallSeekToLivePosition = false
     var _playbackType: PlaybackType = .vod
     var _state: PlaybackState = .none
-    var didCallChangeSubtitleStyle = false
 
     override open var state: PlaybackState {
         get {
@@ -100,10 +99,6 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     
     override var currentDate: Date? {
         return _currentDate
-    }
-
-    override func changeSubtitle(style textStyle: [TextStyle]) {
-        self.didCallChangeSubtitleStyle = true
     }
     
     #if os(iOS)

--- a/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
+++ b/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
@@ -18,7 +18,6 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     var didCallSeekToLivePosition = false
     var _playbackType: PlaybackType = .vod
     var _state: PlaybackState = .none
-    var didChangeSubtitleStyle = false
     var _textStyle: [TextStyle] = []
 
     override open var state: PlaybackState {
@@ -99,9 +98,10 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
         didCallSeekWithValue = timeInterval
     }
 
-    override func changeSubtitle(style textStyle: [TextStyle]) {
-        didChangeSubtitleStyle = true
+    override func applySubtitleStyle(with textStyle: [TextStyle]) -> Bool {
         _textStyle = textStyle
+
+        return true
     }
     
     override var currentDate: Date? {

--- a/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
+++ b/Tests/Clappr_Tests/Classes/Mocks/AVFoundationPlaybackMock.swift
@@ -18,6 +18,8 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
     var didCallSeekToLivePosition = false
     var _playbackType: PlaybackType = .vod
     var _state: PlaybackState = .none
+    var didChangeSubtitleStyle = false
+    var _textStyle: [TextStyle] = []
 
     override open var state: PlaybackState {
         get {
@@ -95,6 +97,11 @@ class AVFoundationPlaybackMock: AVFoundationPlayback {
         super.seek(timeInterval)
         didCallSeek = true
         didCallSeekWithValue = timeInterval
+    }
+
+    override func changeSubtitle(style textStyle: [TextStyle]) {
+        didChangeSubtitleStyle = true
+        _textStyle = textStyle
     }
     
     override var currentDate: Date? {

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -1418,6 +1418,16 @@ class AVFoundationPlaybackTests: QuickSpec {
                 }
             }
 
+            describe("#changeSubtitleStyle") {
+                it("changes the subtitles style") {
+                    let options = [kSourceUrl: "http://clappr.sample/sample.m3u8", kDefaultSubtitle: "pt"]
+                    let playback = AVFoundationPlaybackMock(options: options)
+
+                    playback.changeSubtitle(style: [.font(.default), .bold])
+                    expect(playback.didCallChangeSubtitleStyle).to(beTrue())
+                }
+            }
+
             describe("#selectDefaultAudioIfNeeded") {
                 it("changes audio just once") {
                     let options = [kSourceUrl: "http://clappr.sample/sample.m3u8", kDefaultAudioSource: "pt"]

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -1428,11 +1428,12 @@ class AVFoundationPlaybackTests: QuickSpec {
                     ]
 
                     playback.play()
-                    playback.changeSubtitle(style: [
+                    let didChangeSubtitleStyle = playback.applySubtitleStyle(with: [
                         .bold,
                         .font(.default)
                     ])
 
+                    expect(didChangeSubtitleStyle).to(beTrue())
                     expect(playback.player?.currentItem?.textStyleRules).toEventually(equal(expectedvalue), timeout: 2)
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -1421,10 +1421,19 @@ class AVFoundationPlaybackTests: QuickSpec {
             describe("#changeSubtitleStyle") {
                 it("changes the subtitles style") {
                     let options = [kSourceUrl: "http://clappr.sample/sample.m3u8", kDefaultSubtitle: "pt"]
-                    let playback = AVFoundationPlaybackMock(options: options)
+                    let playback = AVFoundationPlayback(options: options)
+                    let expectedvalue = [
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_BoldStyle)) : true]),
+                        AVTextStyleRule(textMarkupAttributes: [String((kCMTextMarkupAttribute_GenericFontFamilyName)) : kCMTextMarkupGenericFontName_Default]),
+                    ]
 
-                    playback.changeSubtitle(style: [.font(.default), .bold])
-                    expect(playback.didCallChangeSubtitleStyle).to(beTrue())
+                    playback.play()
+                    playback.changeSubtitle(style: [
+                        .bold,
+                        .font(.default)
+                    ])
+
+                    expect(playback.player?.currentItem?.textStyleRules).toEventually(equal(expectedvalue), timeout: 2)
                 }
             }
 


### PR DESCRIPTION
# Goal

Introduce player capability to change the subtitle style.
Create an abstraction from `AVTextStyleRules` to use a non-verbose code

# Class Diagram

![UML](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://gist.githubusercontent.com/helbertgs/d4d711e40bfeb77b9938f5614bf730c1/raw/2d4fa9fcddb20140f56a80ec3f314d48ecd2c726/TextStyle.plantuml)

# How to Test

Change the `options` on `DashboardViewController.swift#19`

```swift
let options: Options = [
            kSourceUrl: "http://sample.vodobox.com/planete_interdite/planete_interdite_alternate.m3u8",
            kPosterUrl: "http://clappr.io/poster.png",
            kDefaultSubtitle: "eng",
            kFullscreen: switchFullscreen.isOn,
            kFullscreenByApp: switchFullscreenControledByApp.isOn
        ]
```

Change the `selectDefaultMediaOptionIfNeeded` function  on `AVFoundationPlayback.swift#650`

```swift
func selectDefaultMediaOptionIfNeeded() {
        selectDefaultAudioIfNeeded()
        changeSubtitle(style: [ 
            .font(.fantasy), 
            .bold, 
            .background(.blue) 
        ])
        selectDefaultSubtitleIfNeeded()
    }
```

Run `Clappr_Example`

### Expected Result (iOS)
![Simulator Screen Shot - iPhone Xs - 2020-08-05 at 16 48 02](https://user-images.githubusercontent.com/6214228/89457886-7b029d80-d73c-11ea-98d6-ccca001116fb.png)

### Expected Result (iPadOS)
![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2020-08-05 at 17 12 11](https://user-images.githubusercontent.com/6214228/89459377-ecdbe680-d73e-11ea-8556-34af3f1f8e9d.png)

Run `Clappr_tvOS_Example`

### Expected Result (tvOS)
![Simulator Screen Shot - Apple TV 4K (at 1080p) - 2020-08-05 at 17 06 53](https://user-images.githubusercontent.com/6214228/89458922-3972f200-d73e-11ea-9ec6-837919bbe0a9.png)
