### PR TITLE
Register plugins (tvOS)

### DIFF
--- a/Sources/Clappr_tvOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_tvOS/Classes/Base/Player.swift
@@ -318,7 +318,7 @@ open class Player: AVPlayerViewController {
         Loader.shared.register(playbacks: playbacks)
     }
 
-    private class func register(plugins: [Plugin.Type]) {
+    open class func register(plugins: [Plugin.Type]) {
         Loader.shared.register(plugins: plugins)
     }
 


### PR DESCRIPTION
## 🏁 Goal
Enable register of plugins to the tvOS player

## ✅ How to test
1. Add the following snippet to ViewController.swift#67 (Clappr_tvOS)

```swift
class PlaybackTypePlugin: SimpleCorePlugin {

    override class var name: String { "PlaybackTypePlugin" }

    override func bindEvents() {
        guard let playback = core?.activePlayback else { return }

        listenTo(playback, event: .assetReady) { _ in
            switch playback.playbackType {
            case .live:
                print("Playback Type: Live")
            case .vod:
                print("Playback Type: VoD")
            default:
                print("Playback Type: Unknown")
            }
        }
    }
}
```

2. Add the following snippet to ViewController.swift#17  (Clappr_tvOS)

```swift
    Player.register(plugins: [PlaybackTypePlugin.self])
```

3. Run the Clappr_tvS=OS_Example project
4. Active Console
5. You should be able to see "Playback Type: VoD" on the console
