### PR TITLE
Adjust seek to live position on iOS 14

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -581,8 +581,9 @@ open class AVFoundationPlayback: Playback, AVPlayerItemInfoDelegate {
 
     open override func seekToLivePosition() {
         guard canSeek else { return }
+        guard let range = player.currentItem?.seekableTimeRanges.last?.timeRangeValue else { return }
         play()
-        seek(.infinity)
+        seek(range.end.seconds)
     }
 
     open override func mute(_ enabled: Bool) {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -582,8 +582,10 @@ open class AVFoundationPlayback: Playback, AVPlayerItemInfoDelegate {
     open override func seekToLivePosition() {
         guard canSeek, let liveCurrentSeekableTimeRange = player.currentItem?.seekableTimeRanges.last else { return }
         let livePosition = liveCurrentSeekableTimeRange.timeRangeValue.end.seconds
-        play()
-        seek(livePosition)
+        seek(livePosition) { [weak self] in
+            self?.play()
+            self?.triggerDvrStatusIfNeeded()
+        }
     }
 
     open override func mute(_ enabled: Bool) {

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -580,11 +580,12 @@ open class AVFoundationPlayback: Playback, AVPlayerItemInfoDelegate {
     }
 
     open override func seekToLivePosition() {
-        guard canSeek, let liveCurrentSeekableTimeRange = player.currentItem?.seekableTimeRanges.last else { return }
-        let livePosition = liveCurrentSeekableTimeRange.timeRangeValue.end.seconds
-        seek(livePosition) { [weak self] in
-            self?.play()
-            self?.triggerDvrStatusIfNeeded()
+        play()
+        if canSeek, let liveCurrentSeekableTimeRange = player.currentItem?.seekableTimeRanges.last {
+            let livePosition = liveCurrentSeekableTimeRange.timeRangeValue.end.seconds
+            seek(livePosition) { [weak self] in
+                self?.triggerDvrStatusIfNeeded()
+            }
         }
     }
 

--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -580,10 +580,10 @@ open class AVFoundationPlayback: Playback, AVPlayerItemInfoDelegate {
     }
 
     open override func seekToLivePosition() {
-        guard canSeek else { return }
-        guard let range = player.currentItem?.seekableTimeRanges.last?.timeRangeValue else { return }
+        guard canSeek, let liveCurrentSeekableTimeRange = player.currentItem?.seekableTimeRanges.last else { return }
+        let livePosition = liveCurrentSeekableTimeRange.timeRangeValue.end.seconds
         play()
-        seek(range.end.seconds)
+        seek(livePosition)
     }
 
     open override func mute(_ enabled: Bool) {

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -1347,8 +1347,9 @@ class AVFoundationPlaybackTests: QuickSpec {
                     }
 
                     playback.seekToLivePosition()
+                    let endPosition = playback.seekableTimeRanges.last?.timeRangeValue.end.seconds
 
-                    expect(updatedPosition).to(equal(Double.infinity))
+                    expect(updatedPosition).to(equal(endPosition))
                 }
             }
 


### PR DESCRIPTION
# Goal
Adjust seek to live position on iOS 14 to use `seekableTimeRanges` instead of using the `infinity` to seek. 

# How to test
1 . Run all automated tests