### PR TITLE
Create the Overlay layer

### DIFF
--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		15D1281C253E20CB00A3B2B9 /* OverlayLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D1281B253E20CB00A3B2B9 /* OverlayLayer.swift */; };
 		23EDF916224D819600FB0D96 /* SwiftVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDF915224D819600FB0D96 /* SwiftVersionTests.swift */; };
 		23EDF918224D83FD00FB0D96 /* Clappr.podspec in Resources */ = {isa = PBXBuildFile; fileRef = D8810057D2C05E1F7A2759D7 /* Clappr.podspec */; };
 		23EDF91B224E8EB900FB0D96 /* .swift-version in Resources */ = {isa = PBXBuildFile; fileRef = 23EDF91A224E8EB800FB0D96 /* .swift-version */; };
@@ -303,6 +304,7 @@
 		A32A4A2D24F546E800953E47 /* LayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32A4A2A24F544C000953E47 /* LayerTests.swift */; };
 		A32A51E424C60FC100A00439 /* LayerComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32A51E324C60FC100A00439 /* LayerComposerTests.swift */; };
 		A32A51E624C61BDF00A00439 /* BackgroundLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32A51E524C61BDF00A00439 /* BackgroundLayerTests.swift */; };
+		A35568772547669900CFBC04 /* OverlayLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D1281B253E20CB00A3B2B9 /* OverlayLayer.swift */; };
 		A3B8019224F6A31A009FA0D4 /* ContainerLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B8019124F6A31A009FA0D4 /* ContainerLayer.swift */; };
 		A3B8019324F6A31A009FA0D4 /* ContainerLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B8019124F6A31A009FA0D4 /* ContainerLayer.swift */; };
 		A3C8F3ED24CF489F002CA3F5 /* LayerComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C8F3EB24CF489F002CA3F5 /* LayerComposer.swift */; };
@@ -479,6 +481,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		15D1281B253E20CB00A3B2B9 /* OverlayLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayLayer.swift; sourceTree = "<group>"; };
 		23EDF915224D819600FB0D96 /* SwiftVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftVersionTests.swift; sourceTree = "<group>"; };
 		23EDF91A224E8EB800FB0D96 /* .swift-version */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ".swift-version"; sourceTree = SOURCE_ROOT; };
 		23EDF91D224EAF9A00FB0D96 /* String+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Ext.swift"; sourceTree = "<group>"; };
@@ -1339,6 +1342,7 @@
 				A32A4A2424F53F5000953E47 /* Layer.swift */,
 				A3C8F3EB24CF489F002CA3F5 /* LayerComposer.swift */,
 				90988E2E25192EA4008CC9E9 /* MediaControlLayer.swift */,
+				15D1281B253E20CB00A3B2B9 /* OverlayLayer.swift */,
 			);
 			path = Layers;
 			sourceTree = "<group>";
@@ -2164,6 +2168,7 @@
 				32E401C81FF42351001C2096 /* UIContainerPlugin.swift in Sources */,
 				26211C2024DC70CE000501A4 /* Font.swift in Sources */,
 				26211C1F24DC70C6000501A4 /* EdgeStyle.swift in Sources */,
+				A35568772547669900CFBC04 /* OverlayLayer.swift in Sources */,
 				571B7B252174DBDD005C0942 /* AVFoundationPlayback.swift in Sources */,
 				5733D1C021BAA6EE002107D2 /* Dictionary+Ext.swift in Sources */,
 				26211C2124DC70D5000501A4 /* Alignment.swift in Sources */,
@@ -2458,6 +2463,7 @@
 				262B490C24D8898F0049DAF7 /* AVPlayerItem+Style.swift in Sources */,
 				9E26CFF32016149600AE92B7 /* FullScreenStateHandler.swift in Sources */,
 				C92747E7220DD4E0009465A7 /* UIImageView+Ext.swift in Sources */,
+				15D1281C253E20CB00A3B2B9 /* OverlayLayer.swift in Sources */,
 				96D362CC1D41339400CCB866 /* Options.swift in Sources */,
 				48563229220B47B10096CDAE /* Core+Ext.swift in Sources */,
 				9EED97012088E2F400D1C84A /* AVFoundationPlayback+ViewPort.swift in Sources */,

--- a/Clappr.xcodeproj/project.pbxproj
+++ b/Clappr.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		A32A51E424C60FC100A00439 /* LayerComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32A51E324C60FC100A00439 /* LayerComposerTests.swift */; };
 		A32A51E624C61BDF00A00439 /* BackgroundLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32A51E524C61BDF00A00439 /* BackgroundLayerTests.swift */; };
 		A35568772547669900CFBC04 /* OverlayLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D1281B253E20CB00A3B2B9 /* OverlayLayer.swift */; };
+		A3B041B825484B79001A35F4 /* OverlayLayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B041B725484B79001A35F4 /* OverlayLayerTests.swift */; };
 		A3B8019224F6A31A009FA0D4 /* ContainerLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B8019124F6A31A009FA0D4 /* ContainerLayer.swift */; };
 		A3B8019324F6A31A009FA0D4 /* ContainerLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B8019124F6A31A009FA0D4 /* ContainerLayer.swift */; };
 		A3C8F3ED24CF489F002CA3F5 /* LayerComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C8F3EB24CF489F002CA3F5 /* LayerComposer.swift */; };
@@ -668,6 +669,7 @@
 		A32A4A2A24F544C000953E47 /* LayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerTests.swift; sourceTree = "<group>"; };
 		A32A51E324C60FC100A00439 /* LayerComposerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayerComposerTests.swift; sourceTree = "<group>"; };
 		A32A51E524C61BDF00A00439 /* BackgroundLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundLayerTests.swift; sourceTree = "<group>"; };
+		A3B041B725484B79001A35F4 /* OverlayLayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayLayerTests.swift; sourceTree = "<group>"; };
 		A3B8019124F6A31A009FA0D4 /* ContainerLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerLayer.swift; sourceTree = "<group>"; };
 		A3C8F3EB24CF489F002CA3F5 /* LayerComposer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayerComposer.swift; sourceTree = "<group>"; };
 		A3C8F3EC24CF489F002CA3F5 /* BackgroundLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundLayer.swift; sourceTree = "<group>"; };
@@ -1328,6 +1330,7 @@
 				A308B35F24F6FD6C00C84AB8 /* ContainerLayerTests.swift */,
 				568445B6251D39C7006568BF /* CoreLayerTests.swift */,
 				3DDDF42325221E5100AAA9CD /* MediaControlLayerTests.swift */,
+				A3B041B725484B79001A35F4 /* OverlayLayerTests.swift */,
 			);
 			path = Layers;
 			sourceTree = "<group>";
@@ -2358,6 +2361,7 @@
 				C94D8CED221B1DDD00C7855D /* ContainerPluginTests.swift in Sources */,
 				96664E571BF0CBD400095E6E /* UIObjectTests.swift in Sources */,
 				7BD29B8723FDE20000C82098 /* AVFoundationPlaybackQualityMetricsTests.swift in Sources */,
+				A3B041B825484B79001A35F4 /* OverlayLayerTests.swift in Sources */,
 				262B491A24D88BD60049DAF7 /* FontTests.swift in Sources */,
 				EFEC758223C52A9A00FA6A52 /* PlaybackRendererTests.swift in Sources */,
 				48B39E8A23510FFF00CE9D72 /* TimeIntervalExtensionTests.swift in Sources */,

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -109,6 +109,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         parentView.addSubviewMatchingConstraints(view)
     
         layerComposer.attachContainer(containerView)
+        layerComposer.attachOverlay(overlayView)
         layerComposer.compose(inside: view)
         
         self.parentController = controller
@@ -118,11 +119,8 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
     
     open override func render() {
-        view.addSubviewMatchingConstraints(overlayView)
         containers.forEach(renderContainer)
         addToContainer()
-        view.bringSubviewToFront(overlayView)
-        overlayView.clipsToBounds = true
     }
 
     private func addToContainer() {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -192,7 +192,6 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         plugins
             .compactMap { $0 as? OverlayPlugin }
             .forEach(render)
-        view.bringSubviewToFront(overlayView)
     }
     #endif
 

--- a/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
@@ -4,9 +4,10 @@ public class LayerComposer {
     private weak var rootView: UIView?
     private let backgroundLayer = BackgroundLayer()
     private let playbackLayer = PlaybackLayer()
-    private let coreLayer = CoreLayer()
     private let containerLayer = ContainerLayer()
     private let mediaControlLayer = MediaControlLayer()
+    private let coreLayer = CoreLayer()
+    private let overlayLayer = OverlayLayer()
 
     public init() { }
     
@@ -18,6 +19,7 @@ public class LayerComposer {
         containerLayer.attach(to: rootView, at: 2)
         mediaControlLayer.attach(to: rootView, at: 3)
         coreLayer.attach(to: rootView, at: 4)
+        overlayLayer.attach(to: rootView, at: 5)
     }
     
     func attachContainer(_ view: UIView) {
@@ -34,5 +36,9 @@ public class LayerComposer {
     
     func attachMediaControl(_ view: UIView) {
         mediaControlLayer.attachMediaControl(view)
+    }
+
+    func attachOverlay(_ view: UIView) {
+        overlayLayer.attachOverlay(view)
     }
 }

--- a/Sources/Clappr/Classes/Base/Layers/OverlayLayer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/OverlayLayer.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+final class OverlayLayer: Layer {
+    func attachOverlay(_ overlayView: UIView) {
+        addSubview(overlayView)
+        
+        overlayView.translatesAutoresizingMaskIntoConstraints = false
+        
+        overlayView.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+        overlayView.heightAnchor.constraint(equalTo: heightAnchor).isActive = true
+        
+        overlayView.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        overlayView.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+        
+        layoutIfNeeded()
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let result = super.hitTest(point, with: event)
+        if result == self { return nil }
+        return result
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Base/Layers/ContainerLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/ContainerLayerTests.swift
@@ -6,7 +6,7 @@ class ContainerLayerTests: QuickSpec {
     override func spec() {
         describe(".ContainerLayer") {
             context("When a Container is attached") {
-                it("resizes to match the layer bounds") {
+                it("resizes to match the layer frame") {
                     let containerView = UIView(frame: .zero)
                     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                     let layer = ContainerLayer(frame: frame)
@@ -16,11 +16,11 @@ class ContainerLayerTests: QuickSpec {
                     layer.attachContainer(containerView)
                     
                     expect(containerView.center).to(equal(expectedCenter))
-                    expect(containerView.bounds.size).to(equal(expectedSize))
+                    expect(containerView.frame.size).to(equal(expectedSize))
                     
                 }
                 context("and the view size changes") {
-                    it("resizes to match the view bounds") {
+                    it("resizes to match the view frame") {
                         let smallFrame = CGRect(x: 0, y: 0, width: 50, height: 50)
                         let bigFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
                         let containerView = UIView(frame: .zero)
@@ -28,10 +28,10 @@ class ContainerLayerTests: QuickSpec {
                         let expectedSize = bigFrame.size
                         
                         containerLayer.attachContainer(containerView)
-                        containerLayer.bounds = bigFrame
+                        containerLayer.frame = bigFrame
                         containerLayer.layoutIfNeeded()
                         
-                        expect(containerView.bounds.size).to(equal(expectedSize))
+                        expect(containerView.frame.size).to(equal(expectedSize))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
@@ -75,7 +75,19 @@ class LayerComposerTests: QuickSpec {
                         description: "CoreLayer should be the fifth subview of rootView, got \(String(describing: type(of: layer)))"
                     )
                 }
+                it("adds OverlayLayer as the sixth layer"){
+                    let index = 5
+                    let rootView = UIView()
+                    let layerComposer = LayerComposer()
 
+                    layerComposer.compose(inside: rootView)
+
+                    let layer = getLayer(from: rootView, at: index)
+                    expect(layer).to(
+                        beAKindOf(OverlayLayer.self),
+                        description: "OverlayLayer should be the sixth subview of rootView, got \(String(describing: type(of: layer)))"
+                    )
+                }
             }
         }
         

--- a/Tests/Clappr_Tests/Classes/Base/Layers/LayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/LayerTests.swift
@@ -6,7 +6,7 @@ class LayerTests: QuickSpec {
     override func spec() {
         describe(".Layer") {
             context("When a Layer is attached to a view") {
-                it("resizes to match the view bounds") {
+                it("resizes to match the view frame") {
                     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                     let superview = UIView(frame: frame)
                     let layer = Layer(frame: .zero)
@@ -15,10 +15,10 @@ class LayerTests: QuickSpec {
                     superview.layoutIfNeeded()
                     
                     expect(layer.center).to(equal(superview.center))
-                    expect(layer.bounds.size).to(equal(superview.bounds.size))
+                    expect(layer.frame.size).to(equal(superview.frame.size))
                 }
                 context("and the view size changes") {
-                    it("resizes to match the view bounds") {
+                    it("resizes to match the view frame") {
                         let frame = CGRect(x: 0, y: 0, width: 50, height: 50)
                         let biggerFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
                         let rootView = UIView(frame: frame)
@@ -26,10 +26,10 @@ class LayerTests: QuickSpec {
                         
                         testLayer.attach(to: rootView)
                         testLayer.layoutIfNeeded()
-                        rootView.bounds = biggerFrame
+                        rootView.frame = biggerFrame
                         rootView.layoutIfNeeded()
                         
-                        expect(testLayer.bounds.size).to(equal(biggerFrame.size))
+                        expect(testLayer.frame.size).to(equal(biggerFrame.size))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/MediaControlLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/MediaControlLayerTests.swift
@@ -6,7 +6,7 @@ class MediaControlLayerTests: QuickSpec {
     override func spec() {
         describe(".MediaControlLayer") {
             context("When a MediaControl is attached") {
-                it("resizes to match the layer bounds") {
+                it("resizes to match the layer frame") {
                     let mediaControlView = UIView(frame: .zero)
                     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                     let layer = MediaControlLayer(frame: frame)
@@ -14,21 +14,22 @@ class MediaControlLayerTests: QuickSpec {
                     layer.attachMediaControl(mediaControlView)
                     
                     expect(mediaControlView.center).to(equal(layer.center))
-                    expect(mediaControlView.bounds.size).to(equal(layer.bounds.size))
+                    expect(mediaControlView.frame.size).to(equal(layer.frame.size))
 
                 }
                 context("and the view size changes") {
-                    it("resizes to match the view bounds") {
+                    it("resizes to match the view frame") {
                         let smallFrame = CGRect(x: 0, y: 0, width: 50, height: 50)
                         let bigFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
                         let mediaControlView = UIView(frame: .zero)
                         let mediaControlLayer = MediaControlLayer(frame: smallFrame)
 
                         mediaControlLayer.attachMediaControl(mediaControlView)
-                        mediaControlLayer.bounds = bigFrame
+                        mediaControlLayer.frame = bigFrame
                         mediaControlLayer.layoutIfNeeded()
 
-                        expect(mediaControlView.bounds.size).to(equal(bigFrame.size))
+                        expect(mediaControlView.center).to(equal(mediaControlLayer.center))
+                        expect(mediaControlView.frame.size).to(equal(bigFrame.size))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/OverlayLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/OverlayLayerTests.swift
@@ -5,7 +5,35 @@ import Nimble
 class OverlayLayerTests: QuickSpec {
     override func spec() {
         describe(".OverlayLayerTests"){
-            
+            context("When overlay view is attached") {
+                it("resizes to match the layer bounds") {
+                    let overlayView = UIView(frame: .zero)
+                    let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
+                    let layer = OverlayLayer(frame: frame)
+                    let expectedSize = frame.size
+                    let expectedCenter = layer.center
+                    
+                    layer.attachOverlay(overlayView)
+                    
+                    expect(overlayView.center).to(equal(expectedCenter))
+                    expect(overlayView.bounds.size).to(equal(expectedSize))
+                }
+                context("and the view size changes") {
+                    it("resizes to match the view bounds") {
+                        let smallFrame = CGRect(x: 0, y: 0, width: 50, height: 50)
+                        let bigFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
+                        let overlayView = UIView(frame: .zero)
+                        let layer = OverlayLayer(frame: smallFrame)
+                        let expectedSize = bigFrame.size
+                        
+                        layer.attachOverlay(overlayView)
+                        layer.frame = bigFrame
+                        layer.layoutIfNeeded()
+                        
+                        expect(overlayView.bounds.size).to(equal(expectedSize))
+                    }
+                }
+            }
         }
     }
 }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/OverlayLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/OverlayLayerTests.swift
@@ -6,7 +6,7 @@ class OverlayLayerTests: QuickSpec {
     override func spec() {
         describe(".OverlayLayerTests"){
             context("When overlay view is attached") {
-                it("resizes to match the layer bounds") {
+                it("resizes to match the layer frame") {
                     let overlayView = UIView(frame: .zero)
                     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                     let layer = OverlayLayer(frame: frame)
@@ -16,10 +16,10 @@ class OverlayLayerTests: QuickSpec {
                     layer.attachOverlay(overlayView)
                     
                     expect(overlayView.center).to(equal(expectedCenter))
-                    expect(overlayView.bounds.size).to(equal(expectedSize))
+                    expect(overlayView.frame.size).to(equal(expectedSize))
                 }
                 context("and the view size changes") {
-                    it("resizes to match the view bounds") {
+                    it("resizes to match the view frame") {
                         let smallFrame = CGRect(x: 0, y: 0, width: 50, height: 50)
                         let bigFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
                         let overlayView = UIView(frame: .zero)
@@ -30,7 +30,7 @@ class OverlayLayerTests: QuickSpec {
                         layer.frame = bigFrame
                         layer.layoutIfNeeded()
                         
-                        expect(overlayView.bounds.size).to(equal(expectedSize))
+                        expect(overlayView.frame.size).to(equal(expectedSize))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/OverlayLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/OverlayLayerTests.swift
@@ -1,0 +1,11 @@
+import Quick
+import Nimble
+@testable import Clappr
+
+class OverlayLayerTests: QuickSpec {
+    override func spec() {
+        describe(".OverlayLayerTests"){
+            
+        }
+    }
+}

--- a/Tests/Clappr_Tests/Classes/Base/Layers/PlaybackLayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/PlaybackLayerTests.swift
@@ -6,7 +6,7 @@ class PlaybackLayerTests: QuickSpec {
     override func spec() {
         describe(".PlaybackLayer") {
             context("When a Playback is attached") {
-                it("resizes to match the layer bounds") {
+                it("resizes to match the layer frame") {
                     let playbackView = UIView(frame: .zero)
                     let frame = CGRect(x: 0, y: 0, width: 100, height: 100)
                     let layer = PlaybackLayer(frame: frame)
@@ -14,21 +14,21 @@ class PlaybackLayerTests: QuickSpec {
                     layer.attachPlayback(playbackView)
                     
                     expect(playbackView.center).to(equal(layer.center))
-                    expect(playbackView.bounds.size).to(equal(layer.bounds.size))
+                    expect(playbackView.frame.size).to(equal(layer.frame.size))
                     
                 }
                 context("and the view size changes") {
-                    it("resizes to match the view bounds") {
+                    it("resizes to match the view frame") {
                         let smallFrame = CGRect(x: 0, y: 0, width: 50, height: 50)
                         let bigFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
                         let playbackView = UIView(frame: .zero)
                         let playbackLayer = PlaybackLayer(frame: smallFrame)
                         
                         playbackLayer.attachPlayback(playbackView)
-                        playbackLayer.bounds = bigFrame
+                        playbackLayer.frame = bigFrame
                         playbackLayer.layoutIfNeeded()
                         
-                        expect(playbackView.bounds.size).to(equal(bigFrame.size))
+                        expect(playbackView.frame.size).to(equal(bigFrame.size))
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -820,7 +820,7 @@ class CoreTests: QuickSpec {
 
                         core.render()
 
-                        expect(core.view.subviews.count).to(equal(3))
+                        expect(core.view.subviews.count).to(equal(2))
                         expect(core.view.subviews.first?.accessibilityIdentifier).to(equal("Container"))
                         expect(core.view.subviews[1].accessibilityIdentifier).to(beNil())
                     }
@@ -927,17 +927,6 @@ class CoreTests: QuickSpec {
 
                         expect(core.overlayView.subviews.count).to(equal(1))
                     }
-                }
-
-                it("has the overlayView on top of the view stack") {
-                    Loader.shared.register(plugins: [OverlayPluginMock.self, UICorePluginMock.self])
-                    let core = CoreFactory.create(with: [:], layerComposer: layerComposer)
-                    let parentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-                    core.parentView = parentView
-
-                    core.render()
-
-                    expect(core.view.subviews.last).to(beAKindOf(PassthroughView.self))
                 }
             }
         }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/OverlayPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/OverlayPluginTests.swift
@@ -47,7 +47,8 @@ class OverlayPluginTests: QuickSpec {
                     it("fits the parentView bounds") {
                         let core = CoreStub()
                         let parentView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
-                        core.parentView = parentView
+                        core.attach(to: parentView, controller: UIViewController())
+                        
                         let plugin = OverlayPluginMock(context: core)
                         plugin._isModal = true
                         plugin.view = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))


### PR DESCRIPTION
## 🏁 Goal
To have a layer that controls the views of overlay plugins.

## ✅ How to test

### Check the Overlay layer's existence
1. Add the following snippet to LayerComposer.swift#20
     ```swift
     overlayLayer.backgroundColor = .red
     ```
1. Run the example
1. Enable view hierarchy debugger
1. You should see the OverlayLayer view with a red background as shown in the `Screenshot` section.

### Plugins underneath it
1. Run the example
1. Double tap on both sides
1. Make sure the Quick Seek feature works as expected.

### Plugins inside the layer
1. Run the example
1. Add the following snippet in `ViewController` as a plugin:
    ```swift
     class CustomBottomDrawerPlugin: BottomDrawerPlugin {
         open class override var name: String {
             return "CustomBottomDrawerPlugin"
         }

         override var placeholder: CGFloat {
             return 32.0
         }

         private let internalView = UIView()
 
         override func render() {
             super.render()
             Logger.setLevel(.debug)
             let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapInsideView))
             internalView.addGestureRecognizer(tapGesture)
             internalView.translatesAutoresizingMaskIntoConstraints = false
             internalView.backgroundColor = .red
             view.addSubviewMatchingConstraints(internalView)
         }

         @objc
         private func didTapInsideView() {
             Logger.logDebug("Did tap inside drawer plugin", scope: "CustomBottomDrawerPlugin")
         }
     }
    ```
1. Register the plugin before the instatiation:
    ```swift
     Player.register(plugins: [CustomBottomDrawerPlugin.self])
     ```
1. Open the drawer
1. Tap the drawer view
1. Look in the console for the logged message.

## 🖼 Screenshots
![OverlayLayer](https://user-images.githubusercontent.com/26371672/97351233-3b95aa00-1870-11eb-942a-21943c2393c9.png)
