### PR TITLE
Chromeless mode for iOS

### DIFF
--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -69,7 +69,8 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         self.options = options
         self.layerComposer = layerComposer
         super.init()
-        addTapGestures()
+        
+        updateChromelessMode()
         
         bindEventListeners()
         
@@ -151,9 +152,10 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
     
     open override func render() {
+        addTapGestures()
         containers.forEach(renderContainer)
         addToContainer()
-        updateChromelessMode()
+        updateGestureRecognizersState()
     }
 
     private func addToContainer() {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -114,13 +114,13 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         }
     }
     
-    public func enterChromelessMode() {
+    private func enterChromelessMode() {
         #if os(iOS)
         layerComposer.hideUI()
         #endif
     }
 
-    public func exitChromelessMode() {
+    private func exitChromelessMode() {
         #if os(iOS)
         layerComposer.showUI()
         #endif

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -69,11 +69,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         self.options = options
         self.layerComposer = layerComposer
         super.init()
-        self.updateChromelessMode()
-        
-        if !chromelessMode {
-            addTapGestures()
-        }
+        addTapGestures()
         
         bindEventListeners()
         
@@ -105,7 +101,10 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
     
     private func updateGestureRecognizersState() {
+        #if os(iOS)
         view.gestureRecognizers?.forEach { $0.isEnabled = !chromelessMode }
+        #endif
+
     }
     
     private func updateChromelessMode() {
@@ -154,6 +153,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     open override func render() {
         containers.forEach(renderContainer)
         addToContainer()
+        updateChromelessMode()
     }
 
     private func addToContainer() {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -55,7 +55,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
 
     @objc open var isFullscreen: Bool = false
-    private var isChromeless: Bool { options.bool(kChromeless) }
+    public var chromelessMode: Bool = false
     
     public required init(options: Options = [:], layerComposer: LayerComposer) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
@@ -63,8 +63,9 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         self.options = options
         self.layerComposer = layerComposer
         super.init()
-        
-        if !isChromeless {
+        self.updateChromelessMode(with: options)
+
+        if !chromelessMode {
             addTapGestures()
         }
         
@@ -91,6 +92,24 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         if activeContainer != container {
             activeContainer = container
         }
+    }
+    
+    public func updateChromelessMode(with option: Options) {
+        if let chromelessMode = options[kChromeless] as? Bool {
+            self.chromelessMode = chromelessMode
+        }
+    }
+    
+    public func enterChromelessMode() {
+        #if os(iOS)
+        layerComposer.hideViews()
+        #endif
+    }
+
+    public func exitChromelessMode() {
+        #if os(iOS)
+        layerComposer.showViews()
+        #endif
     }
 
     private func bindEventListeners() {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -59,6 +59,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     public var chromelessMode: Bool = false {
         didSet {
             updateChromelessModeVisibility()
+            updateGestureRecognizersState()
         }
     }
     
@@ -100,11 +101,11 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
     
     private func updateChromelessModeVisibility() {
-        if chromelessMode {
-            enterChromelessMode()
-        } else {
-            exitChromelessMode()
-        }
+        chromelessMode ? enterChromelessMode() : exitChromelessMode()
+    }
+    
+    private func updateGestureRecognizersState() {
+        view.gestureRecognizers?.forEach { $0.isEnabled = !chromelessMode }
     }
     
     private func updateChromelessMode() {

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -9,6 +9,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     @objc open var options: Options {
         didSet {
             containers.forEach { $0.options = options }
+            updateChromelessMode()
             trigger(Event.didUpdateOptions)
         }
     }
@@ -55,7 +56,11 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     }
 
     @objc open var isFullscreen: Bool = false
-    public var chromelessMode: Bool = false
+    public var chromelessMode: Bool = false {
+        didSet {
+            updateChromelessModeVisibility()
+        }
+    }
     
     public required init(options: Options = [:], layerComposer: LayerComposer) {
         Logger.logDebug("loading with \(options)", scope: "\(type(of: self))")
@@ -63,8 +68,8 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         self.options = options
         self.layerComposer = layerComposer
         super.init()
-        self.updateChromelessMode(with: options)
-
+        self.updateChromelessMode()
+        
         if !chromelessMode {
             addTapGestures()
         }
@@ -94,7 +99,15 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         }
     }
     
-    public func updateChromelessMode(with option: Options) {
+    private func updateChromelessModeVisibility() {
+        if chromelessMode {
+            enterChromelessMode()
+        } else {
+            exitChromelessMode()
+        }
+    }
+    
+    private func updateChromelessMode() {
         if let chromelessMode = options[kChromeless] as? Bool {
             self.chromelessMode = chromelessMode
         }

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -102,13 +102,13 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     
     public func enterChromelessMode() {
         #if os(iOS)
-        layerComposer.hideViews()
+        layerComposer.hideUI()
         #endif
     }
 
     public func exitChromelessMode() {
         #if os(iOS)
-        layerComposer.showViews()
+        layerComposer.showUI()
         #endif
     }
 

--- a/Sources/Clappr/Classes/Base/Core.swift
+++ b/Sources/Clappr/Classes/Base/Core.swift
@@ -58,7 +58,7 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
     @objc open var isFullscreen: Bool = false
     public var chromelessMode: Bool = false {
         didSet {
-            updateChromelessModeVisibility()
+            updateLayersVisibility()
             updateGestureRecognizersState()
         }
     }
@@ -97,33 +97,22 @@ open class Core: UIObject, UIGestureRecognizerDelegate {
         }
     }
     
-    private func updateChromelessModeVisibility() {
-        chromelessMode ? enterChromelessMode() : exitChromelessMode()
+    private func updateLayersVisibility() {
+        #if os(iOS)
+        chromelessMode ? layerComposer.hideUI() : layerComposer.showUI()
+        #endif
     }
     
     private func updateGestureRecognizersState() {
         #if os(iOS)
         view.gestureRecognizers?.forEach { $0.isEnabled = !chromelessMode }
         #endif
-
     }
     
     private func updateChromelessMode() {
         if let chromelessMode = options[kChromeless] as? Bool {
             self.chromelessMode = chromelessMode
         }
-    }
-    
-    private func enterChromelessMode() {
-        #if os(iOS)
-        layerComposer.hideUI()
-        #endif
-    }
-
-    private func exitChromelessMode() {
-        #if os(iOS)
-        layerComposer.showUI()
-        #endif
     }
 
     private func bindEventListeners() {

--- a/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
@@ -36,13 +36,13 @@ public class LayerComposer {
         overlayLayer.attachOverlay(view)
     }
     
-    func showViews() {
+    func showUI() {
         mediaControlLayer.isHidden = false
         coreLayer.isHidden = false
         overlayLayer.isHidden = false
     }
 
-    func hideViews() {
+    func hideUI() {
         mediaControlLayer.isHidden = true
         coreLayer.isHidden = true
         overlayLayer.isHidden = true

--- a/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
@@ -35,4 +35,18 @@ public class LayerComposer {
     func attachOverlay(_ view: UIView) {
         overlayLayer.attachOverlay(view)
     }
+    
+    func showViews() {
+        mediaControlLayer.isHidden = false
+        coreLayer.isHidden = false
+        overlayLayer.isHidden = false
+        containerLayer.isHidden = false
+    }
+
+    func hideViews() {
+        mediaControlLayer.isHidden = true
+        coreLayer.isHidden = true
+        overlayLayer.isHidden = true
+        containerLayer.isHidden = true
+    }
 }

--- a/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
+++ b/Sources/Clappr/Classes/Base/Layers/LayerComposer.swift
@@ -40,13 +40,11 @@ public class LayerComposer {
         mediaControlLayer.isHidden = false
         coreLayer.isHidden = false
         overlayLayer.isHidden = false
-        containerLayer.isHidden = false
     }
 
     func hideViews() {
         mediaControlLayer.isHidden = true
         coreLayer.isHidden = true
         overlayLayer.isHidden = true
-        containerLayer.isHidden = true
     }
 }

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -7,9 +7,7 @@ open class Player: BaseObject {
     public private(set) var core: Core?
     public var chromelessMode: Bool {
         get { core?.chromelessMode ?? false }
-        set {
-            core?.chromelessMode = newValue
-        }
+        set { core?.chromelessMode = newValue }
     }
     static var hasAlreadyRegisteredPlugins = false
     static var hasAlreadyRegisteredPlaybacks = false
@@ -131,16 +129,6 @@ open class Player: BaseObject {
             Logger.logDebug("forced play after return from background", scope: "Player")
             play()
         }
-    }
-    
-    
-    
-    public func enterChromelessMode() {
-        core?.enterChromelessMode()
-    }
-
-    public func exitChromelessMode() {
-        core?.exitChromelessMode()
     }
     
     open func presentFullscreenIn(_ controller: UIViewController) {

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -9,7 +9,6 @@ open class Player: BaseObject {
         get { core?.chromelessMode ?? false }
         set {
             core?.chromelessMode = newValue
-            updateChromelessModeVisibility()
         }
     }
     static var hasAlreadyRegisteredPlugins = false
@@ -92,8 +91,6 @@ open class Player: BaseObject {
         bindMediaControlEvents()
         bindPlaybackEvents()
         bindNotifications()
-        core?.updateChromelessMode(with: options)
-        updateChromelessModeVisibility()
         core?.load()
     }
     
@@ -136,13 +133,7 @@ open class Player: BaseObject {
         }
     }
     
-    private func updateChromelessModeVisibility() {
-        if chromelessMode {
-            enterChromelessMode()
-        } else {
-            exitChromelessMode()
-        }
-    }
+    
     
     public func enterChromelessMode() {
         core?.enterChromelessMode()
@@ -176,8 +167,6 @@ open class Player: BaseObject {
 
     open func configure(options: Options) {
         core?.options = options
-        core?.updateChromelessMode(with: options)
-        updateChromelessModeVisibility()
         core?.load()
     }
 

--- a/Sources/Clappr_iOS/Classes/Base/Player.swift
+++ b/Sources/Clappr_iOS/Classes/Base/Player.swift
@@ -5,8 +5,13 @@ open class Player: BaseObject {
     open var playbackEventsToListen: [String] = []
     private var playbackEventsListenIds: [String] = []
     public private(set) var core: Core?
-    private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
-
+    public var chromelessMode: Bool {
+        get { core?.chromelessMode ?? false }
+        set {
+            core?.chromelessMode = newValue
+            updateChromelessModeVisibility()
+        }
+    }
     static var hasAlreadyRegisteredPlugins = false
     static var hasAlreadyRegisteredPlaybacks = false
 
@@ -87,7 +92,8 @@ open class Player: BaseObject {
         bindMediaControlEvents()
         bindPlaybackEvents()
         bindNotifications()
-
+        core?.updateChromelessMode(with: options)
+        updateChromelessModeVisibility()
         core?.load()
     }
     
@@ -124,10 +130,26 @@ open class Player: BaseObject {
     }
     
     @objc private func willEnterForeground() {
-        if isChromeless {
+        if chromelessMode {
             Logger.logDebug("forced play after return from background", scope: "Player")
             play()
         }
+    }
+    
+    private func updateChromelessModeVisibility() {
+        if chromelessMode {
+            enterChromelessMode()
+        } else {
+            exitChromelessMode()
+        }
+    }
+    
+    public func enterChromelessMode() {
+        core?.enterChromelessMode()
+    }
+
+    public func exitChromelessMode() {
+        core?.exitChromelessMode()
     }
     
     open func presentFullscreenIn(_ controller: UIViewController) {
@@ -154,6 +176,8 @@ open class Player: BaseObject {
 
     open func configure(options: Options) {
         core?.options = options
+        core?.updateChromelessMode(with: options)
+        updateChromelessModeVisibility()
         core?.load()
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -51,10 +51,6 @@ open class PosterPlugin: OverlayPlugin {
         view.addSubviewMatchingConstraints(poster)
 
         view.addSubview(playButton)
-
-        let xCenterConstraint = NSLayoutConstraint(item: playButton, attribute: .centerX,
-                                                   relatedBy: .equal, toItem: view, attribute: .centerX, multiplier: 1, constant: 0)
-        view.addConstraint(xCenterConstraint)
         playButton.anchorInCenter()
     }
 

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -2,8 +2,7 @@ open class PosterPlugin: OverlayPlugin {
     
     private var poster = UIImageView(frame: CGRect.zero)
     private var playButton = UIButton(frame: CGRect.zero)
-    private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
-
+    
     open override class var name: String {
         return "poster"
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -11,10 +11,6 @@ open class PosterPlugin: OverlayPlugin {
     open override func render() {
         guard let core = core else { return }
         
-        if isChromeless {
-            view.isHidden = true
-        }
-        
         if let urlString = core.options[kPosterUrl] as? String {
             setPosterImage(with: urlString)
         } else {
@@ -56,6 +52,10 @@ open class PosterPlugin: OverlayPlugin {
         view.addSubviewMatchingConstraints(poster)
 
         view.addSubview(playButton)
+
+        let xCenterConstraint = NSLayoutConstraint(item: playButton, attribute: .centerX,
+                                                   relatedBy: .equal, toItem: view, attribute: .centerX, multiplier: 1, constant: 0)
+        view.addConstraint(xCenterConstraint)
         playButton.anchorInCenter()
     }
 
@@ -67,7 +67,7 @@ open class PosterPlugin: OverlayPlugin {
         listenTo(container, event: .requestPosterUpdate) { [weak self] info in self?.updatePoster(info) }
         listenTo(container, event: .didUpdateOptions) { [weak self] _ in self?.updatePoster(container.options) }
     }
-
+    
     override open func onDidChangePlayback() {
         guard let playback = activePlayback else { return }
         

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -26,9 +26,9 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     
     private var canHide: Bool { animationState != .hiding && !alwaysVisible }
     private var canShow: Bool {
-        animationState != .showing
-        && !isDrawerActive
-        && controlsEnabled
+        animationState != .showing &&
+        !isDrawerActive &&
+        controlsEnabled
     }
 
     override open func bindEvents() {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -25,7 +25,8 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
     
     private var canHide: Bool { animationState != .hiding && !alwaysVisible }
-    private var canShow: Bool { animationState != .showing
+    private var canShow: Bool {
+        animationState != .showing
         && !isDrawerActive
         && controlsEnabled
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/MediaControl/MediaControl.swift
@@ -16,7 +16,6 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     
     var options: Options? { core?.options }
     private var alwaysVisible: Bool { core?.options.bool(kMediaControlAlwaysVisible) ?? false }
-    private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
     private var isDrawerActive = false
     private var controlsEnabled = true
     private let statesToKeepVisible: [PlaybackState] = [.paused, .idle]
@@ -26,8 +25,7 @@ open class MediaControl: UICorePlugin, UIGestureRecognizerDelegate {
     }
     
     private var canHide: Bool { animationState != .hiding && !alwaysVisible }
-    private var canShow: Bool { !isChromeless
-        && animationState != .showing
+    private var canShow: Bool { animationState != .showing
         && !isDrawerActive
         && controlsEnabled
     }

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
@@ -1,8 +1,6 @@
 import UIKit
 
 public class QuickSeekCorePlugin: QuickSeekPlugin {
-    private var chromelessMode: Bool { core?.chromelessMode ?? false }
-
     open class override var name: String {
         return "QuickSeekCorePlugin"
     }
@@ -24,10 +22,6 @@ public class QuickSeekCorePlugin: QuickSeekPlugin {
     }
     
     override func shouldSeek(point: CGPoint) -> Bool {
-        if chromelessMode {
-            return false
-        }
-        
         let pluginColidingWithGesture = activeContainer?.plugins
             .compactMap({ $0 as? UIContainerPlugin })
             .first(where: {

--- a/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Core/QuickSeekCorePlugin.swift
@@ -1,7 +1,8 @@
 import UIKit
 
 public class QuickSeekCorePlugin: QuickSeekPlugin {
-    
+    private var chromelessMode: Bool { core?.chromelessMode ?? false }
+
     open class override var name: String {
         return "QuickSeekCorePlugin"
     }
@@ -23,6 +24,10 @@ public class QuickSeekCorePlugin: QuickSeekPlugin {
     }
     
     override func shouldSeek(point: CGPoint) -> Bool {
+        if chromelessMode {
+            return false
+        }
+        
         let pluginColidingWithGesture = activeContainer?.plugins
             .compactMap({ $0 as? UIContainerPlugin })
             .first(where: {

--- a/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
@@ -78,6 +78,46 @@ class LayerComposerTests: QuickSpec {
             }
         }
         
+        context("When LayerComposer changes its layers visibility") {
+            it("show all visual layers") {
+                let rootView = UIView()
+                let layerComposer = LayerComposer()
+                layerComposer.compose(inside: rootView)
+
+                layerComposer.showViews()
+
+                let containerLayer = getLayer(from: rootView, at: 2)
+                let mediaControlLayer = getLayer(from: rootView, at: 3)
+                let coreLayer = getLayer(from: rootView, at: 4)
+                let overlayLayer = getLayer(from: rootView, at: 5)
+
+                expect(containerLayer?.isHidden).to(beFalse())
+                expect(mediaControlLayer?.isHidden).to(beFalse())
+                expect(coreLayer?.isHidden).to(beFalse())
+                expect(overlayLayer?.isHidden).to(beFalse())
+
+            }
+
+            it("hides all visual layers") {
+                let rootView = UIView()
+                let layerComposer = LayerComposer()
+                layerComposer.compose(inside: rootView)
+
+                layerComposer.hideViews()
+
+                let containerLayer = getLayer(from: rootView, at: 2)
+                let mediaControlLayer = getLayer(from: rootView, at: 3)
+                let coreLayer = getLayer(from: rootView, at: 4)
+                let overlayLayer = getLayer(from: rootView, at: 5)
+
+                expect(containerLayer?.isHidden).to(beTrue())
+                expect(mediaControlLayer?.isHidden).to(beTrue())
+                expect(coreLayer?.isHidden).to(beTrue())
+                expect(overlayLayer?.isHidden).to(beTrue())
+
+            }
+        }
+        
         func getLayer(from rootView: UIView, at index: Int) -> Layer? {
             return rootView.subviews[index] as? Layer
         }

--- a/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
@@ -23,7 +23,7 @@ class LayerComposerTests: QuickSpec {
                         description: "BackgroundLayer should be the first subview of rootView, got \(String(describing: type(of: layer)))"
                     )
                 }
-                it("adds PlaygroundLayer as the second layer"){
+                it("adds PlaybackLayer as the second layer"){
                     let index = 1
                     let rootView = UIView()
                     let layerComposer = LayerComposer()
@@ -86,12 +86,10 @@ class LayerComposerTests: QuickSpec {
 
                 layerComposer.showViews()
 
-                let containerLayer = getLayer(from: rootView, at: 2)
-                let mediaControlLayer = getLayer(from: rootView, at: 3)
-                let coreLayer = getLayer(from: rootView, at: 4)
-                let overlayLayer = getLayer(from: rootView, at: 5)
+                let mediaControlLayer = getLayer(from: rootView, at: 2)
+                let coreLayer = getLayer(from: rootView, at: 3)
+                let overlayLayer = getLayer(from: rootView, at: 4)
 
-                expect(containerLayer?.isHidden).to(beFalse())
                 expect(mediaControlLayer?.isHidden).to(beFalse())
                 expect(coreLayer?.isHidden).to(beFalse())
                 expect(overlayLayer?.isHidden).to(beFalse())
@@ -105,12 +103,10 @@ class LayerComposerTests: QuickSpec {
 
                 layerComposer.hideViews()
 
-                let containerLayer = getLayer(from: rootView, at: 2)
-                let mediaControlLayer = getLayer(from: rootView, at: 3)
-                let coreLayer = getLayer(from: rootView, at: 4)
-                let overlayLayer = getLayer(from: rootView, at: 5)
+                let mediaControlLayer = getLayer(from: rootView, at: 2)
+                let coreLayer = getLayer(from: rootView, at: 3)
+                let overlayLayer = getLayer(from: rootView, at: 4)
 
-                expect(containerLayer?.isHidden).to(beTrue())
                 expect(mediaControlLayer?.isHidden).to(beTrue())
                 expect(coreLayer?.isHidden).to(beTrue())
                 expect(overlayLayer?.isHidden).to(beTrue())

--- a/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/Layers/LayerComposerTests.swift
@@ -84,7 +84,7 @@ class LayerComposerTests: QuickSpec {
                 let layerComposer = LayerComposer()
                 layerComposer.compose(inside: rootView)
 
-                layerComposer.showViews()
+                layerComposer.showUI()
 
                 let mediaControlLayer = getLayer(from: rootView, at: 2)
                 let coreLayer = getLayer(from: rootView, at: 3)
@@ -101,7 +101,7 @@ class LayerComposerTests: QuickSpec {
                 let layerComposer = LayerComposer()
                 layerComposer.compose(inside: rootView)
 
-                layerComposer.hideViews()
+                layerComposer.hideUI()
 
                 let mediaControlLayer = getLayer(from: rootView, at: 2)
                 let coreLayer = getLayer(from: rootView, at: 3)

--- a/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
@@ -402,7 +402,7 @@ class PlayerTests: QuickSpec {
                                         kChromeless: true]
                 Loader.shared.resetPlugins()
                 Player.register(playbacks: [StubPlayback.self])
-                let player = Player(options: options)
+                let player = StubPlayer(options: options)
                 let playback = player.activePlayback as? StubPlayback
                 
                 it("auto play when come from background") {
@@ -412,13 +412,21 @@ class PlayerTests: QuickSpec {
                     
                     expect(playback?.didCallPlay).to(beTrue())
                 }
+                
+                it("sets chromeless mode property to true") {
+                    expect(player.chromelessMode).to(beTrue())
+                }
+
+                it("calls enterChromelessMode") {
+                    expect(player.didCallEnterChromelessMode).to(beTrue())
+                }
             }
             
             context("when not in Chromeless mode") {
                 let options: Options = [kSourceUrl: "http://sitedoesnotexist.com.br/"]
                 Loader.shared.resetPlugins()
                 Player.register(playbacks: [StubPlayback.self])
-                let player = Player(options: options)
+                let player = StubPlayer(options: options)
                 let playback = player.activePlayback as? StubPlayback
                 
                 it("does not auto play when come from background") {
@@ -428,8 +436,31 @@ class PlayerTests: QuickSpec {
                     
                     expect(playback?.didCallPlay).to(beFalse())
                 }
+                
+                it("sets chromeless mode property to false") {
+                    expect(player.chromelessMode).to(beFalse())
+                }
+
+                it("calls exitChromelessMode") {
+                    player.chromelessMode = false
+                    expect(player.didCallExitChromelessMode).to(beTrue())
+                }
             }
         }
+    }
+    
+    class StubPlayer: Player {
+        var didCallEnterChromelessMode = false
+        var didCallExitChromelessMode = false
+
+        override func enterChromelessMode() {
+            didCallEnterChromelessMode = true
+        }
+
+        override func exitChromelessMode() {
+            didCallExitChromelessMode = true
+        }
+
     }
 
     class StubPlayback: Playback {

--- a/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
+++ b/Tests/Clappr_Tests/Classes/Base/PlayerTests.swift
@@ -402,7 +402,7 @@ class PlayerTests: QuickSpec {
                                         kChromeless: true]
                 Loader.shared.resetPlugins()
                 Player.register(playbacks: [StubPlayback.self])
-                let player = StubPlayer(options: options)
+                let player = Player(options: options)
                 let playback = player.activePlayback as? StubPlayback
                 
                 it("auto play when come from background") {
@@ -416,17 +416,13 @@ class PlayerTests: QuickSpec {
                 it("sets chromeless mode property to true") {
                     expect(player.chromelessMode).to(beTrue())
                 }
-
-                it("calls enterChromelessMode") {
-                    expect(player.didCallEnterChromelessMode).to(beTrue())
-                }
             }
             
             context("when not in Chromeless mode") {
                 let options: Options = [kSourceUrl: "http://sitedoesnotexist.com.br/"]
                 Loader.shared.resetPlugins()
                 Player.register(playbacks: [StubPlayback.self])
-                let player = StubPlayer(options: options)
+                let player = Player(options: options)
                 let playback = player.activePlayback as? StubPlayback
                 
                 it("does not auto play when come from background") {
@@ -440,27 +436,8 @@ class PlayerTests: QuickSpec {
                 it("sets chromeless mode property to false") {
                     expect(player.chromelessMode).to(beFalse())
                 }
-
-                it("calls exitChromelessMode") {
-                    player.chromelessMode = false
-                    expect(player.didCallExitChromelessMode).to(beTrue())
-                }
             }
         }
-    }
-    
-    class StubPlayer: Player {
-        var didCallEnterChromelessMode = false
-        var didCallExitChromelessMode = false
-
-        override func enterChromelessMode() {
-            didCallEnterChromelessMode = true
-        }
-
-        override func exitChromelessMode() {
-            didCallExitChromelessMode = true
-        }
-
     }
 
     class StubPlayback: Playback {

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -64,6 +64,7 @@ class CoreTests: QuickSpec {
 
                 beforeEach {
                     core = CoreFactory.create(with: options, layerComposer: layerComposer)
+                    core.render()
                 }
 
                 it("set frame Rect to zero") {
@@ -945,21 +946,17 @@ class CoreTests: QuickSpec {
                 let layerComposer = LayerComposerSpy()
                 
                 context("when in chromeless mode by options") {
-                    let core = CoreFactory.create(with: [kSourceUrl: "http//test.com", kChromeless: true], layerComposer: layerComposer)
+                    core = CoreFactory.create(with: [kSourceUrl: "http//test.com", kChromeless: true], layerComposer: layerComposer)
                     
                     it("hides LayerComposer layers") {
-                        core.enterChromelessMode()
-                        
                         expect(layerComposer.didCallHideUI).to(beTrue())
                     }
                 }
                 
                 context("when is not in chromeless mode by options") {
-                    let core = CoreFactory.create(with: [kSourceUrl: "http//test.com", kChromeless: false], layerComposer: layerComposer)
+                    core = CoreFactory.create(with: [kSourceUrl: "http//test.com", kChromeless: false], layerComposer: layerComposer)
                     
                     it("shows LayerComposer layers") {
-                        core.exitChromelessMode()
-                        
                         expect(layerComposer.didCallShowUI).to(beTrue())
                     }
                 }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -960,7 +960,7 @@ class CoreTests: QuickSpec {
                     it("shows LayerComposer layers") {
                         core.exitChromelessMode()
                         
-                        expect(layerComposer.didCallHideViews).to(beTrue())
+                        expect(layerComposer.didCallShowViews).to(beTrue())
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -23,6 +23,8 @@ class CoreTests: QuickSpec {
             var didCallCompose = false
             var didCallAttachUICorePlugin = false
             var didCallAttachMediaControl = false
+            var didCallShowViews = false
+            var didCallHideViews = false
             
             override func compose(inside rootView: UIView) {
                 didCallCompose = true
@@ -34,6 +36,14 @@ class CoreTests: QuickSpec {
             
             override func attachMediaControl(_ view: UIView) {
                 didCallAttachMediaControl = true
+            }
+            
+            override func showViews() {
+                didCallShowViews = true
+            }
+
+            override func hideViews() {
+                didCallHideViews = true
             }
         }
 
@@ -929,6 +939,32 @@ class CoreTests: QuickSpec {
                     }
                 }
             }
+            
+            #if os(iOS)
+            describe("#chromelessMode") {
+                let layerComposer = LayerComposerSpy()
+                
+                context("when in chromeless mode by options") {
+                    let core = CoreFactory.create(with: [kSourceUrl: "http//test.com", kChromeless: true], layerComposer: layerComposer)
+                    
+                    it("hides LayerComposer layers") {
+                        core.enterChromelessMode()
+                        
+                        expect(layerComposer.didCallHideViews).to(beTrue())
+                    }
+                }
+                
+                context("when is not in chromeless mode by options") {
+                    let core = CoreFactory.create(with: [kSourceUrl: "http//test.com", kChromeless: false], layerComposer: layerComposer)
+                    
+                    it("shows LayerComposer layers") {
+                        core.exitChromelessMode()
+                        
+                        expect(layerComposer.didCallHideViews).to(beTrue())
+                    }
+                }
+            }
+            #endif
         }
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/CoreTests.swift
@@ -23,8 +23,8 @@ class CoreTests: QuickSpec {
             var didCallCompose = false
             var didCallAttachUICorePlugin = false
             var didCallAttachMediaControl = false
-            var didCallShowViews = false
-            var didCallHideViews = false
+            var didCallShowUI = false
+            var didCallHideUI = false
             
             override func compose(inside rootView: UIView) {
                 didCallCompose = true
@@ -38,12 +38,12 @@ class CoreTests: QuickSpec {
                 didCallAttachMediaControl = true
             }
             
-            override func showViews() {
-                didCallShowViews = true
+            override func showUI() {
+                didCallShowUI = true
             }
 
-            override func hideViews() {
-                didCallHideViews = true
+            override func hideUI() {
+                didCallHideUI = true
             }
         }
 
@@ -950,7 +950,7 @@ class CoreTests: QuickSpec {
                     it("hides LayerComposer layers") {
                         core.enterChromelessMode()
                         
-                        expect(layerComposer.didCallHideViews).to(beTrue())
+                        expect(layerComposer.didCallHideUI).to(beTrue())
                     }
                 }
                 
@@ -960,7 +960,7 @@ class CoreTests: QuickSpec {
                     it("shows LayerComposer layers") {
                         core.exitChromelessMode()
                         
-                        expect(layerComposer.didCallShowViews).to(beTrue())
+                        expect(layerComposer.didCallShowUI).to(beTrue())
                     }
                 }
             }

--- a/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Core/QuickSeekCorePluginTests.swift
@@ -23,6 +23,7 @@ class QuickSeekCorePluginTests: QuickSpec {
                     eventTrigger = true
                     eventParams = userInfo
                 }
+                core.render()
             }
             
             describe("pluginName") {


### PR DESCRIPTION
## Goal

Introduce `Chromeless` mode to remove user interaction and visual elements on iOS.

## How to test
Scenario 1
1 - Add the code on ViewController.swift#18:
```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
    self.player.chromelessMode = true
}

DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
    self.player.chromelessMode = false
}
```
- Run the playground
- At 00:05s the interactions with playback will be disabled and the visual elements will be hide.
- At 00:10s the interactions with playback will be enabled.

Scenario 2
- Add the code on ViewController.swift#18:
```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
    self.player.configure(options: [kChromeless: true])
}

DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
    self.player.configure(options: [kChromeless: false])
}
```
- Run the playground
- At 00:05s the interactions with playback will be disabled and the visual elements will be hide.
- At 00:10s the interactions with playback will be enabled.

Scenario 3
Add the code on ViewController.swift#94:
```swift
options[kChromeless] = true
```
- Run the playground
- The interactions with playback will be disabled and the visual elements will be hidden.

## 🖼  Screenshot
![image](https://user-images.githubusercontent.com/15603892/100098069-4118ec80-2e3c-11eb-828b-a08bb33de762.png)


