### PR TITLE
Adjust PlaybackTest to reflect new PosterPlugin layer

### DIFF
--- a/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
+++ b/Sources/Clappr_iOS/Classes/Plugin/Container/PosterPlugin.swift
@@ -35,6 +35,7 @@ open class PosterPlugin: OverlayPlugin {
                             compatibleWith: nil)
         playButton.setBackgroundImage(image, for: UIControl.State())
         playButton.addTarget(self, action: #selector(PosterPlugin.playTouched), for: .touchUpInside)
+        playButton.accessibilityIdentifier = "PlayPosterButton"
     }
 
     @objc func playTouched() {

--- a/Tests/Clappr_UITests/PlaybackTests.swift
+++ b/Tests/Clappr_UITests/PlaybackTests.swift
@@ -29,7 +29,7 @@ class PlaybackTests: QuickSpec {
             context("when video plays") {
                 it("enters stalling and then playing state") {
                     dashboardInteractor.startVideo()
-                    playerInteractor.tapOnContainer()
+                    playerInteractor.tapOnPlayPosterButton()
 
                     expect(app.isVideoIn(state: .playing)).to(beTrue())
                 }

--- a/Tests/Clappr_UITests/Player/PlayerViewElements.swift
+++ b/Tests/Clappr_UITests/Player/PlayerViewElements.swift
@@ -3,8 +3,10 @@ import XCTest
 class PlayerViewElements {
     let container: XCUIElement
     let fullscreenButton: XCUIElement
+    let playPosterButton: XCUIElement
 
     init(app: XCUIApplication) {
+        playPosterButton = app.buttons["PlayPosterButton"]
         container = app.otherElements["Container"]
         fullscreenButton = app.buttons["FullscreenButton"]
     }

--- a/Tests/Clappr_UITests/Player/PlayerViewInteractor.swift
+++ b/Tests/Clappr_UITests/Player/PlayerViewInteractor.swift
@@ -15,6 +15,10 @@ class PlayerViewInteractor {
     func tapOnContainer() {
         elements.container.tap()
     }
+    
+    func tapOnPlayPosterButton() {
+        elements.playPosterButton.tap()
+    }
 
     func tapOnFullscreen() {
         if XCTWaiter().waitFor(element: elements.fullscreenButton) {


### PR DESCRIPTION
## Goal
The PosterPlugin has a playButton that we use to play the video on the playback tests. 
Since we change the poster plugin to another layer we need to update this test to reflect this change. 

## How to test
- Run UI Tests for Clappr