### PR TITLE
Fix Container view hierarchy

### DIFF
--- a/Sources/Clappr/Classes/Base/Container.swift
+++ b/Sources/Clappr/Classes/Base/Container.swift
@@ -83,10 +83,11 @@ open class Container: UIObject {
         layerComposer.attachPlayback(playback.view)
         #else
         view.addSubviewMatchingConstraints(playback.view)
+        view.sendSubviewToBack(playback.view)
         #endif
         
         playback.render()
-        view.sendSubviewToBack(playback.view)
+        
     }
 
     fileprivate func renderPlugin(_ plugin: Plugin) {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -149,7 +149,9 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
 
     private func renderContainer(_ container: Container) {
+        #if os(tvOS)
         view.addSubviewMatchingConstraints(container.view)
+        #endif
         container.render()
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -858,6 +858,7 @@ class CoreTests: QuickSpec {
                 }
             }
 
+            #if os(tvOS)
             context("core position") {
                 it("is positioned in front of Container view") {
                     Loader.shared.register(plugins: [FakeCorePlugin.self])
@@ -870,6 +871,7 @@ class CoreTests: QuickSpec {
                     expect(core.view.subviews[1].accessibilityIdentifier).to(beNil())
                 }
             }
+            #endif
 
             describe("rendering") {
                 context("when plugin is overlay") {


### PR DESCRIPTION
## Goal
Fix the problem introduced on #396, where the `Container` view was still being added to the Core view, which should only happen on tvOS.

## How to test
1. Run all automated tests
