### PR TITLE
Changes the access control on core

### DIFF
--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -4,7 +4,7 @@ open class Player: BaseObject {
     private var layerComposer = LayerComposer()
     open var playbackEventsToListen: [String] = []
     private var playbackEventsListenIds: [String] = []
-    private(set) var core: Core?
+    public private(set) var core: Core?
     private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
 
     static var hasAlreadyRegisteredPlugins = false


### PR DESCRIPTION
Goal
---
Expose access control for `Core` property on Player to allow external frameworks to be able to access and listen to `Core` events on the correct context layer.

How To Test
---
Classes on external frameworks that inherited from `Player.swift` should be able to access the property `core` only as a getter.
