### PR TITLE
Fix bottom drawer gesture handler

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -28,8 +28,8 @@ open class BottomDrawerPlugin: DrawerPlugin {
     required public init(context: UIObject) {
         super.init(context: context)
 
-        addGesture(UITapGestureRecognizer(target: self, action: #selector(didTapView)))
-        addGesture(UIPanGestureRecognizer(target: self, action: #selector(onDragView)), cancelsTouchesInView: true)
+        addGesture(UITapGestureRecognizer(target: self, action: #selector(didTapView)), cancelingTouchesInView: false)
+        addGesture(UIPanGestureRecognizer(target: self, action: #selector(onDragView)))
     }
 
     override open func render() {
@@ -57,21 +57,21 @@ open class BottomDrawerPlugin: DrawerPlugin {
     }
 
     private func moveUp() {
-        enableUserInteractionOnFirstSubview(true)
+        toggleContentInteraction(enabled: true)
         view.setVerticalPoint(to: size.height, duration: ClapprAnimationDuration.mediaControlShow)
     }
 
     private func moveDown(with duration: TimeInterval = ClapprAnimationDuration.mediaControlHide) {
-        enableUserInteractionOnFirstSubview(false)
+        toggleContentInteraction(enabled: false)
         view.setVerticalPoint(to: hiddenHeight, duration: duration)
     }
 
-    private func enableUserInteractionOnFirstSubview(_ enabled: Bool) {
+    private func toggleContentInteraction(enabled: Bool) {
         self.view.subviews.first?.isUserInteractionEnabled = enabled
     }
 
-    private func addGesture(_ gesture: UIGestureRecognizer, cancelsTouchesInView: Bool = false) {
-        gesture.cancelsTouchesInView = cancelsTouchesInView
+    private func addGesture(_ gesture: UIGestureRecognizer, cancelingTouchesInView: Bool = true) {
+        gesture.cancelsTouchesInView = cancelingTouchesInView
         view.addGestureRecognizer(gesture)
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -29,7 +29,7 @@ open class BottomDrawerPlugin: DrawerPlugin {
         super.init(context: context)
 
         addGesture(UITapGestureRecognizer(target: self, action: #selector(didTapView)))
-        addGesture(UIPanGestureRecognizer(target: self, action: #selector(onDragView)))
+        addGesture(UIPanGestureRecognizer(target: self, action: #selector(onDragView)), cancelsTouchesInView: true)
     }
 
     override open func render() {
@@ -57,15 +57,21 @@ open class BottomDrawerPlugin: DrawerPlugin {
     }
 
     private func moveUp() {
+        enableUserInteractionOnFirstSubview(true)
         view.setVerticalPoint(to: size.height, duration: ClapprAnimationDuration.mediaControlShow)
     }
 
     private func moveDown(with duration: TimeInterval = ClapprAnimationDuration.mediaControlHide) {
+        enableUserInteractionOnFirstSubview(false)
         view.setVerticalPoint(to: hiddenHeight, duration: duration)
     }
 
-    private func addGesture(_ gesture: UIGestureRecognizer) {
-        gesture.cancelsTouchesInView = false
+    private func enableUserInteractionOnFirstSubview(_ enabled: Bool) {
+        self.view.subviews.first?.isUserInteractionEnabled = enabled
+    }
+
+    private func addGesture(_ gesture: UIGestureRecognizer, cancelsTouchesInView: Bool = false) {
+        gesture.cancelsTouchesInView = cancelsTouchesInView
         view.addGestureRecognizer(gesture)
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -89,6 +89,16 @@ class BottomDrawerPluginTests: QuickSpec {
 
                         expect(plugin.view.frame.origin.y).to(equal(coreViewHeight/2))
                     }
+
+                    it("enables user interaction on plugin's subviews") {
+                        let view = UIView(frame: .zero)
+                        view.isUserInteractionEnabled = false
+                        plugin.view.addSubview(view)
+
+                        core.trigger(.showDrawerPlugin)
+
+                        expect(view.isUserInteractionEnabled).to(beTrue())
+                    }
                 }
 
                 context("when the hideDrawer event is triggered") {
@@ -97,6 +107,16 @@ class BottomDrawerPluginTests: QuickSpec {
 
                         expect(plugin.view.frame.origin.y).to(equal(coreViewHeight))
                     }
+
+                    it("disables user interaction on plugin's subviews") {
+                          let view = UIView(frame: .zero)
+                          view.isUserInteractionEnabled = true
+                          plugin.view.addSubview(view)
+
+                          core.trigger(.hideDrawerPlugin)
+
+                          expect(view.isUserInteractionEnabled).to(beFalse())
+                      }
                 }
             }
         }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -35,6 +35,12 @@ class BottomDrawerPluginTests: QuickSpec {
                     
                     expect(panGestureRecognizer?.cancelsTouchesInView).to(beTrue())
                 }
+
+                it("disables touches in view for UITapGestureRecognizer") {
+                    let tapGestureRecognizer = plugin.view.gestureRecognizers?.first(where: {$0 is UITapGestureRecognizer})
+
+                    expect(tapGestureRecognizer?.cancelsTouchesInView).to(beFalse())
+                }
             }
 
             describe("#render") {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/Drawer/BottomDrawerPluginTests.swift
@@ -29,6 +29,12 @@ class BottomDrawerPluginTests: QuickSpec {
 
                     expect(plugin.size).to(equal(CGSize(width: coreViewWidth, height: coreViewHeight/2)))
                 }
+
+                it("sets touches in view for UIPanGestureRecognizer") {
+                    let panGestureRecognizer = plugin.view.gestureRecognizers?.first(where: {$0 is UIPanGestureRecognizer})
+                    
+                    expect(panGestureRecognizer?.cancelsTouchesInView).to(beTrue())
+                }
             }
 
             describe("#render") {


### PR DESCRIPTION
## 🏁  Goal
Fix gesture handler on drag bottom drawer when showing and hiding 

## ✅  How to test
1. Run unit tests.
2. Interact with drawer

On `ViewController.swift` insert:

`Line #94`
```swift
Player.register(plugins: [CustomBottomDrawerPlugin.self])
```

`Line #110`
```swift
class CustomBottomDrawerPlugin: BottomDrawerPlugin {
    open class override var name: String {
        return "CustomBottomDrawerPlugin"
    }
    override var placeholder: CGFloat {
        return 32.0
    }
    override func render() {
        super.render()
        view.backgroundColor = .red
    }
}
```