### PR TITLE
Create MediaControl layer

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		7BD29B8523FDDF5300C82098 /* AccessLogEventMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD29B8423FDDF5300C82098 /* AccessLogEventMock.swift */; };
 		7BD29B8723FDE20000C82098 /* AVFoundationPlaybackQualityMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD29B8623FDE20000C82098 /* AVFoundationPlaybackQualityMetricsTests.swift */; };
 		7BD29B8923FDE27000C82098 /* OHTTPStubsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD29B8823FDE27000C82098 /* OHTTPStubsHelper.swift */; };
+		90988E2F25192EA4008CC9E9 /* MediaControlLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90988E2E25192EA4008CC9E9 /* MediaControlLayer.swift */; };
 		96036D671CBD89500022CCCA /* PlaybackFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */; };
 		9603A06C1C05E6D100B55D8F /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9603A06B1C05E6D100B55D8F /* PlayerTests.swift */; };
 		963B19981E4B827700A0A6BA /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963B19971E4B827700A0A6BA /* Event.swift */; };
@@ -565,6 +566,7 @@
 		7BD29B8623FDE20000C82098 /* AVFoundationPlaybackQualityMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVFoundationPlaybackQualityMetricsTests.swift; sourceTree = "<group>"; };
 		7BD29B8823FDE27000C82098 /* OHTTPStubsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OHTTPStubsHelper.swift; sourceTree = "<group>"; };
 		8F3389F0416A5259ADD1C31F /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		90988E2E25192EA4008CC9E9 /* MediaControlLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlLayer.swift; sourceTree = "<group>"; };
 		96036D651CBD88B60022CCCA /* PlaybackFactoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaybackFactoryTests.swift; sourceTree = "<group>"; };
 		9603A06B1C05E6D100B55D8F /* PlayerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayerTests.swift; sourceTree = "<group>"; };
 		963B19971E4B827700A0A6BA /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
@@ -1320,6 +1322,7 @@
 				A32A4A2424F53F5000953E47 /* Layer.swift */,
 				A32A4A2624F53FAA00953E47 /* PlaybackLayer.swift */,
 				A3B8019124F6A31A009FA0D4 /* ContainerLayer.swift */,
+				90988E2E25192EA4008CC9E9 /* MediaControlLayer.swift */,
 			);
 			path = Layers;
 			sourceTree = "<group>";
@@ -2388,6 +2391,7 @@
 				C9177B2E21664D1C001D0292 /* UIImage+Ext.swift in Sources */,
 				4822B6B1220C72D100D1C134 /* SeekBubbleSide.swift in Sources */,
 				96D362E11D41339400CCB866 /* UIContainerPlugin.swift in Sources */,
+				90988E2F25192EA4008CC9E9 /* MediaControlLayer.swift in Sources */,
 				96D362E41D41339400CCB866 /* NoOpPlayback.swift in Sources */,
 				48A29C0B221DEFC10004AD3B /* CorePlugin.swift in Sources */,
 				AB16350D215AC9FC00635233 /* MediaControlView.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -113,6 +113,8 @@
 		3D5AF51B250026D10020081F /* Core+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5AF517250026C30020081F /* Core+Convenience.swift */; };
 		3D5AF51D2500289C0020081F /* Container+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5AF51C2500289C0020081F /* Container+Convenience.swift */; };
 		3D5AF51E2500289C0020081F /* Container+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5AF51C2500289C0020081F /* Container+Convenience.swift */; };
+		3DDDF42425221E5100AAA9CD /* MediaControlLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDDF42325221E5100AAA9CD /* MediaControlLayerTests.swift */; };
+		3DDDF42525221E5100AAA9CD /* MediaControlLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDDF42325221E5100AAA9CD /* MediaControlLayerTests.swift */; };
 		4822B6AD220B6F7200D1C134 /* Core+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48563228220B47B10096CDAE /* Core+Ext.swift */; };
 		4822B6AF220C72AE00D1C134 /* SeekBubble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4822B6AE220C72AE00D1C134 /* SeekBubble.swift */; };
 		4822B6B1220C72D100D1C134 /* SeekBubbleSide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4822B6B0220C72D100D1C134 /* SeekBubbleSide.swift */; };
@@ -514,6 +516,7 @@
 		32E4021D1FF43534001C2096 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		3D5AF517250026C30020081F /* Core+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Core+Convenience.swift"; sourceTree = "<group>"; };
 		3D5AF51C2500289C0020081F /* Container+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Container+Convenience.swift"; sourceTree = "<group>"; };
+		3DDDF42325221E5100AAA9CD /* MediaControlLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaControlLayerTests.swift; sourceTree = "<group>"; };
 		4822B6AE220C72AE00D1C134 /* SeekBubble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekBubble.swift; sourceTree = "<group>"; };
 		4822B6B0220C72D100D1C134 /* SeekBubbleSide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeekBubbleSide.swift; sourceTree = "<group>"; };
 		4822B6B32214961900D1C134 /* ClapprAnimationDuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClapprAnimationDuration.swift; sourceTree = "<group>"; };
@@ -1310,6 +1313,7 @@
 				A32A4A2A24F544C000953E47 /* LayerTests.swift */,
 				A308B35C24F6E8F700C84AB8 /* PlaybackLayerTests.swift */,
 				A308B35F24F6FD6C00C84AB8 /* ContainerLayerTests.swift */,
+				3DDDF42325221E5100AAA9CD /* MediaControlLayerTests.swift */,
 			);
 			path = Layers;
 			sourceTree = "<group>";
@@ -2239,6 +2243,7 @@
 				32FC971C20B72C4200ABA0C2 /* AVURLAssetWithCookiesTests.swift in Sources */,
 				48A29C09221DEF6A0004AD3B /* CorePluginTests.swift in Sources */,
 				7BCD8EE123073A8900FBE5A2 /* SimpleContainerPluginTests.swift in Sources */,
+				3DDDF42525221E5100AAA9CD /* MediaControlLayerTests.swift in Sources */,
 				FC7785C1200526D500EC879F /* AVFoundationNowPlayingBuilderTests.swift in Sources */,
 				571B7B2A21750157005C0942 /* HTTPStub.swift in Sources */,
 				524B66AE242A9C070085789D /* PlayerItemAccessLogMock.swift in Sources */,
@@ -2285,6 +2290,7 @@
 				A308B35D24F6E8F700C84AB8 /* PlaybackLayerTests.swift in Sources */,
 				C92F1C9A216F8F000059D860 /* UIViewExtensionTests.swift in Sources */,
 				5753591C2187486900A88BE2 /* Array+appendOrReplaceTests.swift in Sources */,
+				3DDDF42425221E5100AAA9CD /* MediaControlLayerTests.swift in Sources */,
 				7BCD8EE023073A8900FBE5A2 /* SimpleContainerPluginTests.swift in Sources */,
 				A32A4A2D24F546E800953E47 /* LayerTests.swift in Sources */,
 				96A9CE391C973A0600C21E80 /* LoaderTests.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		32E4021F1FF43534001C2096 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32E4021D1FF43534001C2096 /* Nimble.framework */; };
 		32FC971B20B7257800ABA0C2 /* AVURLAssetWithCookiesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C561FB0DD0D000A239E /* AVURLAssetWithCookiesBuilder.swift */; };
 		32FC971C20B72C4200ABA0C2 /* AVURLAssetWithCookiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57937C581FB0DD27000A239E /* AVURLAssetWithCookiesTests.swift */; };
+		3D1EE05E25228D4800870828 /* MediaControlLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90988E2E25192EA4008CC9E9 /* MediaControlLayer.swift */; };
 		3D5AF519250026CD0020081F /* Core+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5AF517250026C30020081F /* Core+Convenience.swift */; };
 		3D5AF51B250026D10020081F /* Core+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5AF517250026C30020081F /* Core+Convenience.swift */; };
 		3D5AF51D2500289C0020081F /* Container+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5AF51C2500289C0020081F /* Container+Convenience.swift */; };
@@ -2186,6 +2187,7 @@
 				32DA341A1FFBD02A00484C90 /* Loader.swift in Sources */,
 				CD10D93E22C28D4C0096B035 /* Environment.swift in Sources */,
 				AB24DCD62152ED0E002D4660 /* AvailableMediaOptions.swift in Sources */,
+				3D1EE05E25228D4800870828 /* MediaControlLayer.swift in Sources */,
 				A3B8019324F6A31A009FA0D4 /* ContainerLayer.swift in Sources */,
 				C94D8CF1221B22C300C7855D /* ContainerPlugin.swift in Sources */,
 				FBD47AAD21AD6733003265AF /* CoreFactory.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -175,8 +175,8 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         guard let mediaControl = plugins.first(where: { $0 is MediaControl }) as? MediaControl else {
             return
         }
-        let mediaControlView = mediaControl.view
-        layerComposer.attachMediaControl(mediaControlView)
+
+        layerComposer.attachMediaControl(mediaControl.view)
         mediaControl.safeRender()
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -119,10 +119,12 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
     
     private func setupMediaControlLayer() {
+        #if os(iOS)
         let mediaControl = plugins.first { $0 is MediaControl } as? MediaControl
         if let mediaControlView = mediaControl?.view {
             layerComposer.attachMediaControl(mediaControlView)
         }
+        #endif
     }
     
     open override func render() {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -169,6 +169,9 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     private func renderMediaControlElements() {
         let mediaControl = plugins.first { $0 is MediaControl } as? MediaControl
+        if let mediaControlView = mediaControl?.mediaControlView {
+            layerComposer.attachMediaControl(mediaControlView)
+        }
         let elements = plugins.compactMap { $0 as? MediaControl.Element }
         mediaControl?.render(elements)
     }

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -109,12 +109,20 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         parentView.addSubviewMatchingConstraints(view)
     
         layerComposer.attachContainer(containerView)
+        setupMediaControlLayer()
         layerComposer.compose(inside: view)
         
         self.parentController = controller
         self.parentView = parentView
     
         trigger(.didAttachView)
+    }
+    
+    private func setupMediaControlLayer() {
+        let mediaControl = plugins.first { $0 is MediaControl } as? MediaControl
+        if let mediaControlView = mediaControl?.view {
+            layerComposer.attachMediaControl(mediaControlView)
+        }
     }
     
     open override func render() {
@@ -169,9 +177,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
 
     private func renderMediaControlElements() {
         let mediaControl = plugins.first { $0 is MediaControl } as? MediaControl
-        if let mediaControlView = mediaControl?.mediaControlView {
-            layerComposer.attachMediaControl(mediaControlView)
-        }
         let elements = plugins.compactMap { $0 as? MediaControl.Element }
         mediaControl?.render(elements)
     }

--- a/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
@@ -5,7 +5,8 @@ public class LayerComposer {
     private let backgroundLayer = BackgroundLayer()
     private let playbackLayer = PlaybackLayer()
     private let containerLayer = ContainerLayer()
-    
+    private let mediaControlLayer = MediaControlLayer()
+
     public init() { }
     
     func compose(inside rootView: UIView) {
@@ -14,6 +15,7 @@ public class LayerComposer {
         backgroundLayer.attach(to: rootView, at: 0)
         playbackLayer.attach(to: rootView, at: 1)
         containerLayer.attach(to: rootView, at: 2)
+        mediaControlLayer.attach(to: rootView, at: 3)
     }
     
     func attachContainer(_ view: UIView) {
@@ -22,5 +24,9 @@ public class LayerComposer {
     
     func attachPlayback(_ view: UIView) {
         playbackLayer.attachPlayback(view)
+    }
+    
+    func attachMediaControl(_ view: UIView) {
+        mediaControlLayer.attachMediaControl(view)
     }
 }

--- a/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 final class MediaControlLayer: Layer {
     func attachMediaControl(_ mediaControl: UIView) {
         addSubview(mediaControl)

--- a/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
@@ -12,7 +12,7 @@ final class MediaControlLayer: Layer {
         mediaControl.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         mediaControl.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
-        mediaControl.layoutIfNeeded()
+        layoutIfNeeded()
     }
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {

--- a/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
@@ -1,0 +1,15 @@
+final class MediaControlLayer: Layer {
+    func attachMediaControl(_ mediaControl: UIView) {
+        addSubview(mediaControl)
+        
+        mediaControl.translatesAutoresizingMaskIntoConstraints = false
+        
+        mediaControl.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+        mediaControl.heightAnchor.constraint(equalTo: heightAnchor).isActive = true
+        
+        mediaControl.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        mediaControl.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+
+        mediaControl.layoutIfNeeded()
+    }
+}

--- a/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/MediaControlLayer.swift
@@ -14,4 +14,10 @@ final class MediaControlLayer: Layer {
 
         mediaControl.layoutIfNeeded()
     }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let result = super.hitTest(point, with: event)
+        if result == self { return nil }
+        return result
+    }
 }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
@@ -49,6 +49,19 @@ class LayerComposerTests: QuickSpec {
                         description: "ContainerLayer should be the third subview of rootView, got \(String(describing: type(of: layer)))"
                     )
                 }
+                it("adds MediaControlLayer as the fourth layer"){
+                    let index = 3
+                    let rootView = UIView()
+                    let layerComposer = LayerComposer()
+                    
+                    layerComposer.compose(inside: rootView)
+                    
+                    let layer = getLayer(from: rootView, at: index)
+                    expect(layer).to(
+                        beAKindOf(MediaControlLayer.self),
+                        description: "MediaControlLayer should be the third subview of rootView, got \(String(describing: type(of: layer)))"
+                    )
+                }
             }
         }
         

--- a/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
@@ -59,7 +59,7 @@ class LayerComposerTests: QuickSpec {
                     let layer = getLayer(from: rootView, at: index)
                     expect(layer).to(
                         beAKindOf(MediaControlLayer.self),
-                        description: "MediaControlLayer should be the third subview of rootView, got \(String(describing: type(of: layer)))"
+                        description: "MediaControlLayer should be the fourth subview of rootView, got \(String(describing: type(of: layer)))"
                     )
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/MediaControlLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/MediaControlLayerTests.swift
@@ -12,8 +12,7 @@ class MediaControlLayerTests: QuickSpec {
                     let layer = MediaControlLayer(frame: frame)
 
                     layer.attachMediaControl(mediaControlView)
-                    layer.layoutIfNeeded()
-
+                    
                     expect(mediaControlView.center).to(equal(layer.center))
                     expect(mediaControlView.bounds.size).to(equal(layer.bounds.size))
 
@@ -26,7 +25,6 @@ class MediaControlLayerTests: QuickSpec {
                         let mediaControlLayer = MediaControlLayer(frame: smallFrame)
 
                         mediaControlLayer.attachMediaControl(mediaControlView)
-                        mediaControlLayer.layoutIfNeeded()
                         mediaControlLayer.bounds = bigFrame
                         mediaControlLayer.layoutIfNeeded()
 

--- a/Tests/Clappr_Tests/Classes/Base/Layers/MediaControlLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/MediaControlLayerTests.swift
@@ -1,0 +1,39 @@
+import Quick
+import Nimble
+@testable import Clappr
+
+class MediaControlLayerTests: QuickSpec {
+    override func spec() {
+        describe(".MediaControlLayer") {
+            context("When a MediaControl is attached") {
+                it("resizes to match the layer bounds") {
+                    let mediaControlView = UIView(frame: .zero)
+                    let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+                    let layer = MediaControlLayer(frame: frame)
+
+                    layer.attachMediaControl(mediaControlView)
+                    layer.layoutIfNeeded()
+
+                    expect(mediaControlView.center).to(equal(layer.center))
+                    expect(mediaControlView.bounds.size).to(equal(layer.bounds.size))
+
+                }
+                context("and the view size changes") {
+                    it("resizes to match the view bounds") {
+                        let smallFrame = CGRect(x: 0, y: 0, width: 50, height: 50)
+                        let bigFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
+                        let mediaControlView = UIView(frame: .zero)
+                        let mediaControlLayer = MediaControlLayer(frame: smallFrame)
+
+                        mediaControlLayer.attachMediaControl(mediaControlView)
+                        mediaControlLayer.layoutIfNeeded()
+                        mediaControlLayer.bounds = bigFrame
+                        mediaControlLayer.layoutIfNeeded()
+
+                        expect(mediaControlView.bounds.size).to(equal(bigFrame.size))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -169,7 +169,8 @@ class CoreTests: QuickSpec {
 
                             core.addPlugin(mediaControlMock)
                             core.attach(to: .init(), controller: .init())
-
+                            core.render()
+                            
                             expect(layerComposerSpy.didCallAttachMediaControl).to(beTrue())
                         }
                     }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -21,9 +21,14 @@ class CoreTests: QuickSpec {
         
         class LayerComposerSpy: LayerComposer {
             var didCallCompose = false
+            var didCallAttachMediaControl = false
             
             override func compose(inside rootView: UIView) {
                 didCallCompose = true
+            }
+
+            override func attachMediaControl(_ view: UIView) {
+                didCallAttachMediaControl = true
             }
         }
 
@@ -152,6 +157,19 @@ class CoreTests: QuickSpec {
                             core.attach(to: parentView, controller: parentViewController)
 
                             expect(didAttachPlayer).to(beFalse())
+                        }
+                    }
+
+                    context("when calls attach") {
+                        it("should calls the attachMediaControl on LayerComposer") {
+                            let layerComposerSpy = LayerComposerSpy()
+                            let core = CoreFactory.create(with: [:], layerComposer: layerComposerSpy)
+                            let mediaControlMock = MediaControlMock(context: core)
+
+                            core.addPlugin(mediaControlMock)
+                            core.attach(to: .init(), controller: .init())
+
+                            expect(layerComposerSpy.didCallAttachMediaControl).to(beTrue())
                         }
                     }
                 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -160,6 +160,7 @@ class CoreTests: QuickSpec {
                         }
                     }
 
+                    #if os(iOS)
                     context("when calls attach") {
                         it("should calls the attachMediaControl on LayerComposer") {
                             let layerComposerSpy = LayerComposerSpy()
@@ -172,6 +173,7 @@ class CoreTests: QuickSpec {
                             expect(layerComposerSpy.didCallAttachMediaControl).to(beTrue())
                         }
                     }
+                    #endif
                 }
             }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -161,8 +161,8 @@ class CoreTests: QuickSpec {
                     }
 
                     #if os(iOS)
-                    context("when calls attach") {
-                        it("should calls the attachMediaControl on LayerComposer") {
+                    context("when attach is called") {
+                        it("should attach the MediaControl layer on LayerComposer") {
                             let layerComposerSpy = LayerComposerSpy()
                             let core = CoreFactory.create(with: [:], layerComposer: layerComposerSpy)
                             let mediaControlMock = MediaControlMock(context: core)

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/QuickSeekMediaControlPluginTests.swift
@@ -82,6 +82,22 @@ class QuickSeekMediaControlPluginTests: QuickSpec {
                     
                     context("and it collides with that plugin") {
                         it("does not seek") {
+                            let coreStub: CoreStub = CoreStub()
+                            let quickSeekPlugin: QuickSeekMediaControlPlugin = QuickSeekMediaControlPlugin(context: coreStub)
+                            let mediaControl: MediaControl = MediaControl(context: coreStub)
+                            let playButton: PlayButton = PlayButton(context: coreStub)
+                            let rootView: UIView = UIView(frame: .init(origin: .zero, size: .init(width: 320, height: 200)))
+                            
+                            coreStub.playbackMock?.videoDuration = 60.0
+                            coreStub.addPlugin(mediaControl)
+                            coreStub.addPlugin(quickSeekPlugin)
+                            coreStub.addPlugin(playButton)
+                            
+                            coreStub.attach(to: rootView, controller: UIViewController())
+                            coreStub.render()
+                            
+                            rootView.layoutIfNeeded()
+                            
                             let playButtonCenterInMediaControlCoordinate = playButton.view.convert(playButton.view.center, to: mediaControl.mediaControlView)
                             
                             let shouldSeek = quickSeekPlugin.shouldSeek(point: playButtonCenterInMediaControlCoordinate)


### PR DESCRIPTION
## 🏁 Goal
Continue the implementation of the visual layers abstraction by adding Media Control layer.

## ✅ How to test
1. Add the following snippet to LayerComposer.swift#19
```swift
mediaControlLayer.backgroundColor = .yellow
```
2. Run the Clappr_Example project
3. Enable view hierarchy debugger
4. You should be able to see the new layer

## 🖼 Screenshots
![Screen Shot 2020-09-28 at 16 14 19](https://user-images.githubusercontent.com/6214228/94475637-bf8f4000-01a5-11eb-9789-1cb3e13e7a3a.png)

