### PR TITLE
Close bottom drawer plugin only if it's open on orientation change

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/Drawer/BottomDrawerPlugin.swift
@@ -38,7 +38,9 @@ open class BottomDrawerPlugin: DrawerPlugin {
         guard let core = core else { return }
         
         listenTo(core, eventName: Event.didChangeScreenOrientation.rawValue) { [weak self] _ in
-            self?.hideDrawerPlugin()
+            if let isClosed = self?.isClosed, !isClosed {
+                self?.hideDrawerPlugin()
+            }
             self?.adjustHeightConstraint()
         }
     }


### PR DESCRIPTION
Goal
---
To close the drawer plugin only when it's open when changing screen orientation, preventing any unexpected behavior in plugins that listen to drawer events.

How To Test
---
1. Add this snippet to `ViewController.swift#94`, before instantiating the Player:

    ```swift
     Player.register(plugins: [CustomBottomDrawerPlugin.self])
     ```
1. Add this snippet to `ViewController.swift#110`, after the ViewController class definition: 
    ```swift
    class CustomBottomDrawerPlugin: BottomDrawerPlugin {
         open class override var name: String {
            return "CustomBottomDrawerPlugin"
        }
        override var placeholder: CGFloat {
            return 32.0
        }
        override func render() {
            super.render()
            view.backgroundColor = .red
        }
    }
    ```
1. Run `Clappr_Example`
1. Uncheck the `Fullscreen controlled by app` switch
1. Tap `Start video`

### Scenario 1
1. Before playing, rotate the device / simulator
1. Check that the MediaControl **will not show up**.

### Scenario 2
1. Play the video
1. Wait for the MediaControl to disappear
1. Rotate the device / simulator
1. Check that the MediaControl **will not show up**.

### Scenario 3
1. Play the video
1. Open the Drawer
1. Rotate the device / simulator
1. Check that the Drawer **will close** and the MediaControl **will show up**.