### PR TITLE
Disable external playback

### DIFF
--- a/Sources/Clappr/Classes/Base/Options.swift
+++ b/Sources/Clappr/Classes/Base/Options.swift
@@ -15,6 +15,7 @@ public let kMinDvrSize = "minDvrSize"
 public let kMediaControl = "mediaControl"
 public let kMediaControlAlwaysVisible = "mediaControlAlwaysVisible"
 public let kChromeless = "chromeless"
+public let kDisableExternalPlayback = "disableExternalPlayback"
 
 // List of MediaControl Elements
 public let kMediaControlElements = "mediaControlElements"

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -467,7 +467,7 @@ open class AVFoundationPlayback: Playback {
     
     private func setAudioSessionCategory(to category: AVAudioSession.Category, with options: AVAudioSession.CategoryOptions = []) {
         do {
-            try AVAudioSession.sharedInstance().setCategory(category, mode: .default, options: options)
+            try AVAudioSession.sharedInstance().setCategory(category, mode: .moviePlayback, options: options)
         } catch {
             Logger.logError("It was not possible to set the audio session category")
         }

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -260,7 +260,8 @@ open class AVFoundationPlayback: Playback {
         if let player = player as? AVQueuePlayer {
             playerLooper = AVPlayerLooper(player: player, templateItem: item)
         }
-        player?.allowsExternalPlayback = true
+        
+        player?.allowsExternalPlayback = !options.bool(kDisableExternalPlayback, orElse: false)
         player?.appliesMediaSelectionCriteriaAutomatically = false
     }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -24,7 +24,6 @@ open class AVFoundationPlayback: Playback {
     private var isStopped = false
     private var timeObserver: Any?
     private var asset: AVURLAsset?
-    private var audioSessionCategoryBackup: AVAudioSession.Category?
     private var canTriggerWillPause = true
     private(set) var loopObserver: NSKeyValueObservation?
     private var lastBitrate: Double?
@@ -463,25 +462,9 @@ open class AVFoundationPlayback: Playback {
     }
 
     private func updateAirplayStatus(from player: AVPlayer) {
-        if player.isExternalPlaybackActive {
-            enableBackgroundSession()
-        } else {
-            restoreBackgroundSession()
-        }
         trigger(.didUpdateAirPlayStatus, userInfo: ["externalPlaybackActive": player.isExternalPlaybackActive])
     }
-
-    private func enableBackgroundSession() {
-        audioSessionCategoryBackup = AVAudioSession.sharedInstance().category
-        setAudioSessionCategory(to: .playback, with: [.allowAirPlay])
-    }
-
-    private func restoreBackgroundSession() {
-        if let backgroundSession = audioSessionCategoryBackup {
-            setAudioSessionCategory(to: backgroundSession)
-        }
-    }
-
+    
     private func setAudioSessionCategory(to category: AVAudioSession.Category, with options: AVAudioSession.CategoryOptions = []) {
         do {
             try AVAudioSession.sharedInstance().setCategory(category, mode: .default, options: options)

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -28,6 +28,11 @@ open class AVFoundationPlayback: Playback {
     private var canTriggerWillPause = true
     private(set) var loopObserver: NSKeyValueObservation?
     private var lastBitrate: Double?
+    
+    private var isExternalPlaybackEnabled: Bool {
+        let disableExternalPlayback = options.bool(kDisableExternalPlayback)
+        return !disableExternalPlayback
+    }
 
     private var observers = [NSKeyValueObservation]()
 
@@ -261,7 +266,7 @@ open class AVFoundationPlayback: Playback {
             playerLooper = AVPlayerLooper(player: player, templateItem: item)
         }
         
-        player?.allowsExternalPlayback = !options.bool(kDisableExternalPlayback, orElse: false)
+        player?.allowsExternalPlayback = isExternalPlaybackEnabled
         player?.appliesMediaSelectionCriteriaAutomatically = false
     }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -210,19 +210,10 @@ open class AVFoundationPlayback: Playback {
         return playbackType == .live ? isDvrAvailable : !duration.isZero
     }
 
-    fileprivate func configureAudioSession() {
-        if !isExternalPlaybackEnabled && isAirplayOn {
-            setAudioSessionCategory(to: .playback, with: [.mixWithOthers])
-        } else {
-            setAudioSessionCategory(to: .playback)
-        }
-    }
-    
     public required init(options: Options) {
         super.init(options: options)
         asset = createAsset(from: options[kSourceUrl] as? String)
-        
-        configureAudioSession()
+        setAudioSessionCategory(to: .playback)
     }
 
     private func createAsset(from sourceUrl: String?) -> AVURLAsset? {
@@ -251,12 +242,6 @@ open class AVFoundationPlayback: Playback {
         updateInitialStateIfNeeded()
     }
 
-    private var isAirplayOn: Bool {
-        let outputs = AVAudioSession.sharedInstance().currentRoute.outputs
-        let airPlayPort = outputs.first { port -> Bool in port.portType == .airPlay }
-        return airPlayPort != nil
-    }
-    
     private func updateInitialStateIfNeeded() {
         guard player?.currentItem?.isPlaybackLikelyToKeepUp == true else { return }
         updateState(.stalling)


### PR DESCRIPTION
## 🏁 Goal
Allow the client application to disable external playback, such as AirPlay.

## ✅ How to test
⚠️  As there's no AirPlay support on the simulator, to test this you'll need a device to run the example application and another one to use as the AirPlay destination, such as an Apple TV.

### Scenario 1: AirPlay enabled
1. Run the Example app
2. Play the video
3. Open the Control Center
4. Connect to the Apple TV
5. Video and audio should play normally on the TV

### Scenario 2: Airplay disabled
1. On the example app, add the following line at ViewController.swift:94
```swift
options[kDisableExternalPlayback] = true
```
1. Build and run the Example app
2. Play the video
3. Open the Control Center
4. Connect to the Apple TV
5. Video and audio should play locally