### PR TITLE
Feature/xcode12 build compatible

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,4 +1,4 @@
 github "Quick/Quick" == 3.0.0
 github "Quick/Nimble" == 8.1.1
 github "AliSoftware/OHHTTPStubs" == 8.0.0
-github "httpswift/swifter" == 1.4.7
+github "httpswift/swifter" == 1.5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "8.0.0"
 github "Quick/Nimble" "v8.1.1"
 github "Quick/Quick" "v3.0.0"
-github "httpswift/swifter" "1.4.7"
+github "httpswift/swifter" "1.5.0"

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -407,11 +407,11 @@ class CoreTests: QuickSpec {
                             expect(core.parentView?.subviews).to(contain(core.view))
                         }
 
-//                        it("removes core as subview of fullscreenController") {
-//                            core.setFullscreen(false)
-//
-//                            expect(core.fullscreenController?.view.subviews).toNot(contain(core))
-//                        }
+                        it("removes core as subview of fullscreenController") {
+                            core.setFullscreen(false)
+
+                            expect(core.fullscreenController?.view.subviews).toNot(contain(core.view))
+                        }
 
                         it("only set core as subview of parentView once") {
                             core.setFullscreen(false)

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -407,11 +407,11 @@ class CoreTests: QuickSpec {
                             expect(core.parentView?.subviews).to(contain(core.view))
                         }
 
-                        it("removes core as subview of fullscreenController") {
-                            core.setFullscreen(false)
-
-                            expect(core.fullscreenController?.view.subviews).toNot(contain(core))
-                        }
+//                        it("removes core as subview of fullscreenController") {
+//                            core.setFullscreen(false)
+//
+//                            expect(core.fullscreenController?.view.subviews).toNot(contain(core))
+//                        }
 
                         it("only set core as subview of parentView once") {
                             core.setFullscreen(false)

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/PlayButtonTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/PlayButtonTests.swift
@@ -163,9 +163,9 @@ class PlayButtonTests: QuickSpec {
                 }
 
                 describe("button") {
-//                    it("adds it in the view") {
-//                        expect(playButton.view.subviews).to(contain(playButton.button))
-//                    }
+                    it("adds it in the view") {
+                        expect(playButton.view.subviews).to(contain(playButton.button!))
+                    }
 
                     it("has scaleAspectFit content mode") {
                         expect(playButton.button?.imageView?.contentMode).to(equal(UIView.ContentMode.scaleAspectFit))

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/PlayButtonTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/MediaControl/PlayButtonTests.swift
@@ -163,9 +163,9 @@ class PlayButtonTests: QuickSpec {
                 }
 
                 describe("button") {
-                    it("adds it in the view") {
-                        expect(playButton.view.subviews).to(contain(playButton.button))
-                    }
+//                    it("adds it in the view") {
+//                        expect(playButton.view.subviews).to(contain(playButton.button))
+//                    }
 
                     it("has scaleAspectFit content mode") {
                         expect(playButton.button?.imageView?.contentMode).to(equal(UIView.ContentMode.scaleAspectFit))

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStateMachineEventsTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackStateMachineEventsTests.swift
@@ -99,7 +99,7 @@ class AVFoundationPlaybackStateMachineEventsTests: QuickSpec {
                             playback.seek(playback.duration)
                         }
 
-                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 12)
+                        expect(triggeredEvents).toEventually(equal(expectedEvents), timeout: 15)
                     }
                 }
 

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# carthage.sh
+# Make the script executable: chmod +x carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+for simulator in iphonesimulator appletvsimulator; do
+    echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_${simulator}__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+done
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(PLATFORM_NAME)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+cat $XCODE_XCCONFIG_FILE
+carthage "$@"


### PR DESCRIPTION
🏁 Goal
Make Carthage build compatible with the Xcode 12.2 simulator architecture to Intel MacBooks.

✅ How to test
- Make the script executable: `chmod +x carthage.sh`
- Usage example: `./carthage.sh update` to build and update the dependencies 
- Run `make test`
