### PR TITLE
Fix Drawer Exit Fullscreen

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -91,6 +91,8 @@ open class BottomDrawerPlugin: DrawerPlugin {
     private func moveUp(with duration: TimeInterval = ClapprAnimationDuration.mediaControlShow) {
         guard let superview = view.superview else { return }
 
+        toggleContentInteraction(enabled: true)
+
         topDistanceFromBottom.constant = (overlayViewFrame.height / 2) * -1
         UIView.animate(withDuration: duration) {
             superview.layoutIfNeeded()
@@ -99,6 +101,8 @@ open class BottomDrawerPlugin: DrawerPlugin {
 
     private func moveDown(with duration: TimeInterval = ClapprAnimationDuration.mediaControlHide) {
         guard let superview = view.superview else { return }
+
+        toggleContentInteraction(enabled: false)
 
         topDistanceFromBottom.constant = placeholder * -1
         UIView.animate(withDuration: duration) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -89,22 +89,20 @@ open class BottomDrawerPlugin: DrawerPlugin {
     }
 
     private func moveUp(with duration: TimeInterval = ClapprAnimationDuration.mediaControlShow) {
-        guard let superview = view.superview else { return }
-
         toggleContentInteraction(enabled: true)
-
         topDistanceFromBottom.constant = (overlayViewFrame.height / 2) * -1
-        UIView.animate(withDuration: duration) {
-            superview.layoutIfNeeded()
-        }
+        refreshSuperviewLayout(with: duration)
     }
 
     private func moveDown(with duration: TimeInterval = ClapprAnimationDuration.mediaControlHide) {
+        toggleContentInteraction(enabled: false)
+        topDistanceFromBottom.constant = placeholder * -1
+        refreshSuperviewLayout(with: duration)
+    }
+
+    private func refreshSuperviewLayout(with duration: TimeInterval) {
         guard let superview = view.superview else { return }
 
-        toggleContentInteraction(enabled: false)
-
-        topDistanceFromBottom.constant = placeholder * -1
         UIView.animate(withDuration: duration) {
             superview.layoutIfNeeded()
         }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -2,7 +2,8 @@ open class BottomDrawerPlugin: DrawerPlugin {
     private var initialCenterY: CGFloat = .zero
 
     private var maxHeight: CGFloat {
-        return coreViewFrame.height/2
+        return overlayViewFrame.height/2
+    }
     }
 
     open var height: CGFloat {
@@ -117,7 +118,7 @@ open class BottomDrawerPlugin: DrawerPlugin {
     }
 
     private func handleGestureEnded(for newYCoordinate: CGFloat) {
-        let isHalfWayOpen = newYCoordinate <= minYToShow
+        let isHalfWayOpen = abs(newYCoordinate - overlayViewFrame.height) >= minHeightToShow
         isHalfWayOpen ? showDrawerPlugin() : hideDrawerPlugin()
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -19,7 +19,7 @@ open class BottomDrawerPlugin: DrawerPlugin {
         min(desiredHeight, maxHeight)
     }
     
-    private var openedYPosition: CGFloat {
+    private var immersionPosition: CGFloat {
         actualHeight * -1
     }
 
@@ -87,7 +87,7 @@ open class BottomDrawerPlugin: DrawerPlugin {
 
     private func moveUp(with duration: TimeInterval = ClapprAnimationDuration.mediaControlShow) {
         toggleContentInteraction(enabled: true)
-        drawerTopConstraint.constant = openedYPosition
+        drawerTopConstraint.constant = immersionPosition
         refreshSuperviewLayout(with: duration)
     }
 
@@ -150,17 +150,19 @@ open class BottomDrawerPlugin: DrawerPlugin {
         if canDrag(with: newBottomDistance) {
             drawerTopConstraint.constant = newBottomDistance
 
-            calculateMediaControlAlpha(for: newBottomDistance)
+            let alpha = calculateMediaControlAlpha(for: newBottomDistance)
+            core?.trigger(InternalEvent.didDragDrawer.rawValue, userInfo: ["alpha": alpha])
+
         }
     }
 
-    private func calculateMediaControlAlpha(for newBottomDistance: CGFloat) {
+    private func calculateMediaControlAlpha(for newBottomDistance: CGFloat) -> CGFloat {
         let maxOpacity: CGFloat = 1.0
         let distanceFromBottom = abs(newBottomDistance)
         let portionShown = distanceFromBottom / actualHeight
         let mediaControlAlpha = maxOpacity - portionShown
 
-        core?.trigger(InternalEvent.didDragDrawer.rawValue, userInfo: ["alpha": mediaControlAlpha])
+        return mediaControlAlpha
     }
 
     private func handleGestureEnded(for newYCoordinate: CGFloat) {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -1,6 +1,4 @@
 open class BottomDrawerPlugin: DrawerPlugin {
-    private var initialCenterY: CGFloat = .zero
-
     private var maxHeight: CGFloat {
         return overlayViewFrame.height/2
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -18,6 +18,7 @@ open class DrawerPlugin: OverlayPlugin {
 
     open var overlayViewFrame: CGRect {
         guard let overlayView = view.superview else { return .zero }
+
         return overlayView.frame
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -16,9 +16,9 @@ open class DrawerPlugin: OverlayPlugin {
         return .zero
     }
 
-    open var coreViewFrame: CGRect {
-        guard let core = core else { return .zero }
-        return core.view.frame
+    open var overlayViewFrame: CGRect {
+        guard let overlayView = view.superview else { return .zero }
+        return overlayView.frame
     }
 
     private(set) var isClosed: Bool = true {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -86,7 +86,6 @@ open class DrawerPlugin: OverlayPlugin {
     }
 
     private func toggleIsClosed(to newValue: Bool) {
-        guard isClosed != newValue else { return }
         isClosed = newValue
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/DrawerPlugin.swift
@@ -51,18 +51,10 @@ open class DrawerPlugin: OverlayPlugin {
     }
 
     private func bindCoreEvents(context: UIObject) {
-        let eventsToRender: [Event] = [.didEnterFullscreen, .didExitFullscreen, .didChangeScreenOrientation]
-
         listenTo(context, eventName: InternalEvent.didTappedCore.rawValue) { [weak self] _ in
             guard self?.isClosed == false else { return }
 
             context.trigger(.hideDrawerPlugin)
-        }
-
-        eventsToRender.forEach {
-            listenTo(context, event: $0) { [weak self] _ in
-                self?.render()
-            }
         }
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -147,6 +147,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     private func onDrawerDragged(info: EventUserInfo) {
         guard let alpha = info?["alpha"] as? CGFloat else { return }
 
+        keepVisible()
+        view.isHidden = false
         view.alpha = alpha
     }
     

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPlugin.swift
@@ -11,6 +11,8 @@ public class QuickSeekMediaControlPlugin: QuickSeekPlugin {
     }
     
     override func removeGesture() {
+        guard let doubleTapGesture = doubleTapGesture else { return }
+        
         mediaControl?.mediaControlView.removeGestureRecognizer(doubleTapGesture)
     }
     

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
@@ -7,6 +7,8 @@ public class QuickSeekCorePlugin: QuickSeekPlugin {
     }
     
     override func removeGesture() {
+        guard let doubleTapGesture = doubleTapGesture else { return }
+
         core?.view.removeGestureRecognizer(doubleTapGesture)
     }
     

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -229,14 +229,14 @@ class CoreTests: QuickSpec {
                         let core = Core(options: options)
                         core.parentView = UIView()
                         core.parentController = self.rootViewController()
-                        var callbackWasCall = false
+                        var callbackWasCalled = false
                         core.on(Event.didEnterFullscreen.rawValue) { _ in
-                            callbackWasCall = true
+                            callbackWasCalled = true
                         }
 
                         core.render()
 
-                        expect(callbackWasCall).toEventually(beTrue(), timeout: 5)
+                        expect(callbackWasCalled).toEventually(beTrue(), timeout: 5)
                         expect(core.parentView?.subviews.contains(core.view)).to(beFalse())
                         expect(core.fullscreenController?.view.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beTrue())

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -236,7 +236,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(callbackWasCall).toEventually(beTrue())
+                        expect(callbackWasCall).toEventually(beTrue(), timeout: 5)
                         expect(core.parentView?.subviews.contains(core.view)).to(beFalse())
                         expect(core.fullscreenController?.view.subviews.contains(core.view)).to(beTrue())
                         expect(core.isFullscreen).to(beTrue())

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -47,41 +47,49 @@ class BottomDrawerPluginTests: QuickSpec {
                     core.view = UIView(frame: CGRect(x: 0, y: 0, width: coreViewWidth, height: coreViewHeight))
                 }
 
-                context("width anchor") {
-                    it("has a width anchor") {
-                        let view = UIView(frame: .zero)
+                context("width size") {
+                    it("has a width with the same size as superview") {
+                        let view = UIView(frame: .init(origin: .zero, size: .init(width: coreViewWidth, height: coreViewHeight)))
                         view.addSubview(plugin.view)
 
                         plugin.render()
+                        plugin.view.layoutIfNeeded()
 
-                        let widthConstraint = plugin.view.superview?.constraints.first { $0.firstAttribute == .width }
-                        expect(widthConstraint?.constant).to(equal(0))
+
+                        let width = plugin.view.frame.width
+                        expect(width).to(equal(coreViewWidth))
                     }
                 }
 
-                context("height anchor") {
-                    context("and the maxHeight is smaller than height") {
-                        it("has a height anchor on superview") {
-                            let view = UIView(frame: .zero)
-                            view.addSubview(plugin.view)
+                context("actualHeight size") {
+                    context("when the desiredHeight is greater than the default value") {
+                        it("sets actualHeight equal to default value") {
+                            let view = UIView(frame: .init(origin: .zero, size: .init(width: coreViewWidth, height: coreViewHeight)))
+                            let pluginMock = BottomDrawerPluginMock(context: core)
+                            view.addSubview(pluginMock.view)
+                            pluginMock._desiredHeight = coreViewHeight
 
-                            plugin.render()
+                            pluginMock.render()
+                            pluginMock.view.layoutIfNeeded()
 
-                            let heightConstraint = plugin.view.superview?.constraints.first { $0.firstAttribute == .height }
-                            expect(heightConstraint?.constant).to(equal(0))
+                            let height = pluginMock.view.frame.height
+                            expect(height).to(equal(coreViewHeight/2))
                         }
                     }
 
-                    context("and the maxHeight is greater than height") {
-                        it("has a height anchor on superview") {
-                            let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 2002))
+                    context("when the desiredHeight is smaller than the default value") {
+                        it("sets actualHeight equal to desiredHeight") {
+                            let view = UIView(frame: .init(origin: .zero, size: .init(width: coreViewWidth, height: coreViewHeight)))
                             let pluginMock = BottomDrawerPluginMock(context: core)
                             view.addSubview(pluginMock.view)
+                            pluginMock._desiredHeight = coreViewHeight/2 - 1
 
                             pluginMock.render()
+                            pluginMock.view.layoutIfNeeded()
 
-                            let heightConstraint = pluginMock.view.constraints.first { $0.firstAttribute == .height }
-                            expect(heightConstraint?.constant).to(equal(1000))
+                            let expectedHeight = pluginMock._desiredHeight
+                            let height = pluginMock.view.frame.height
+                            expect(height).to(equal(expectedHeight))
                         }
                     }
                 }
@@ -159,6 +167,7 @@ class BottomDrawerPluginTests: QuickSpec {
 }
 
 class BottomDrawerPluginMock: BottomDrawerPlugin {
-    override var height: CGFloat { 1000 }
+    var _desiredHeight: CGFloat = 1000
+    override var desiredHeight: CGFloat { _desiredHeight }
     override var placeholder: CGFloat { 18 }
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -57,7 +57,7 @@ class BottomDrawerPluginTests: QuickSpec {
 
 
                         let width = plugin.view.frame.width
-                        expect(width).to(equal(coreViewWidth))
+                        expect(width).to(equal(320))
                     }
                 }
 
@@ -73,7 +73,7 @@ class BottomDrawerPluginTests: QuickSpec {
                             pluginMock.view.layoutIfNeeded()
 
                             let height = pluginMock.view.frame.height
-                            expect(height).to(equal(coreViewHeight/2))
+                            expect(height).to(equal(50))
                         }
                     }
 
@@ -87,9 +87,8 @@ class BottomDrawerPluginTests: QuickSpec {
                             pluginMock.render()
                             pluginMock.view.layoutIfNeeded()
 
-                            let expectedHeight = pluginMock._desiredHeight
                             let height = pluginMock.view.frame.height
-                            expect(height).to(equal(expectedHeight))
+                            expect(height).to(equal(49))
                         }
                     }
                 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -32,7 +32,7 @@ class BottomDrawerPluginTests: QuickSpec {
 
                 it("sets touches in view for UIPanGestureRecognizer") {
                     let panGestureRecognizer = plugin.view.gestureRecognizers?.first(where: {$0 is UIPanGestureRecognizer})
-                    
+
                     expect(panGestureRecognizer?.cancelsTouchesInView).to(beTrue())
                 }
 
@@ -53,26 +53,56 @@ class BottomDrawerPluginTests: QuickSpec {
                     core.view = UIView(frame: CGRect(x: 0, y: 0, width: coreViewWidth, height: coreViewHeight))
                 }
 
-                it("has origin x on zero and y equal to parentView height") {
-                    plugin.render()
+                context("width anchor") {
+                    it("has a width anchor") {
+                        let view = UIView(frame: .zero)
+                        view.addSubview(plugin.view)
 
-                    expect(plugin.view.frame.origin).to(equal(CGPoint(x: .zero, y: coreViewHeight)))
+                        plugin.render()
+
+                        let widthConstraint = plugin.view.superview?.constraints.first { $0.firstAttribute == .width }
+                        expect(widthConstraint?.constant).to(equal(0))
+                    }
                 }
 
-                it("has a view frame size equals to his size") {
-                    plugin.render()
+                context("height anchor") {
+                    context("and the maxHeight is smaller than height") {
+                        it("has a height anchor on superview") {
+                            let view = UIView(frame: .zero)
+                            view.addSubview(plugin.view)
 
-                    expect(plugin.view.frame.size).to(equal(CGSize(width: coreViewWidth, height: coreViewHeight/2)))
+                            plugin.render()
+
+                            let heightConstraint = plugin.view.superview?.constraints.first { $0.firstAttribute == .height }
+                            expect(heightConstraint?.constant).to(equal(0))
+                        }
+                    }
+
+                    context("and the maxHeight is greater than height") {
+                        it("has a height anchor on superview") {
+                            let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 2002))
+                            let pluginMock = BottomDrawerPluginMock(context: core)
+                            view.addSubview(pluginMock.view)
+
+                            pluginMock.render()
+
+                            let heightConstraint = pluginMock.view.constraints.first { $0.firstAttribute == .height }
+                            expect(heightConstraint?.constant).to(equal(1000))
+                        }
+                    }
                 }
 
                 context("when plugin request a height greater then the limit") {
                     it("uses the height limit instead") {
-                        core.view = UIView(frame: CGRect(x: 0, y: 0, width: coreViewWidth, height: coreViewHeight))
+                        let view = UIView(frame: CGRect(x: 0, y: 0, width: coreViewWidth, height: coreViewHeight))
+                        view.heightAnchor.constraint(equalToConstant: 200).isActive = true
                         let pluginMock = BottomDrawerPluginMock(context: core)
+                        view.addSubview(pluginMock.view)
 
                         pluginMock.render()
 
-                        expect(pluginMock.view.frame.size).to(equal(CGSize(width: coreViewWidth, height: coreViewHeight/2)))
+                        let heightConstraint = pluginMock.view.superview?.constraints.first { $0.firstAttribute == .height }
+                        expect(heightConstraint?.constant).to(equal(200))
                     }
                 }
             }
@@ -80,20 +110,24 @@ class BottomDrawerPluginTests: QuickSpec {
             describe("#events") {
                 var core: CoreStub!
                 var plugin: BottomDrawerPlugin!
+                var view: UIView!
 
                 beforeEach {
-                    Loader.shared.resetPlugins()
                     core = CoreStub()
-                    plugin = BottomDrawerPlugin(context: core)
+                    plugin = BottomDrawerPluginMock(context: core)
                     core.view = UIView(frame: CGRect(x: 0, y: 0, width: coreViewWidth, height: coreViewHeight))
+                    view = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
+                    view.addSubview(plugin.view)
+
                     plugin.render()
                 }
 
                 context("when the showDrawerPlugin event is triggered") {
-                    it("push up the drawer to half of core height") {
+                    it("push up the drawer to half of super view height") {
                         core.trigger(.showDrawerPlugin)
 
-                        expect(plugin.view.frame.origin.y).to(equal(coreViewHeight/2))
+                        let heightConstraint = plugin.view.superview?.constraints.first { $0.firstAttribute == .top }
+                        expect(heightConstraint?.constant).to(equal(-25))
                     }
 
                     it("enables user interaction on plugin's subviews") {
@@ -108,10 +142,11 @@ class BottomDrawerPluginTests: QuickSpec {
                 }
 
                 context("when the hideDrawer event is triggered") {
-                    it("push down the drawer to core height") {
+                    it("push down the drawer to placeholder") {
                         core.trigger(.hideDrawerPlugin)
 
-                        expect(plugin.view.frame.origin.y).to(equal(coreViewHeight))
+                        let heightConstraint = plugin.view.superview?.constraints.first { $0.firstAttribute == .top }
+                        expect(heightConstraint?.constant).to(equal(-18))
                     }
 
                     it("disables user interaction on plugin's subviews") {
@@ -130,8 +165,6 @@ class BottomDrawerPluginTests: QuickSpec {
 }
 
 class BottomDrawerPluginMock: BottomDrawerPlugin {
-
-    override var height: CGFloat {
-        return 1000
-    }
+    override var height: CGFloat { 1000 }
+    override var placeholder: CGFloat { 18 }
 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -24,12 +24,6 @@ class BottomDrawerPluginTests: QuickSpec {
                     expect(plugin.position).to(equal(.bottom))
                 }
 
-                it("has size with the same width and the half of the height from parentView") {
-                    core.view = UIView(frame: CGRect(x: 0, y: 0, width: coreViewWidth, height: coreViewHeight))
-
-                    expect(plugin.size).to(equal(CGSize(width: coreViewWidth, height: coreViewHeight/2)))
-                }
-
                 it("sets touches in view for UIPanGestureRecognizer") {
                     let panGestureRecognizer = plugin.view.gestureRecognizers?.first(where: {$0 is UIPanGestureRecognizer})
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/DrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/DrawerPluginTests.swift
@@ -58,15 +58,6 @@ class DrawerPluginTests: QuickSpec {
                     }
                 }
 
-                context("when drawer is closed") {
-                    it("doesn't trigger willHide and didHide events") {
-                        core.trigger(.hideDrawerPlugin)
-
-                        expect(plugin.isClosed).to(beTrue())
-                        expect(triggeredEvents).to(equal([]))
-                    }
-                }
-                
                 context("when showDrawerPlugin is triggered") {
                     it("opens the drawer") {
                         core.trigger(.showDrawerPlugin)
@@ -81,7 +72,7 @@ class DrawerPluginTests: QuickSpec {
                         core.trigger(.hideDrawerPlugin)
 
                         expect(plugin.isClosed).to(beTrue())
-                        expect(triggeredEvents).to(beEmpty())
+                        expect(triggeredEvents).to(equal([.willHideDrawerPlugin, .didHideDrawerPlugin]))
                     }
                 }
 
@@ -174,39 +165,6 @@ class DrawerPluginTests: QuickSpec {
 
                         expect(plugin.placeholder).to(equal(.zero))
                         expect(didCallRequestPadding).to(beFalse())
-                    }
-                }
-
-                context("when enter on fullscreen") {
-                    it("calls render") {
-                        let core = CoreStub()
-                        let plugin = MockDrawerPlugin(context: core)
-
-                        core.trigger(.didEnterFullscreen)
-
-                        expect(plugin.didCallRender).to(beTrue())
-                    }
-                }
-
-                context("when exit fullscreen") {
-                    it("calls render") {
-                        let core = CoreStub()
-                        let plugin = MockDrawerPlugin(context: core)
-
-                        core.trigger(.didExitFullscreen)
-
-                        expect(plugin.didCallRender).to(beTrue())
-                    }
-                }
-
-                context("when changes the orientation") {
-                    it("calls render") {
-                        let core = CoreStub()
-                        let plugin = MockDrawerPlugin(context: core)
-
-                        core.trigger(.didChangeScreenOrientation)
-
-                        expect(plugin.didCallRender).to(beTrue())
                     }
                 }
             }


### PR DESCRIPTION
## Goal

Fixes the drawer anchors when exiting fullscreen 

## How to Test

On `ViewController.swift` insert:

`Line #94`
```swift
Player.register(plugins: [CustomBottomDrawerPlugin.self])
```

`Line #110`
```swift
class CustomBottomDrawerPlugin: BottomDrawerPlugin {
    open class override var name: String {
        return "CustomBottomDrawerPlugin"
    }
    override var placeholder: CGFloat {
        return 32.0
    }
    override func render() {
        super.render()
        view.backgroundColor = .red
    }
}
```

1 - Portrait Mode

- Run the Clappr_Example and verify if the CustomDrawer is showing and interactable
- Click on Fullscreen button
- The drawer must be resized with the new screen size and interactable
- Click on Fullscreen button
- The drawer must be resized with the new screen size and interactable in the portrait mode

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-31 at 09 51 59](https://user-images.githubusercontent.com/28604291/91721820-bfccf900-eb6f-11ea-91b1-b3255240f087.png)

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-31 at 09 52 04](https://user-images.githubusercontent.com/28604291/91721849-cbb8bb00-eb6f-11ea-81cf-5db7b8d66d3f.png)

2 - Landscape Mode

- Run the Clappr_Example and verify if the CustomDrawer is showing and interactable
- Click on Fullscreen button
- The drawer must be resized with the new screen size and interactable
- Click on Fullscreen button
- The drawer must be resized with the new screen size and interactable in the landscape mode

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-31 at 09 54 10](https://user-images.githubusercontent.com/28604291/91721952-f571e200-eb6f-11ea-8a71-bd2913f60b0e.png)
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-08-31 at 09 54 14](https://user-images.githubusercontent.com/28604291/91721957-f73ba580-eb6f-11ea-9178-2abc973635bf.png)
