### PR TITLE
Fix Call update asset if needed when player current item changes

### DIFF
--- a/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
+++ b/Sources/Clappr/Classes/Plugin/Playback/AVFoundationPlayback.swift
@@ -288,11 +288,13 @@ open class AVFoundationPlayback: Playback, AVPlayerItemInfoDelegate {
         selectDefaultSubtitleIfNeeded()
     }
     
-    private func updateAssetIfNeeded(_ player: AVPlayer) {
+    private func updateAssetIfNeeded(_ item: AVPlayerItem?) {
         if self.asset == nil,
-           let url: URL = (player.currentItem?.asset as? AVURLAsset)?.url,
+           let item = item,
+           let url: URL = (item.asset as? AVURLAsset)?.url,
            let asset = self.createAsset(from: url.absoluteString) {
             self.asset = asset
+            itemInfo = AVPlayerItemInfo(item: item, delegate: self)
             self.trigger(.ready)
         }
     }
@@ -304,7 +306,7 @@ open class AVFoundationPlayback: Playback, AVPlayerItemInfoDelegate {
                 self?.hideSubtitleForSmallScreen()
             },
             player.observe(\.currentItem) { [weak self] player, _ in
-                self?.updateAssetIfNeeded(player)
+                self?.updateAssetIfNeeded(player.currentItem)
                 self?.itemInfo?.update(item: player.currentItem)
             },
             player.observe(\.currentItem?.status) { [weak self] player, _ in self?.handleStatusChangedEvent(player) },

--- a/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
+++ b/Tests/Clappr_Tests/Classes/Plugin/Playback/AVFoundationPlaybackTests.swift
@@ -57,6 +57,25 @@ class AVFoundationPlaybackTests: QuickSpec {
             }
 
             describe("#init") {
+                context("without current item") {
+                    it("it should call update asset if needed when current item is set") {
+                        var didCallEventReady = false
+                        playback = AVFoundationPlayback(options: [:])
+                        playback.render()
+                        expect(playback.itemInfo).to(beNil())
+                        expect(playback.player.currentItem).to(beNil())
+
+                        playback.on(Event.ready.rawValue) { _ in
+                            didCallEventReady = true
+                        }
+                        playback.player.replaceCurrentItem(with: item)
+                        playback.play()
+
+                        expect(playback.itemInfo).toNot(beNil())
+                        expect(playback.player.currentItem).toNot(beNil())
+                        expect(didCallEventReady).toEventually(beTrue(), timeout: 5)
+                    }
+                }
                 context("without kLoop option") {
                     it("instantiates player as an instance of AVPlayer") {
                         let options = [kSourceUrl: "http://clappr.io/highline.mp4"]


### PR DESCRIPTION
### Goal
This fixes a bug when the `AVFoundationPlayback` is created without an asset and we add a new item on the player later in time the `AVURLAsset` and the `AVPlayerItemInfo` are not being set correctly and the event `.ready` is not being triggered. 

### How to test
Run unit tests
