### PR TITLE
Convert SpinnerPlugin to OverlayPlugin

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -1,4 +1,4 @@
-open class SpinnerPlugin: UIContainerPlugin {
+open class SpinnerPlugin: OverlayPlugin {
 
     fileprivate var spinningWheel: UIActivityIndicatorView!
 
@@ -17,37 +17,16 @@ open class SpinnerPlugin: UIContainerPlugin {
         view.isUserInteractionEnabled = false
         view.accessibilityIdentifier = "SpinnerPlugin"
     }
-
-    override open func bindEvents() {
-        bindPlaybackEvents()
-    }
+    
+    open override func bindEvents() {}
 
     open override func render() {
-        addCenteringConstraints()
+        view.addMatchingConstraints(spinningWheel)
+        view.anchorInCenter()
     }
 
-    private func addCenteringConstraints() {
-        view.translatesAutoresizingMaskIntoConstraints = false
-
-        let widthConstraint = NSLayoutConstraint(item: view, attribute: .width, relatedBy: .equal,
-                                                 toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: spinningWheel.frame.width)
-        view.addConstraint(widthConstraint)
-
-        let heightConstraint = NSLayoutConstraint(item: view, attribute: .height, relatedBy: .equal,
-                                                  toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: spinningWheel.frame.height)
-        view.addConstraint(heightConstraint)
-
-        let xCenterConstraint = NSLayoutConstraint(item: view, attribute: .centerX,
-                                                   relatedBy: .equal, toItem: container?.view, attribute: .centerX, multiplier: 1, constant: 0)
-        container?.view.addConstraint(xCenterConstraint)
-
-        let yCenterConstraint = NSLayoutConstraint(item: view, attribute: .centerY,
-                                                   relatedBy: .equal, toItem: container?.view, attribute: .centerY, multiplier: 1, constant: 0)
-        container?.view.addConstraint(yCenterConstraint)
-    }
-
-    private func bindPlaybackEvents() {
-        guard let playback = playback else { return }
+    override open func onDidChangePlayback() {
+        guard let playback = core?.activePlayback else { return }
         
         listenTo(playback, event: .playing) { [weak self] _ in self?.stopAnimating() }
         listenTo(playback, event: .stalling) { [weak self] _ in self?.startAnimating() }

--- a/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
+++ b/Sources/Clappr/Classes/Plugin/Container/SpinnerPlugin.swift
@@ -32,6 +32,8 @@ open class SpinnerPlugin: OverlayPlugin {
     }
 
     override open func onDidChangePlayback() {
+        updateVisibility()
+        
         guard let playback = core?.activePlayback else { return }
         
         listenTo(playback, event: .playing) { [weak self] _ in self?.stopAnimating() }

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/SpinnerPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/SpinnerPluginTests.swift
@@ -4,161 +4,203 @@ import Nimble
 @testable import Clappr
 
 class SpinnerPluginTests: QuickSpec {
-
+    
     override func spec() {
-
-        var container: Container!
+        
+        var core: CoreStub!
         var spinnerPlugin: SpinnerPlugin!
-        var playback: AVFoundationPlayback!
-
+        var playback: AVFoundationPlaybackMock!
+        
         beforeEach {
-            container = Container()
-            spinnerPlugin = SpinnerPlugin(context: container)
-            playback = AVFoundationPlayback(options: [:])
-            container.playback = playback
+            core = CoreStub()
+            spinnerPlugin = SpinnerPlugin(context: core)
+            playback = core.playbackMock
         }
-
+        
         describe("SpinnerPlugin") {
-
-            describe("#init") {
-
-                it("sets the accessibilityIdentifier") {
-                    expect(spinnerPlugin.view.accessibilityIdentifier).to(equal("SpinnerPlugin"))
-                }
-
-                it("sets the pluginName as spinner") {
-                    expect(spinnerPlugin.pluginName).to(equal("spinner"))
-                }
-
-                it("is a container plugin") {
-                    expect(spinnerPlugin).to(beAKindOf(UIContainerPlugin.self))
-                }
-
-                it("sets isUserInteractionEnabled to false") {
-                    expect(spinnerPlugin.view.isUserInteractionEnabled).to(beFalse())
-                }
-
-                it("has a UIActivityIndicatorView as subview") {
-                    expect(spinnerPlugin.view.subviews.contains(where: { $0 is UIActivityIndicatorView})).to(beTrue())
-                }
-            }
-
-            describe("#destroy") {
-                it("removes from itself from superview") {
-                    spinnerPlugin.destroy()
-
-                    expect(spinnerPlugin.view.superview).to(beNil())
-                }
-            }
-
-            context("when the playback trigger a playing event") {
-
+                       
+            context("When Playback is changed") {
+                
+                var oldPlayback: Playback!
+                
                 beforeEach {
-                    playback.trigger(Event.playing.rawValue)
+                    oldPlayback = core.activePlayback
+                    core._container?.playback = Playback(options: [:])
+                    core._container?.trigger(Event.didChangePlayback)
                 }
-
-                it("hides the spinner") {
-                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
-                }
-
-                it("sets the isAnimating to false") {
-                    expect(spinnerPlugin.isAnimating).toEventually(beFalse())
-                }
-            }
-
-            context("when the playback trigger an error event") {
-
-                beforeEach {
-                    playback.trigger(Event.error.rawValue)
-                }
-
-                it("hides the spinner") {
-                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
-                }
-
-                it("sets the isAnimating to false") {
-                    expect(spinnerPlugin.isAnimating).toEventually(beFalse())
-                }
-            }
-
-            context("when the playback trigger a didComplete event") {
-
-                beforeEach {
-                    playback.trigger(Event.didComplete.rawValue)
-                }
-
-                it("hides the spinner") {
-                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
-                }
-
-                it("sets the isAnimating to false") {
-                    expect(spinnerPlugin.isAnimating).toEventually(beFalse())
-                }
-            }
-
-            context("when the playback trigger a stalling event") {
-
-                beforeEach {
-                    playback.trigger(Event.stalling.rawValue)
-                }
-
-                it("hides the spinner") {
-                    expect(spinnerPlugin.view.isHidden).toEventually(beFalse())
-                }
-
-                it("sets the isAnimating to false") {
-                    expect(spinnerPlugin.isAnimating).toEventually(beTrue())
+                
+                it("stops listening to the old playback"){
+                    spinnerPlugin.view.isHidden = true
+                    
+                    oldPlayback.trigger(Event.stalling)
+                    
+                    expect(spinnerPlugin.view.isHidden).to(beTrue())
                 }
             }
             
-            context("when the playback trigger a pause event") {
-
+            describe("Playback events") {
+                
                 beforeEach {
-                    playback.trigger(Event.didPause.rawValue)
+                    spinnerPlugin.onDidChangePlayback()
                 }
-
-                it("hides the spinner") {
-                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
+                
+                context("When playback starts playing") {
+                    
+                    beforeEach {
+                        playback.trigger(Event.playing.rawValue)
+                    }
+                    
+                    it("hides the spinner") {
+                        expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
+                    }
+                    
+                    it("sets the isAnimating to false") {
+                        expect(spinnerPlugin.isAnimating).toEventually(beFalse())
+                    }
                 }
-
-                it("sets the isAnimating to false") {
-                    expect(spinnerPlugin.isAnimating).toEventually(beFalse())
+                
+                context("When playback fails") {
+                    
+                    beforeEach {
+                        playback.trigger(Event.error.rawValue)
+                    }
+                    
+                    it("hides the spinner") {
+                        expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
+                    }
+                    
+                    it("sets the isAnimating to false") {
+                        expect(spinnerPlugin.isAnimating).toEventually(beFalse())
+                    }
+                }
+                
+                context("When playback completes") {
+                    
+                    beforeEach {
+                        playback.trigger(Event.didComplete.rawValue)
+                    }
+                    
+                    it("hides the spinner") {
+                        expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
+                    }
+                    
+                    it("sets the isAnimating to false") {
+                        expect(spinnerPlugin.isAnimating).toEventually(beFalse())
+                    }
+                }
+                
+                context("When playback stalls") {
+                    
+                    beforeEach {
+                        playback.trigger(Event.stalling.rawValue)
+                    }
+                    
+                    it("hides the spinner") {
+                        expect(spinnerPlugin.view.isHidden).toEventually(beFalse())
+                    }
+                    
+                    it("sets the isAnimating to false") {
+                        expect(spinnerPlugin.isAnimating).toEventually(beTrue())
+                    }
+                }
+                
+                context("When playback pauses") {
+                    
+                    beforeEach {
+                        playback.trigger(Event.didPause.rawValue)
+                    }
+                    
+                    it("hides the spinner") {
+                        expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
+                    }
+                    
+                    it("sets the isAnimating to false") {
+                        expect(spinnerPlugin.isAnimating).toEventually(beFalse())
+                    }
+                }
+                
+                context("When playback stops") {
+                    
+                    beforeEach {
+                        playback.trigger(Event.didStop.rawValue)
+                    }
+                    
+                    it("hides the spinner") {
+                        expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
+                    }
+                    
+                    it("sets the isAnimating to false") {
+                        expect(spinnerPlugin.isAnimating).toEventually(beFalse())
+                    }
+                }
+                
+                context("When playback trigger a willPlay event") {
+                    
+                    beforeEach {
+                        playback.trigger(Event.willPlay.rawValue)
+                    }
+                    
+                    it("shows the spinner") {
+                        expect(spinnerPlugin.view.isHidden).toEventually(beFalse())
+                    }
+                    
+                    it("sets the isAnimating to false") {
+                        expect(spinnerPlugin.isAnimating).toEventually(beTrue())
+                    }
                 }
             }
-
-            context("when the playback trigger a stop event") {
-
-                beforeEach {
-                    playback.trigger(Event.didStop.rawValue)
+            
+            describe("Modal events") {
+                context("When a modal plugin will show") {
+                    it("hides itself") {
+                        spinnerPlugin.view.isHidden = false
+                        
+                        core.trigger(Event.willShowModal)
+                        
+                        expect(spinnerPlugin.view.isHidden).to(beTrue())
+                    }
                 }
-
-                it("hides the spinner") {
-                    expect(spinnerPlugin.view.isHidden).toEventually(beTrue())
-                }
-
-                it("sets the isAnimating to false") {
-                    expect(spinnerPlugin.isAnimating).toEventually(beFalse())
+                context("When a modal plugin will hide") {
+                    context("and Playback is stalling") {
+                        it("shows itself"){
+                            spinnerPlugin.view.isHidden = true
+                            playback.state = .stalling
+                            
+                            core.trigger(Event.willHideModal)
+                            
+                            expect(spinnerPlugin.view.isHidden).to(beFalse())
+                        }
+                    }
+                    context("and Playback has no state") {
+                        it("shows itself"){
+                            spinnerPlugin.view.isHidden = true
+                            playback.state = .none
+                            
+                            core.trigger(Event.willHideModal)
+                            
+                            expect(spinnerPlugin.view.isHidden).to(beFalse())
+                        }
+                    }
+                    context("and Playback is not stalling") {
+                        it("hides itself"){
+                            spinnerPlugin.view.isHidden = false
+                            playback.state = .error
+                            
+                            core.trigger(Event.willHideModal)
+                            
+                            expect(spinnerPlugin.view.isHidden).to(beTrue())
+                        }
+                    }
                 }
             }
-
-            context("when the playback trigger a willPlay event") {
-
-                beforeEach {
-                    playback.trigger(Event.willPlay.rawValue)
-                }
-
-                it("hides the spinner") {
-                    expect(spinnerPlugin.view.isHidden).toEventually(beFalse())
-                }
-
-                it("sets the isAnimating to false") {
-                    expect(spinnerPlugin.isAnimating).toEventually(beTrue())
+            
+            context("When plugin is destoyed") {
+                it("removes itself from superview") {
+                    spinnerPlugin.destroy()
+                    
+                    expect(core.overlayView.subviews).notTo(contain(spinnerPlugin.view))
                 }
             }
         }
-    }
-
-    class PlaybackStub: Playback {
-        override class var name: String { return "playbackstub" }
     }
 }


### PR DESCRIPTION
## 🏁 Goal
The `SpinnerPlugin` is currently a UIContainerPlugin and this plugin should be adjusted for its the correct layer, which is the OverlayPlugin.

## ✅ How to test

### Check the SpinnerPlugin layer's existence
1. Run the example
1. Enable view hierarchy debugger
1. You should see the SpinnerPlugin in the OverlayLayer hierarchy. 

## 🖼 Screenshots
![image](https://user-images.githubusercontent.com/15603892/100450065-c518e180-3093-11eb-8ea5-7aa92445263b.png)

