### PR TITLE
Change layer composer attach to update layout on SuperView

### DIFF
--- a/Sources/Clappr/Classes/Base/Layers/ContainerLayer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/ContainerLayer.swift
@@ -12,6 +12,6 @@ final class ContainerLayer: Layer {
         container.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         container.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
-        container.layoutIfNeeded()
+        layoutIfNeeded()
     }
 }

--- a/Sources/Clappr/Classes/Base/Layers/PlaybackLayer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/PlaybackLayer.swift
@@ -12,6 +12,6 @@ final class PlaybackLayer: Layer {
         playback.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         playback.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
 
-        playback.layoutIfNeeded()
+        layoutIfNeeded()
     }
 }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/ContainerLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/ContainerLayerTests.swift
@@ -14,7 +14,6 @@ class ContainerLayerTests: QuickSpec {
                     let expectedCenter = layer.center
                     
                     layer.attachContainer(containerView)
-                    layer.layoutIfNeeded()
                     
                     expect(containerView.center).to(equal(expectedCenter))
                     expect(containerView.bounds.size).to(equal(expectedSize))
@@ -29,7 +28,6 @@ class ContainerLayerTests: QuickSpec {
                         let expectedSize = bigFrame.size
                         
                         containerLayer.attachContainer(containerView)
-                        containerLayer.layoutIfNeeded()
                         containerLayer.bounds = bigFrame
                         containerLayer.layoutIfNeeded()
                         

--- a/Tests/Clappr_Tests/Classes/Base/Layers/PlaybackLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/PlaybackLayerTests.swift
@@ -12,7 +12,6 @@ class PlaybackLayerTests: QuickSpec {
                     let layer = PlaybackLayer(frame: frame)
                     
                     layer.attachPlayback(playbackView)
-                    layer.layoutIfNeeded()
                     
                     expect(playbackView.center).to(equal(layer.center))
                     expect(playbackView.bounds.size).to(equal(layer.bounds.size))
@@ -26,7 +25,6 @@ class PlaybackLayerTests: QuickSpec {
                         let playbackLayer = PlaybackLayer(frame: smallFrame)
                         
                         playbackLayer.attachPlayback(playbackView)
-                        playbackLayer.layoutIfNeeded()
                         playbackLayer.bounds = bigFrame
                         playbackLayer.layoutIfNeeded()
                         


### PR DESCRIPTION
## 🏁 Goal
Change the method `attach` view on `LayerComposer` to update the layout if need on `SuperView` .

## ✅ How to test

1. Run the Clappr_Example project

## 🖼 Screenshots

![image](https://user-images.githubusercontent.com/15603892/94946684-e0f87080-04b2-11eb-8165-7794fe7a51ef.png)


