### PR TITLE
Stop Playback before destroying it

### DIFF
--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -109,6 +109,7 @@ open class Playback: UIObject, NamedType {
 
     @objc open func destroy() {
         Logger.logDebug("destroying", scope: "Playback")
+        stop()
         Logger.logDebug("destroying ui elements", scope: "Playback")
         view.removeFromSuperview()
         Logger.logDebug("destroying listeners", scope: "Playback")

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -523,6 +523,8 @@ open class AVFoundationPlayback: Playback {
     }
 
     open override func stop() {
+        guard state != .idle else { return }
+        
         isStopped = true
         trigger(.willStop)
         updateState(.idle)

--- a/Tests/Clappr_Tests/Classes/Base/PlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlaybackTests.swift
@@ -87,6 +87,14 @@ class PlaybackTests: QuickSpec {
 
                 expect(callbackWasCalled) == false
             }
+            
+            it("calls stop when destroy is called") {
+                let playbackSpy = PlaybackSpy(options: options)
+                
+                playbackSpy.destroy()
+                
+                expect(playbackSpy.didCallStop).to(beTrue())
+            }
 
             it("has a class function to check if a source can be played with default value false") {
                 let canPlay = Playback.canPlay([:])
@@ -168,6 +176,14 @@ class PlaybackTests: QuickSpec {
                 }
             }
         }
+    }
+}
+
+class PlaybackSpy: Playback {
+    var didCallStop = false
+    
+    override func stop() {
+        didCallStop = true
     }
 }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackQualityMetricsTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackQualityMetricsTests.swift
@@ -126,6 +126,7 @@ class AVFoundationPlaybackQualityMetricsTests: QuickSpec {
                                 name: .AVPlayerItemNewAccessLogEntry,
                                 object: player.currentItem
                             )
+                            avfoundationPlayback.state = .playing
                             
                             avfoundationPlayback.stop()
                             

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStopActionTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStopActionTests.swift
@@ -22,6 +22,7 @@ class AVFoundationPlaybackStopActionTests: QuickSpec {
                     let avfoundationPlayback = AVFoundationPlayback(options: [:])
                     avfoundationPlayback.player = PlayerMock()
                     avfoundationPlayback.addObservers()
+                    avfoundationPlayback.state = .playing
                     
                     avfoundationPlayback.stop()
                     
@@ -35,6 +36,7 @@ class AVFoundationPlaybackStopActionTests: QuickSpec {
                         let avfoundationPlayback = AVFoundationPlayback(options: [:])
                         avfoundationPlayback.player = PlayerMock()
                         avfoundationPlayback.addObservers()
+                        avfoundationPlayback.state = .playing
                         baseObject.listenTo(avfoundationPlayback, event: .willStop) { _ in
                             didCallWillStop = true
                         }
@@ -50,6 +52,7 @@ class AVFoundationPlaybackStopActionTests: QuickSpec {
                         let avfoundationPlayback = AVFoundationPlayback(options: [:])
                         avfoundationPlayback.player = PlayerMock()
                         avfoundationPlayback.addObservers()
+                        avfoundationPlayback.state = .playing
                         baseObject.listenTo(avfoundationPlayback, event: .didStop) { _ in
                             didCallDidStop = true
                         }

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -1622,6 +1622,20 @@ class AVFoundationPlaybackTests: QuickSpec {
                             expect(playback.state).toEventually(equal(.paused), timeout: 3)
                         }
                     }
+                    context("when stop is called") {
+                        it("does not trigger didStop event") {
+                            let options = [kSourceUrl: "http://clappr.sample/master.m3u8"]
+                            let playback = AVFoundationPlayback(options: options)
+                            var didStopWasTriggered = false
+                            playback.on(Event.didStop.rawValue) { _ in
+                                didStopWasTriggered = true
+                            }
+                            
+                            playback.stop()
+                            
+                            expect(didStopWasTriggered).to(beFalse())
+                        }
+                    }
                 }
 
                 describe("#playing") {


### PR DESCRIPTION
## 🏁 Goal
Stop playback before destroying the player in order to maintain state integrity.

## ✅ How to test
- Run the automated tests