### PR TITLE
Change minDvrSize visibility to open

### DIFF
--- a/Sources/Clappr/Classes/Base/Playback.swift
+++ b/Sources/Clappr/Classes/Base/Playback.swift
@@ -120,7 +120,7 @@ open class Playback: UIObject, NamedType {
 
 // MARK: - DVR
 extension Playback {
-    @objc var minDvrSize: Double {
+    @objc open var minDvrSize: Double {
         return 0
     }
 


### PR DESCRIPTION
# Goal
Change `minDvrSize` visibility to open to keep consistency with other properties related to DVR.

# How to test
1 . Run all automated tests