### PR TITLE
Subtitle style based on Player size

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		48EC492122A1908300DC7A2D /* AVPlayerItem+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EC491F22A1908300DC7A2D /* AVPlayerItem+Ext.swift */; };
 		48F1E971232296F600EAD6A1 /* DrawerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F1E970232296F600EAD6A1 /* DrawerPluginTests.swift */; };
 		48F1E97423229FDC00EAD6A1 /* DrawerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F1E97323229FDC00EAD6A1 /* DrawerPlugin.swift */; };
+		521D893924E462D100AAA58C /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491924D88BD60049DAF7 /* FontTests.swift */; };
 		522C8997246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */; };
 		522C8998246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */; };
 		5232A455248A73780095D174 /* UIFocusEnvironment+ExtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5232A454248A73780095D174 /* UIFocusEnvironment+ExtTests.swift */; };
@@ -2166,6 +2167,7 @@
 				C9096F1F24086B05001BB2A4 /* OHTTPStubsHelper.swift in Sources */,
 				C9C8BFAF2305C9B800A8FA55 /* SimpleCorePluginTests.swift in Sources */,
 				32755E2421503A830088724E /* PlaybackTests.swift in Sources */,
+				521D893924E462D100AAA58C /* FontTests.swift in Sources */,
 				48A29BFA221C8F290004AD3B /* CoreStub.swift in Sources */,
 				486E8DFE23156A880024E6CA /* OverlayPluginTests.swift in Sources */,
 				522C8998246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -150,6 +150,8 @@
 		48EC492122A1908300DC7A2D /* AVPlayerItem+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EC491F22A1908300DC7A2D /* AVPlayerItem+Ext.swift */; };
 		48F1E971232296F600EAD6A1 /* DrawerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F1E970232296F600EAD6A1 /* DrawerPluginTests.swift */; };
 		48F1E97423229FDC00EAD6A1 /* DrawerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F1E97323229FDC00EAD6A1 /* DrawerPlugin.swift */; };
+		5217467824EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5217467724EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift */; };
+		5217467924EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5217467724EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift */; };
 		521D893924E462D100AAA58C /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B491924D88BD60049DAF7 /* FontTests.swift */; };
 		522C8997246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */; };
 		522C8998246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */; };
@@ -515,6 +517,7 @@
 		48EC491F22A1908300DC7A2D /* AVPlayerItem+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayerItem+Ext.swift"; sourceTree = "<group>"; };
 		48F1E970232296F600EAD6A1 /* DrawerPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPluginTests.swift; sourceTree = "<group>"; };
 		48F1E97323229FDC00EAD6A1 /* DrawerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPlugin.swift; sourceTree = "<group>"; };
+		5217467724EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackSubtitleTests.swift; sourceTree = "<group>"; };
 		522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackStopActionTests.swift; sourceTree = "<group>"; };
 		5232A454248A73780095D174 /* UIFocusEnvironment+ExtTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFocusEnvironment+ExtTests.swift"; sourceTree = "<group>"; };
 		571B7B30217503BB005C0942 /* NowPlayingServiceStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingServiceStub.swift; sourceTree = "<group>"; };
@@ -1353,6 +1356,7 @@
 				C9A1CCAF23E995D000621048 /* AVFoundationPlaybackMediaSelectionTests.swift */,
 				7BD29B8623FDE20000C82098 /* AVFoundationPlaybackQualityMetricsTests.swift */,
 				522C8996246D938B008F5856 /* AVFoundationPlaybackStopActionTests.swift */,
+				5217467724EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift */,
 			);
 			path = Playback;
 			sourceTree = "<group>";
@@ -2164,6 +2168,7 @@
 				571B7B2B2175015F005C0942 /* AVURLAssetStub.swift in Sources */,
 				C934669B2305C13F0062E8DE /* String+Ext.swift in Sources */,
 				571B7B292175013F005C0942 /* AVFoundationPlaybackTests.swift in Sources */,
+				5217467924EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift in Sources */,
 				C9096F1F24086B05001BB2A4 /* OHTTPStubsHelper.swift in Sources */,
 				C9C8BFAF2305C9B800A8FA55 /* SimpleCorePluginTests.swift in Sources */,
 				32755E2421503A830088724E /* PlaybackTests.swift in Sources */,
@@ -2260,6 +2265,7 @@
 				48D81F1F21FA31FA00B2D52E /* QuickSeekCorePluginTests.swift in Sources */,
 				571B7B2E21750204005C0942 /* AVFoundationPlaybackTests.swift in Sources */,
 				7BD29B7F23FDDE7300C82098 /* PlayerMock.swift in Sources */,
+				5217467824EAE54D00BDBC43 /* AVFoundationPlaybackSubtitleTests.swift in Sources */,
 				EDF652221D467CCA00627C48 /* UICorePluginTests.swift in Sources */,
 				48F1E971232296F600EAD6A1 /* DrawerPluginTests.swift in Sources */,
 				C94D8CED221B1DDD00C7855D /* ContainerPluginTests.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Font/TextStyle.swift
+++ b/Sources/Clappr/Classes/Base/Font/TextStyle.swift
@@ -5,7 +5,7 @@ public enum TextStyle {
     case characterBackground(UIColor)
     case background(UIColor)
     case foreground(UIColor)
-    case fontSize(Int)
+    case fontSizePercentage(Double)
     case bold
     case italic
     case underline
@@ -19,7 +19,7 @@ public enum TextStyle {
         case .background: return String(kCMTextMarkupAttribute_BackgroundColorARGB)
         case .characterBackground: return String(kCMTextMarkupAttribute_CharacterBackgroundColorARGB)
         case .foreground: return String(kCMTextMarkupAttribute_ForegroundColorARGB)
-        case .fontSize: return String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight)
+        case .fontSizePercentage: return String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight)
         case .bold: return String(kCMTextMarkupAttribute_BoldStyle)
         case .underline: return String(kCMTextMarkupAttribute_UnderlineStyle)
         case .italic: return String(kCMTextMarkupAttribute_ItalicStyle)
@@ -34,7 +34,7 @@ public enum TextStyle {
         switch self {
         case .bold, .italic, .underline:
             return AVTextStyleRule(textMarkupAttributes: [ self.key: true])!
-        case .fontSize(let size):
+        case .fontSizePercentage(let size):
             return AVTextStyleRule(textMarkupAttributes: [ self.key: size])!
         case .background(let color), .characterBackground(let color), .foreground(let color):
             return AVTextStyleRule(textMarkupAttributes: [ self.key: color.argb])!

--- a/Sources/Clappr/Classes/Base/Font/TextStyle.swift
+++ b/Sources/Clappr/Classes/Base/Font/TextStyle.swift
@@ -6,6 +6,7 @@ public enum TextStyle {
     case background(UIColor)
     case foreground(UIColor)
     case fontSizePercentage(Double)
+    case writingSizePercentage(Double)
     case bold
     case italic
     case underline
@@ -20,6 +21,7 @@ public enum TextStyle {
         case .characterBackground: return String(kCMTextMarkupAttribute_CharacterBackgroundColorARGB)
         case .foreground: return String(kCMTextMarkupAttribute_ForegroundColorARGB)
         case .fontSizePercentage: return String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight)
+        case .writingSizePercentage: return String(kCMTextMarkupAttribute_WritingDirectionSizePercentage)
         case .bold: return String(kCMTextMarkupAttribute_BoldStyle)
         case .underline: return String(kCMTextMarkupAttribute_UnderlineStyle)
         case .italic: return String(kCMTextMarkupAttribute_ItalicStyle)
@@ -34,7 +36,7 @@ public enum TextStyle {
         switch self {
         case .bold, .italic, .underline:
             return AVTextStyleRule(textMarkupAttributes: [ self.key: true])!
-        case .fontSizePercentage(let size):
+        case .fontSizePercentage(let size), .writingSizePercentage(let size):
             return AVTextStyleRule(textMarkupAttributes: [ self.key: size])!
         case .background(let color), .characterBackground(let color), .foreground(let color):
             return AVTextStyleRule(textMarkupAttributes: [ self.key: color.argb])!

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -309,7 +309,10 @@ open class AVFoundationPlayback: Playback {
     @objc func setupObservers() {
         guard let player = player else { return }
         observers += [
-            view.observe(\.bounds) { [weak self] view, _ in self?.maximizePlayer(within: view) },
+            view.observe(\.bounds) { [weak self] view, _ in
+                self?.maximizePlayer(within: view)
+                self?.hideSubtitleForSmallScreen()
+            },
             player.observe(\.currentItem?.status) { [weak self] player, _ in self?.handleStatusChangedEvent(player) },
             player.observe(\.currentItem?.loadedTimeRanges) { [weak self] player, _ in self?.triggerDidUpdateBuffer(with: player) },
             player.observe(\.currentItem?.seekableTimeRanges) { [weak self] player, _ in self?.handleSeekableTimeRangesEvent(player) },

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -85,9 +85,9 @@ open class AVFoundationPlayback: Playback {
             if newValue == MediaOption.offSubtitle {
                 setMediaSelectionOption(nil, characteristic: .legible)
             } else {
+                lastSelectedSubtitle = newValue
                 let newOption = newValue?.avMediaSelectionOption
                 setMediaSelectionOption(newOption, characteristic: .legible)
-                lastSelectedSubtitle = newValue
             }
 
             triggerMediaOptionSelectedEvent(option: newValue, event: .didSelectSubtitle)

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -67,7 +67,7 @@ open class AVFoundationPlayback: Playback {
         }
         set {
             if newValue == MediaOption.offSubtitle {
-                turnOffSubtitle()
+                hideSubtitle()
             } else {
                 let newOption = newValue?.avMediaSelectionOption
                 setMediaSelectionOption(newOption, characteristic: .legible)
@@ -712,7 +712,7 @@ open class AVFoundationPlayback: Playback {
         return player?.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic)
     }
 
-    public func turnOffSubtitle() {
+    open func hideSubtitle() {
         setMediaSelectionOption(nil, characteristic: .legible)
     }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -67,7 +67,7 @@ open class AVFoundationPlayback: Playback {
         }
         set {
             if newValue == MediaOption.offSubtitle {
-                setMediaSelectionOption(nil, characteristic: .legible)
+                turnOffSubtitle()
             } else {
                 let newOption = newValue?.avMediaSelectionOption
                 setMediaSelectionOption(newOption, characteristic: .legible)
@@ -710,6 +710,10 @@ open class AVFoundationPlayback: Playback {
 
     private func mediaSelectionGroup(_ characteristic: AVMediaCharacteristic) -> AVMediaSelectionGroup? {
         return player?.currentItem?.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic)
+    }
+
+    public func turnOffSubtitle() {
+        setMediaSelectionOption(nil, characteristic: .legible)
     }
 
     deinit {

--- a/Tests/Clappr_Tests/Classes/Base/FontTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/FontTests.swift
@@ -260,7 +260,7 @@ class FontTests: QuickSpec {
             
             context(".fontSize") {
                 it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight and the value be equal to 12") {
-                    let style: TextStyle = .fontSize(12)
+                    let style: TextStyle = .fontSizePercentage(12)
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight) : 12])
                     
                     expect(style.key).to(equal(String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight)))
@@ -348,7 +348,7 @@ class FontTests: QuickSpec {
                         .direction(.ltr),
                         .edge(.dropShadow),
                         .font(.casual),
-                        .fontSize(12),
+                        .fontSizePercentage(12),
                         .foreground(.blue),
                         .italic,
                         .underline

--- a/Tests/Clappr_Tests/Classes/Base/FontTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/FontTests.swift
@@ -258,7 +258,7 @@ class FontTests: QuickSpec {
                 }
             }
             
-            context(".fontSize") {
+            context(".fontSizePercentage") {
                 it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight and the value be equal to 12") {
                     let style: TextStyle = .fontSizePercentage(12)
                     let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_BaseFontSizePercentageRelativeToVideoHeight) : 12])
@@ -267,7 +267,17 @@ class FontTests: QuickSpec {
                     expect(style.value).to(equal(expectedValue))
                 }
             }
-            
+
+            context(".writingSizePercentage") {
+                it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_WritingDirectionSizePercentage and the value be equal to 92") {
+                    let style: TextStyle = .writingSizePercentage(92)
+                    let expectedValue = AVTextStyleRule(textMarkupAttributes: [String(kCMTextMarkupAttribute_WritingDirectionSizePercentage) : 92])
+
+                    expect(style.key).to(equal(String(kCMTextMarkupAttribute_WritingDirectionSizePercentage)))
+                    expect(style.value).to(equal(expectedValue))
+                }
+            }
+
             context(".bold") {
                 it("should the value be equal an AVTextStyleRyle with the key equal to kCMTextMarkupAttribute_BoldStyle and the value be equal to true") {
                     let style: TextStyle = .bold

--- a/Tests/Clappr_Tests/Classes/Mocks/PlayerItemMock.swift
+++ b/Tests/Clappr_Tests/Classes/Mocks/PlayerItemMock.swift
@@ -1,11 +1,17 @@
 import AVFoundation
 
+@testable import Clappr
+
 class PlayerItemMock: AVPlayerItem {
     private var itemAccessLog: AVPlayerItemAccessLog
     private var isFinished: Bool
     private var durationMocked: CMTime
     private var currentTimeMocked: CMTime
-    
+    private var assetMocked: AVAssetMock
+
+    var mediaSelectionOptionMocked: AVMediaSelectionOption?
+
+    override var asset: AVAsset { assetMocked }
     override var duration: CMTime { durationMocked }
     
     init(accessLogEvent: AccessLogEventMock, isFinished: Bool = false) {
@@ -13,10 +19,23 @@ class PlayerItemMock: AVPlayerItem {
         self.isFinished = isFinished
         self.durationMocked = CMTimeMakeWithSeconds(100, preferredTimescale: Int32(NSEC_PER_SEC))
         self.currentTimeMocked = CMTimeMakeWithSeconds(0, preferredTimescale: Int32(NSEC_PER_SEC))
-        
+        self.assetMocked = AVAssetMock()
+
         super.init(asset: AVAsset(url: URL(string: "http://clappr.sample/master.m3u8")!), automaticallyLoadedAssetKeys: nil)
     }
     
     override func currentTime() -> CMTime { isFinished ? duration : currentTimeMocked }
     override func accessLog() -> AVPlayerItemAccessLog? { itemAccessLog }
+
+    override func select(_ mediaSelectionOption: AVMediaSelectionOption?, in mediaSelectionGroup: AVMediaSelectionGroup) {
+        mediaSelectionOptionMocked = MediaOption.mockedSubtitle.avMediaSelectionOption
+    }
+}
+
+class AVAssetMock: AVAsset {
+    override func mediaSelectionGroup(forMediaCharacteristic mediaCharacteristic: AVMediaCharacteristic) -> AVMediaSelectionGroup? { AVMediaSelectionGroup() }
+}
+
+extension MediaOption {
+    static var mockedSubtitle = MediaOption(name: "Mocked", type: .subtitle, language: "moc", raw: AVMediaSelectionOption())
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
@@ -52,23 +52,6 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
 
                         expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("pt"))
                     }
-
-                    context("and sets selectedSubtitle to off") {
-                        it("sets language to off") {
-                            let options = [
-                                kSourceUrl: "http://clappr.io/highline.mp4",
-                                kDefaultSubtitle: "off"
-                            ]
-                            let avfoundationPlayback = AVFoundationPlayback(options: options)
-                            avfoundationPlayback.view.bounds = CGRect(x: 0, y: 0, width: 1920, height: 1080)
-
-                            avfoundationPlayback.play()
-
-                            avfoundationPlayback.selectedSubtitle = MediaOption.offSubtitle
-
-                            expect(avfoundationPlayback.selectedSubtitle?.language).toEventually(equal("off"))
-                        }
-                    }
                 }
             }
         }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackMediaSelectionTests.swift
@@ -46,6 +46,7 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
                             kDefaultSubtitle: "pt"
                         ]
                         let avfoundationPlayback = AVFoundationPlayback(options: options)
+                        avfoundationPlayback.view.bounds = CGRect(x: 0, y: 0, width: 1920, height: 1080)
 
                         avfoundationPlayback.play()
 
@@ -56,9 +57,11 @@ class AVFoundationPlaybackMediaSelectionTests: QuickSpec {
                         it("sets language to off") {
                             let options = [
                                 kSourceUrl: "http://clappr.io/highline.mp4",
-                                kDefaultSubtitle: "pt"
+                                kDefaultSubtitle: "off"
                             ]
                             let avfoundationPlayback = AVFoundationPlayback(options: options)
+                            avfoundationPlayback.view.bounds = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+
                             avfoundationPlayback.play()
 
                             avfoundationPlayback.selectedSubtitle = MediaOption.offSubtitle

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackSubtitleTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackSubtitleTests.swift
@@ -6,12 +6,12 @@ import Nimble
 class AVFoundationPlaybackSubtitleTests: QuickSpec {
     override func spec() {
         describe(".AVFoundationPlaybackSubtitleTests") {
-            describe("when turnOffSubtitle is called") {
+            describe("when hideSubtitle is called") {
                 it("sets subtitle to off") {
                     let avfoundationPlayback = AVFoundationPlayback(options: [:])
                     avfoundationPlayback.player = PlayerMock()
 
-                    avfoundationPlayback.turnOffSubtitle()
+                    avfoundationPlayback.hideSubtitle()
 
                     let playerItemMock = avfoundationPlayback.player?.currentItem as? PlayerItemMock
                     expect(playerItemMock?.mediaSelectionOptionMocked).to(equal(MediaOption.mockedSubtitle.avMediaSelectionOption))

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackSubtitleTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackSubtitleTests.swift
@@ -1,0 +1,22 @@
+import Quick
+import Nimble
+
+@testable import Clappr
+
+class AVFoundationPlaybackSubtitleTests: QuickSpec {
+    override func spec() {
+        describe(".AVFoundationPlaybackSubtitleTests") {
+            describe("when turnOffSubtitle is called") {
+                it("sets subtitle to off") {
+                    let avfoundationPlayback = AVFoundationPlayback(options: [:])
+                    avfoundationPlayback.player = PlayerMock()
+
+                    avfoundationPlayback.turnOffSubtitle()
+
+                    let playerItemMock = avfoundationPlayback.player?.currentItem as? PlayerItemMock
+                    expect(playerItemMock?.mediaSelectionOptionMocked).to(equal(MediaOption.mockedSubtitle.avMediaSelectionOption))
+                }
+            }
+        }
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackSubtitleTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackSubtitleTests.swift
@@ -6,15 +6,19 @@ import Nimble
 class AVFoundationPlaybackSubtitleTests: QuickSpec {
     override func spec() {
         describe(".AVFoundationPlaybackSubtitleTests") {
-            describe("when hideSubtitle is called") {
-                it("sets subtitle to off") {
-                    let avfoundationPlayback = AVFoundationPlayback(options: [:])
-                    avfoundationPlayback.player = PlayerMock()
+            describe("#hideSubtitleForSmallScreen") {
+                context("when view is resized to a size smaller than 280x156") {
+                    it("sets subtitle to off") {
+                        let avfoundationPlayback = AVFoundationPlayback(options: [:])
+                        avfoundationPlayback.player = PlayerMock()
+                        avfoundationPlayback.setupObservers()
 
-                    avfoundationPlayback.hideSubtitle()
+                        avfoundationPlayback.selectedSubtitle = MediaOption.mockedSubtitle
 
-                    let playerItemMock = avfoundationPlayback.player?.currentItem as? PlayerItemMock
-                    expect(playerItemMock?.mediaSelectionOptionMocked).to(equal(MediaOption.mockedSubtitle.avMediaSelectionOption))
+                        avfoundationPlayback.view.bounds = CGRect(x: 0, y: 0, width: 279, height: 155)
+
+                        expect(avfoundationPlayback.selectedSubtitle?.language).to(equal("off"))
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Goal

Introduce the following capabilities for playback subtitles:

1. Change the subtitle size;
2. Change the subtitle container size;
3. Automatically hide subtitles when the player was resized to small sizes.


# How to Test

## 1 - Show/Hide the Subtitle

On `DashboardViewController.swift#19` change the code:

```swift
let options: Options = [
    kSourceUrl: "http://sample.vodobox.com/planete_interdite/planete_interdite_alternate.m3u8",
    kPosterUrl: "http://clappr.io/poster.png",
    kFullscreen: switchFullscreen.isOn,
    kFullscreenByApp: switchFullscreenControledByApp.isOn,
    kDefaultSubtitle: "fre"
]
```

On `AVFoundationPlayback.swift#65` change the code:

```swift
private let minSizeToShowSubtitle = CGSize(width: 376, height: 212)
```

- Run the Clappr_Example
- On portrait, the subtitle should not appear
- Put the app on fullscreen mode
- The subtitle should appear

## 2 - Subtitle Container Size

On `AVFoundationPlayback.swift#680` add the code:

```swift
applySubtitleStyle()
```

On `AVFoundationPlayback.swift#684` add the code:

```swift
func applySubtitleStyle() {
    applySubtitleStyle(with: [
        .writingSizePercentage(10)
    ])
}
```

The result should be similar to the image below (_occupying 10% of the screen width_):
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-19 at 10 54 21](https://user-images.githubusercontent.com/28604291/90644003-9ecce580-e20a-11ea-8992-c2c83e56f87f.png)

## 3 - Subtitle Font Size 

On `AVFoundationPlayback.swift#680` add the code:

```swift
applySubtitleStyle()
```

On `AVFoundationPlayback.swift#684` add the code:

```swift
func applySubtitleStyle() {
    applySubtitleStyle(with: [
        .fontSizePercentage(50)
    ])
}
```

The result should be similar to the image below (_occupying 50% of the screen height_):
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-19 at 10 57 39](https://user-images.githubusercontent.com/28604291/90644241-e18ebd80-e20a-11ea-8487-d6ffc0af8236.png)
