### PR TITLE
Convert PosterPlugin to OverlayPlugin

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -1,16 +1,11 @@
 open class PosterPlugin: OverlayPlugin {
-    var poster = UIImageView(frame: CGRect.zero)
-    fileprivate var playButton = UIButton(frame: CGRect.zero)
+    
+    private var poster = UIImageView(frame: CGRect.zero)
+    private var playButton = UIButton(frame: CGRect.zero)
     private var isChromeless: Bool { core?.options.bool(kChromeless) ?? false }
 
     open override class var name: String {
         return "poster"
-    }
-
-    public required init(context: UIObject) {
-        super.init(context: context)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        poster.contentMode = .scaleAspectFit
     }
 
     open override func render() {
@@ -24,27 +19,26 @@ open class PosterPlugin: OverlayPlugin {
             setPosterImage(with: urlString)
         } else {
             view.isHidden = true
-            core.activeContainer?.mediaControlEnabled = false
+            activeContainer?.mediaControlEnabled = false
         }
 
         configurePlayButton()
-        configureViews()
+        configureContraints()
     }
 
-    fileprivate typealias PosterUrl = String
-    fileprivate func setPosterImage(with urlString: PosterUrl) {
+    private func setPosterImage(with urlString: String) {
         if let url = URL(string: urlString) {
             poster.setImage(from: url)
+            poster.contentMode = .scaleAspectFit
         } else {
             Logger.logWarn("invalid URL.", scope: pluginName)
         }
     }
 
-    fileprivate func configurePlayButton() {
+    private func configurePlayButton() {
         let image = UIImage(named: "poster-play", in: Bundle(for: PosterPlugin.self),
                             compatibleWith: nil)
         playButton.setBackgroundImage(image, for: UIControl.State())
-        playButton.translatesAutoresizingMaskIntoConstraints = false
         playButton.addTarget(self, action: #selector(PosterPlugin.playTouched), for: .touchUpInside)
     }
 
@@ -53,49 +47,47 @@ open class PosterPlugin: OverlayPlugin {
         activePlayback?.play()
     }
 
-    fileprivate func configureViews() {
+    private func configureContraints() {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        playButton.translatesAutoresizingMaskIntoConstraints = false
+        poster.translatesAutoresizingMaskIntoConstraints = false
+        
         core?.overlayView.addMatchingConstraints(view)
         view.addSubviewMatchingConstraints(poster)
 
         view.addSubview(playButton)
-
-        let xCenterConstraint = NSLayoutConstraint(item: playButton, attribute: .centerX,
-                                                   relatedBy: .equal, toItem: view, attribute: .centerX, multiplier: 1, constant: 0)
-        view.addConstraint(xCenterConstraint)
-
-        let yCenterConstraint = NSLayoutConstraint(item: playButton, attribute: .centerY,
-                                                   relatedBy: .equal, toItem: view, attribute: .centerY, multiplier: 1, constant: 0)
-        view.addConstraint(yCenterConstraint)
+        playButton.anchorInCenter()
     }
 
     override open func bindEvents() {}
 
     override open func onDidChangeActiveContainer() {
         guard let container = activeContainer else { return }
-        listenTo(container, eventName: Event.requestPosterUpdate.rawValue) { [weak self] info in self?.updatePoster(info) }
-        listenTo(container, eventName: Event.didUpdateOptions.rawValue) { [weak self] _ in self?.updatePoster(container.options) }
+        
+        listenTo(container, event: .requestPosterUpdate) { [weak self] info in self?.updatePoster(info) }
+        listenTo(container, event: .didUpdateOptions) { [weak self] _ in self?.updatePoster(container.options) }
     }
 
     override open func onDidChangePlayback() {
-        if let playback = activePlayback {
-            listenTo(playback, eventName: Event.playing.rawValue) { [weak self] _ in self?.playbackStarted() }
-            listenTo(playback, eventName: Event.stalling.rawValue) { [weak self] _ in self?.playbackStalled() }
-            
-            if playback is NoOpPlayback {
-                view.isHidden = true
-            }
+        guard let playback = activePlayback else { return }
+        
+        listenTo(playback, event: .playing) { [weak self] _ in self?.playbackStarted() }
+        listenTo(playback, event: .stalling) { [weak self] _ in self?.playbackStalled() }
+        
+        if playback is NoOpPlayback {
+            view.isHidden = true
         }
     }
 
-    fileprivate func playbackStalled() {
+    private func playbackStalled() {
         playButton.isHidden = true
     }
 
-    fileprivate func playbackStarted() {
+    private func playbackStarted() {
         view.isHidden = true
     }
     
-    fileprivate func updatePoster(_ info: EventUserInfo) {
+    private func updatePoster(_ info: EventUserInfo) {
         Logger.logInfo("Updating poster", scope: pluginName)
         guard let posterUrl = info?[kPosterUrl] as? String else {
             Logger.logWarn("Unable to update poster, no url was found", scope: pluginName)

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
@@ -132,6 +132,20 @@ class PosterPluginTests: QuickSpec {
                     }
                 }
             }
+            
+            context("When play button is pressed") {
+                it("starts the video at the beginning") {
+                    let core = CoreStub()
+                    core.render()
+                    
+                    let posterPlugin = self.getPosterPlugin(core)
+                    posterPlugin.playTouched()
+                    
+                    expect(core.playbackMock?.didCallPlay).to(beTrue())
+                    expect(core.playbackMock?.didCallSeek).to(beTrue())
+                    expect(core.playbackMock?.didCallSeekWithValue).to(equal(0))
+                }
+            }
         }
     }
 

--- a/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Container/PosterPluginTests.swift
@@ -29,7 +29,7 @@ class PosterPluginTests: QuickSpec {
                     core = CoreFactory.create(with: [:], layerComposer: layerComposer)
                     core.render()
 
-                    let posterPlugin = self.getPosterPlugin(core.activeContainer)
+                    let posterPlugin = self.getPosterPlugin(core)
 
                     expect(posterPlugin.view.isHidden).to(beTrue())
                 }
@@ -40,7 +40,7 @@ class PosterPluginTests: QuickSpec {
                     core = CoreFactory.create(with: ["anotherOption": true], layerComposer: layerComposer)
                     core.render()
 
-                    let posterPlugin = self.getPosterPlugin(core.activeContainer)
+                    let posterPlugin = self.getPosterPlugin(core)
 
                     expect(posterPlugin.view.isHidden).to(beTrue())
                 }
@@ -51,9 +51,9 @@ class PosterPluginTests: QuickSpec {
                     core = CoreFactory.create(with: options, layerComposer: layerComposer)
                     core.render()
 
-                    let posterPlugin = self.getPosterPlugin(core.activeContainer)
+                    let posterPlugin = self.getPosterPlugin(core)
 
-                    expect(posterPlugin.view.superview).to(equal(core.activeContainer?.view))
+                    expect(posterPlugin.view.superview).to(equal(core.overlayView))
                 }
             }
 
@@ -67,7 +67,7 @@ class PosterPluginTests: QuickSpec {
                 context("to NoOpPlayback") {
                     beforeEach {
                         core.activeContainer?.playback = NoOpPlayback(options: [:])
-                        posterPlugin = self.getPosterPlugin(core.activeContainer)
+                        posterPlugin = self.getPosterPlugin(core)
                     }
 
                     it("hides itself") {
@@ -75,13 +75,13 @@ class PosterPluginTests: QuickSpec {
                     }
 
                     it("isNoOpPlayback is true") {
-                        expect(posterPlugin.isNoOpPlayback).to(beTrue())
+                        expect(posterPlugin.activePlayback).to(beAKindOf(NoOpPlayback.self))
                     }
 
                     context("and change again to another playback") {
                         beforeEach {
                             core.activeContainer?.playback = AVFoundationPlayback(options: [:])
-                            posterPlugin = self.getPosterPlugin(core.activeContainer)
+                            posterPlugin = self.getPosterPlugin(core)
                         }
 
                         it("hides itself") {
@@ -94,7 +94,7 @@ class PosterPluginTests: QuickSpec {
 
                     beforeEach {
                         core.activeContainer?.playback = AVFoundationPlayback(options: [:])
-                        posterPlugin = self.getPosterPlugin(core.activeContainer)
+                        posterPlugin = self.getPosterPlugin(core)
                     }
 
                     it("reveal itself") {
@@ -102,7 +102,7 @@ class PosterPluginTests: QuickSpec {
                     }
 
                     it("isNoOpPlayback is false") {
-                        expect(posterPlugin.isNoOpPlayback).to(beFalse())
+                        expect(posterPlugin).toNot(beAKindOf(NoOpPlayback.self))
                     }
                 }
             }
@@ -113,7 +113,7 @@ class PosterPluginTests: QuickSpec {
                 beforeEach {
                     core = CoreFactory.create(with: options, layerComposer: layerComposer)
                     core.load()
-                    posterPlugin = self.getPosterPlugin(core.activeContainer)
+                    posterPlugin = self.getPosterPlugin(core)
                 }
 
                 context("when playback trigger a play event") {
@@ -135,7 +135,7 @@ class PosterPluginTests: QuickSpec {
         }
     }
 
-    private func getPosterPlugin(_ container: Container?) -> PosterPlugin {
-        return container?.plugins.first { $0.pluginName == PosterPlugin.name } as! PosterPlugin
+    private func getPosterPlugin(_ core: Core?) -> PosterPlugin {
+        return core?.plugins.first { $0.pluginName == PosterPlugin.name } as! PosterPlugin
     }
 }


### PR DESCRIPTION
## 🏁 Goal
The `PosterPlugin` is currently a UIContainerPlugin and this plugin should be adjusted for its the correct layer, which is the OverlayPlugin.

## ✅ How to test

### Check the PosterPlugin layer's existence
1. Run the example
1. Enable view hierarchy debugger
1. You should see the PosterPlugin in the OverlayLayer hierarchy. 

## 🖼 Screenshots
![image](https://user-images.githubusercontent.com/15603892/100450314-2f318680-3094-11eb-841d-35add919f198.png)

